### PR TITLE
docs: add architecture decision records

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,3 +51,15 @@ Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`, `style`
 ## Pre-commit Hooks
 
 Lefthook runs lint, format check, and typecheck on every commit. These are installed automatically via the `prepare` script when you run `pnpm install`.
+
+## Architecture Decision Records
+
+Significant technical decisions are recorded as ADRs in `docs/adr/`. We use [adr-tools](https://github.com/npryce/adr-tools) to manage them.
+
+To create a new ADR:
+
+```bash
+adr new "Title of decision"
+```
+
+This creates a numbered markdown file in `docs/adr/` with the standard template. Fill in the Context, Decision, and Consequences sections.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/adr/0002-use-node-js-over-bun-as-runtime.md
+++ b/docs/adr/0002-use-node-js-over-bun-as-runtime.md
@@ -1,0 +1,26 @@
+# 2. Use Node.js over Bun as runtime
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+Tomo is a terminal-native AI chat client built with Ink (React for CLIs). It needs to be distributed as a standalone binary. We evaluated both Node.js and Bun as the runtime.
+
+Bun was attractive because `bun build --compile` produces a standalone binary in a single command, and Bun natively runs TypeScript — which would have eliminated the need for tsx, tsup, and the complex Node SEA build pipeline. Bun also includes a built-in package manager, which would have replaced pnpm.
+
+## Decision
+
+Use Node.js (v25) as the runtime.
+
+Bun was ruled out because Ink has runtime issues under Bun — renders hang indefinitely and `console.Console` constructor errors occur in the patch-console dependency. These are fundamental incompatibilities with the TUI framework the project depends on.
+
+## Consequences
+
+- The SEA build pipeline is more complex (official binary download, dynamic config generation, codesigning)
+- We need tsx for dev, tsup for bundling, and pnpm for package management — tools Bun would have replaced
+- We get full Ink/React compatibility and a mature, well-tested runtime
+- If Bun's Ink compatibility improves in the future, this decision could be revisited

--- a/docs/adr/0003-esm-bundle-output.md
+++ b/docs/adr/0003-esm-bundle-output.md
@@ -1,0 +1,23 @@
+# 3. ESM bundle output
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+The tsup bundler can output either CommonJS (CJS) or ECMAScript Modules (ESM). The original plan was to use CJS because Node SEA's `useCodeCache` option requires it for faster startup. The project uses `"type": "module"` in package.json.
+
+## Decision
+
+Use ESM as the bundle output format.
+
+Ink and its dependency yoga-layout use top-level `await`, which is incompatible with CJS. Since the core TUI framework requires ESM features, CJS is not viable.
+
+## Consequences
+
+- Cannot use `useCodeCache` in the SEA config, meaning slightly slower cold starts
+- Some transitive dependencies use CJS `require()` for Node builtins, requiring a `createRequire` shim in the bundle
+- The bundle must be a single file (no code splitting) since Node SEA can only embed one JS file

--- a/docs/adr/0004-node-sea-build-strategy.md
+++ b/docs/adr/0004-node-sea-build-strategy.md
@@ -1,0 +1,26 @@
+# 4. Node SEA build strategy
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+Tomo is distributed as a standalone binary via Node Single Executable Applications (SEA). Node 25.5+ introduced `node --build-sea`, which combines blob generation and injection in a single command, replacing the legacy `--experimental-sea-config` + postject workflow.
+
+Node binaries installed via homebrew or mise do not include the SEA fuse sentinel required for injection. Only official nodejs.org binaries have it.
+
+## Decision
+
+Use `node --build-sea` with an official Node binary downloaded at build time.
+
+The build script (`scripts/build-sea.sh`) downloads the official binary, caches it locally, and generates the SEA config dynamically because it contains an absolute path to the cached binary. The same script is used in both local dev and CI.
+
+## Consequences
+
+- First build requires downloading the official Node binary (~130MB); subsequent builds use the cache
+- The SEA config is generated at build time, not checked in
+- The resulting binary is ~134MB (full Node runtime embedded)
+- Contributors using homebrew or mise for Node don't need to change their setup — the build script handles the official binary separately

--- a/docs/adr/0005-biome-for-linting-and-formatting.md
+++ b/docs/adr/0005-biome-for-linting-and-formatting.md
@@ -1,0 +1,21 @@
+# 5. Biome for linting and formatting
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+The project needs a linter and formatter for TypeScript and TSX files. The traditional choice is ESLint + Prettier, but this requires configuring and maintaining two separate tools with potential conflicts between them.
+
+## Decision
+
+Use Biome as a single tool for both linting and formatting.
+
+## Consequences
+
+- Single tool to configure and maintain instead of two
+- Faster than ESLint + Prettier (Biome is written in Rust)
+- Biome's rule set is smaller than ESLint's ecosystem of plugins, but sufficient for this project

--- a/docs/adr/0006-tool-version-pinning-from-repo-files.md
+++ b/docs/adr/0006-tool-version-pinning-from-repo-files.md
@@ -1,0 +1,28 @@
+# 6. Tool version pinning from repo files
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+Node and pnpm versions need to be consistent across local development, CI, and the SEA build. Hardcoding versions in multiple places (CI workflows, mise config, scripts) creates drift risk.
+
+## Decision
+
+Pin tool versions in canonical repo files and reference them everywhere else:
+
+- **Node version**: `.nvmrc` (read by `actions/setup-node` via `node-version-file`, and by mise/nvm locally)
+- **pnpm version**: `packageManager` field in `package.json` (read by `pnpm/action-setup` automatically)
+- **Bun/other tools**: `.mise.toml` for local development
+
+CI workflows reference these files instead of hardcoding version numbers.
+
+## Consequences
+
+- Single source of truth for each tool version
+- Version updates are a one-line change in one file
+- CI and local dev are guaranteed to use the same versions
+- Contributors using nvm, fnm, or mise all read from `.nvmrc`


### PR DESCRIPTION
## Summary

Initialize adr-tools and add ADRs for the key technical decisions made during project scaffolding. Updated CONTRIBUTING.md with instructions for creating new ADRs.

## GitHub Issue

N/A

## What Changed

Set up adr-tools in `docs/adr/` and added 5 ADRs covering: runtime choice (Node over Bun), ESM bundle output, Node SEA build strategy, Biome for linting/formatting, and tool version pinning. Added an ADR section to CONTRIBUTING.md explaining how to create new records.