### PR TITLE
fix: add pull-requests read permission to release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v6
         env:


### PR DESCRIPTION
## Summary

Fix release drafter failing with "Resource not accessible by integration" by adding missing `pull-requests: read` permission to the update-release-draft job.

## GitHub Issue

Refs #19

## What Changed

The `update-release-draft` job had job-level permissions that only specified `contents: write`, which overrode the top-level permissions and dropped `pull-requests: read`. The GraphQL query for PR data requires this permission. Added `pull-requests: read` to the job-level permissions.