### PR TITLE
ci: add GitHub Actions workflow for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+      - run: pnpm lint
+      - run: pnpm format:check
+      - run: pnpm typecheck
+      - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "lefthook"
     ]
   },
+  "packageManager": "pnpm@10.11.1",
   "dependencies": {
     "ink": "^6.8.0",
     "react": "^19.2.4"


### PR DESCRIPTION
## Summary

Add a GitHub Actions CI workflow that runs on pull requests to main to validate code quality.

## GitHub Issue

Closes #17

## What Changed

Added `.github/workflows/ci.yml` triggered on PRs to main. Steps: checkout, setup pnpm (version from `packageManager` in package.json), setup Node (version from `.nvmrc`), install deps, then run build, lint, format check, typecheck, and test. Added `packageManager` field to `package.json` so the pnpm version is pinned in the repo rather than hardcoded in the workflow.