### PR TITLE
chore: add PR title validation for conventional commits

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,16 @@
+name: PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to enforce semantic PR titles using conventional commit format.

## GitHub Issue

Closes #18

## What Changed

Added `.github/workflows/pr.yml` using `amannn/action-semantic-pull-request@v5` to validate PR titles match conventional commit format on open, edit, and synchronize events.