### PR TITLE
chore: add publish workflow for macOS SEA binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build:sea
+
+      - name: Zip binary
+        run: zip tomo-darwin-arm64.zip tomo
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: tomo-darwin-arm64.zip


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that builds a macOS SEA binary and attaches it to the GitHub release when published.

## GitHub Issue

Closes #21

## What Changed

Added `.github/workflows/publish.yml` triggered on release publish. Builds on `macos-latest`, runs tsup, generates SEA binary via `node --build-sea`, codesigns, zips as `tomo-darwin-arm64.zip`, and uploads to the release.