### PR TITLE
chore: add Node SEA executable build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.blob
 tomo
+sea-config.json

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "build:sea": "bash scripts/build-sea.sh",
     "dev": "tsx src/index.tsx",
     "format": "biome format --write .",
     "format:check": "biome format .",
@@ -21,6 +22,7 @@
     "@types/react": "^19.2.14",
     "ink-testing-library": "^4.0.0",
     "lefthook": "^2.1.4",
+    "react-devtools-core": "^7.0.1",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       ink:
         specifier: ^6.8.0
-        version: 6.8.0(@types/react@19.2.14)(react@19.2.4)
+        version: 6.8.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -27,6 +27,9 @@ importers:
       lefthook:
         specifier: ^2.1.4
         version: 2.1.4
+      react-devtools-core:
+        specifier: ^7.0.1
+        version: 7.0.1
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
@@ -953,6 +956,9 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  react-devtools-core@7.0.1:
+    resolution: {integrity: sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==}
+
   react-reconciler@0.33.0:
     resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
     engines: {node: '>=0.10.0'}
@@ -990,6 +996,10 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1205,6 +1215,18 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -1701,7 +1723,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  ink@6.8.0(@types/react@19.2.14)(react@19.2.4):
+  ink@6.8.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.4):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.2.5
       ansi-escapes: 7.3.0
@@ -1731,6 +1753,7 @@ snapshots:
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 19.2.14
+      react-devtools-core: 7.0.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -1901,6 +1924,14 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  react-devtools-core@7.0.1:
+    dependencies:
+      shell-quote: 1.8.3
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   react-reconciler@0.33.0(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -1972,6 +2003,8 @@ snapshots:
       fsevents: 2.3.3
 
   scheduler@0.27.0: {}
+
+  shell-quote@1.8.3: {}
 
   siginfo@2.0.0: {}
 
@@ -2146,6 +2179,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@7.5.10: {}
 
   ws@8.19.0: {}
 

--- a/scripts/build-sea.sh
+++ b/scripts/build-sea.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+NODE_VERSION="$(node -e 'console.log(process.version)')"
+ARCH="$(uname -m)"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+
+case "$ARCH" in
+  arm64|aarch64) ARCH="arm64" ;;
+  x86_64)        ARCH="x64" ;;
+esac
+
+case "$OS" in
+  darwin) PLATFORM="darwin" ;;
+  linux)  PLATFORM="linux" ;;
+  *)      echo "Unsupported OS: $OS" && exit 1 ;;
+esac
+
+TARBALL="node-${NODE_VERSION}-${PLATFORM}-${ARCH}"
+CACHE_DIR="/tmp/tomo-sea-cache"
+NODE_BIN="${CACHE_DIR}/${TARBALL}/bin/node"
+
+# Download official Node binary (has SEA fuse) if not cached
+if [[ ! -f "$NODE_BIN" ]]; then
+  echo "Downloading official Node ${NODE_VERSION} binary..."
+  mkdir -p "$CACHE_DIR"
+  curl -sL "https://nodejs.org/dist/${NODE_VERSION}/${TARBALL}.tar.gz" \
+    | tar -xz -C "$CACHE_DIR" "${TARBALL}/bin/node"
+fi
+
+# Bundle the app
+pnpm build
+
+# Write sea-config with the official node binary path
+cat > sea-config.json << EOF
+{
+  "main": "dist/tomo.js",
+  "mainFormat": "module",
+  "executable": "${NODE_BIN}",
+  "output": "tomo",
+  "disableExperimentalSEAWarning": true
+}
+EOF
+
+# Build SEA — copies executable, generates blob, injects, all in one step
+node --build-sea sea-config.json
+
+# Codesign on macOS
+if [[ "$PLATFORM" == "darwin" ]]; then
+  codesign --sign - tomo
+fi
+
+echo "SEA binary built: ./tomo"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,10 +7,8 @@ export default defineConfig({
   platform: "node",
   bundle: true,
   noExternal: [/.*/],
+  splitting: false,
   banner: {
     js: 'import { createRequire } from "module"; const require = createRequire(import.meta.url);',
-  },
-  esbuildOptions(options) {
-    options.external = ["react-devtools-core"];
   },
 });


### PR DESCRIPTION
## Summary

Configure Node Single Executable Application (SEA) build to produce a standalone binary from the bundled app.

## GitHub Issue

Closes #16

## What Changed

Added `scripts/build-sea.sh` which downloads an official Node.js binary (homebrew/mise builds lack the SEA fuse sentinel), generates `sea-config.json` dynamically with the correct binary path, and runs `node --build-sea` to produce the standalone `./tomo` executable. The tsup config was updated to disable code splitting (SEA requires a single file) and bundle `react-devtools-core` instead of externalising it (SEA ESM can only import built-in modules).

## Notes for Reviewers

The official Node binary is cached at `/tmp/tomo-sea-cache/` to avoid re-downloading on repeat builds. The `sea-config.json` is generated at build time (not checked in) because it contains an absolute path to the cached binary. The resulting binary is ~134MB since it embeds the full Node runtime.