### PR TITLE
chore: configure release drafter with autolabelling

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,84 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+template: |
+  ## What Changed
+
+  $CHANGES
+
+categories:
+  - title: "Breaking Changes"
+    labels:
+      - breaking
+  - title: "Features"
+    labels:
+      - feature
+  - title: "Bug Fixes"
+    labels:
+      - fix
+  - title: "Documentation"
+    labels:
+      - docs
+  - title: "Maintenance"
+    labels:
+      - chore
+      - refactor
+      - perf
+      - test
+      - ci
+      - build
+      - style
+
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - feature
+  patch:
+    labels:
+      - fix
+      - chore
+      - docs
+      - refactor
+      - perf
+      - test
+      - ci
+      - build
+      - style
+  default: patch
+
+autolabeler:
+  - label: breaking
+    title:
+      - "/^.+!:/"
+  - label: feature
+    title:
+      - "/^feat(\\(.+\\))?:/"
+  - label: fix
+    title:
+      - "/^fix(\\(.+\\))?:/"
+  - label: docs
+    title:
+      - "/^docs(\\(.+\\))?:/"
+  - label: chore
+    title:
+      - "/^chore(\\(.+\\))?:/"
+  - label: refactor
+    title:
+      - "/^refactor(\\(.+\\))?:/"
+  - label: perf
+    title:
+      - "/^perf(\\(.+\\))?:/"
+  - label: test
+    title:
+      - "/^test(\\(.+\\))?:/"
+  - label: ci
+    title:
+      - "/^ci(\\(.+\\))?:/"
+  - label: build
+    title:
+      - "/^build(\\(.+\\))?:/"
+  - label: style
+    title:
+      - "/^style(\\(.+\\))?:/"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,30 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update-release-draft:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  label:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Configure release-drafter to auto-generate release notes from merged PRs and auto-label PRs based on their semantic title prefix.

## GitHub Issue

Closes #19

## What Changed

Added `.github/workflows/release-drafter.yml` with two jobs: one updates the draft release on push to main, the other auto-labels PRs on open/reopen/sync. Added `.github/release-drafter.yml` config with categories (Breaking Changes, Features, Bug Fixes, Documentation, Maintenance), version resolver (major/minor/patch from labels), and autolabeler rules matching conventional commit prefixes to labels.