### PR TITLE
feat(provider): add OpenAI-compatible streaming chat completion client

### DIFF
--- a/src/provider/client.test.ts
+++ b/src/provider/client.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { streamChatCompletion, type ChatMessage } from "./client";
+
+function createSSEResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function makeChunk(content: string): string {
+  return JSON.stringify({
+    id: "chatcmpl-1",
+    object: "chat.completion.chunk",
+    created: 1234567890,
+    model: "test-model",
+    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+  });
+}
+
+const defaultOptions = {
+  baseUrl: "http://localhost:11434",
+  model: "test-model",
+  messages: [{ role: "user" as const, content: "Hello" }],
+};
+
+describe("streamChatCompletion", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("yields content tokens from streaming response", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      createSSEResponse([
+        `data: ${makeChunk("Hello")}\n\ndata: ${makeChunk(" world")}\n\ndata: [DONE]\n\n`,
+      ]),
+    );
+
+    const tokens: string[] = [];
+    for await (const token of streamChatCompletion(defaultOptions)) {
+      tokens.push(token);
+    }
+
+    expect(tokens).toEqual(["Hello", " world"]);
+  });
+
+  it("sends correct request to the endpoint", async () => {
+    vi.mocked(fetch).mockResolvedValue(createSSEResponse(["data: [DONE]\n\n"]));
+
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You are helpful" },
+      { role: "user", content: "Hi" },
+    ];
+
+    for await (const _ of streamChatCompletion({
+      baseUrl: "http://localhost:11434",
+      model: "llama3",
+      messages,
+    })) {
+      // consume
+    }
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "llama3",
+          messages,
+          stream: true,
+        }),
+      }),
+    );
+  });
+
+  it("strips trailing slashes from baseUrl", async () => {
+    vi.mocked(fetch).mockResolvedValue(createSSEResponse(["data: [DONE]\n\n"]));
+
+    for await (const _ of streamChatCompletion({
+      ...defaultOptions,
+      baseUrl: "http://localhost:11434/",
+    })) {
+      // consume
+    }
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/chat/completions",
+      expect.anything(),
+    );
+  });
+
+  it("throws on HTTP error response", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+
+    await expect(async () => {
+      for await (const _ of streamChatCompletion(defaultOptions)) {
+        // consume
+      }
+    }).rejects.toThrow("Provider returned HTTP 500: Internal Server Error");
+  });
+
+  it("throws on connection failure", async () => {
+    vi.mocked(fetch).mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(async () => {
+      for await (const _ of streamChatCompletion(defaultOptions)) {
+        // consume
+      }
+    }).rejects.toThrow("Failed to connect to provider");
+  });
+
+  it("skips chunks with no content (e.g. role-only delta)", async () => {
+    const roleChunk = JSON.stringify({
+      id: "1",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "test",
+      choices: [
+        { index: 0, delta: { role: "assistant" }, finish_reason: null },
+      ],
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      createSSEResponse([
+        `data: ${roleChunk}\n\ndata: ${makeChunk("Hi")}\n\ndata: [DONE]\n\n`,
+      ]),
+    );
+
+    const tokens: string[] = [];
+    for await (const token of streamChatCompletion(defaultOptions)) {
+      tokens.push(token);
+    }
+
+    expect(tokens).toEqual(["Hi"]);
+  });
+
+  it("passes abort signal to fetch", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    vi.mocked(fetch).mockRejectedValue(
+      new DOMException("The operation was aborted", "AbortError"),
+    );
+
+    await expect(async () => {
+      for await (const _ of streamChatCompletion({
+        ...defaultOptions,
+        signal: controller.signal,
+      })) {
+        // consume
+      }
+    }).rejects.toThrow("aborted");
+  });
+
+  it("throws on empty response body", async () => {
+    const response = new Response(null, { status: 200 });
+    Object.defineProperty(response, "body", { value: null });
+    vi.mocked(fetch).mockResolvedValue(response);
+
+    await expect(async () => {
+      for await (const _ of streamChatCompletion(defaultOptions)) {
+        // consume
+      }
+    }).rejects.toThrow("Provider returned an empty response body");
+  });
+});

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -1,0 +1,65 @@
+import { parseSSEStream } from "./sse";
+
+export interface ChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+export interface CompletionOptions {
+  baseUrl: string;
+  model: string;
+  messages: ChatMessage[];
+  signal?: AbortSignal;
+}
+
+/**
+ * Streams chat completion tokens from an OpenAI-compatible endpoint.
+ * Sends a POST to `/v1/chat/completions` with `stream: true` and
+ * yields content strings as they arrive.
+ */
+export async function* streamChatCompletion(
+  options: CompletionOptions,
+): AsyncGenerator<string> {
+  const { baseUrl, model, messages, signal } = options;
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/chat/completions`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, messages, stream: true }),
+      signal,
+    });
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error(
+        `Failed to connect to provider at ${url}: ${error.message}`,
+      );
+    }
+    throw error;
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Provider returned HTTP ${response.status}${body ? `: ${body}` : ""}`,
+    );
+  }
+
+  if (!response.body) {
+    throw new Error("Provider returned an empty response body");
+  }
+
+  for await (const data of parseSSEStream(response.body)) {
+    try {
+      const chunk = JSON.parse(data);
+      const content = chunk.choices?.[0]?.delta?.content;
+      if (content) {
+        yield content;
+      }
+    } catch {
+      // Skip malformed JSON in SSE data
+    }
+  }
+}

--- a/src/provider/sse.test.ts
+++ b/src/provider/sse.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { parseSSEStream } from "./sse";
+
+function createStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+async function collect(gen: AsyncGenerator<string>): Promise<string[]> {
+  const results: string[] = [];
+  for await (const item of gen) {
+    results.push(item);
+  }
+  return results;
+}
+
+describe("parseSSEStream", () => {
+  it("parses complete data lines", async () => {
+    const stream = createStream([
+      'data: {"content":"hello"}\n\ndata: {"content":"world"}\n\n',
+    ]);
+    const results = await collect(parseSSEStream(stream));
+    expect(results).toEqual(['{"content":"hello"}', '{"content":"world"}']);
+  });
+
+  it("handles data split across chunks", async () => {
+    const stream = createStream(['data: {"con', 'tent":"hello"}\n\n']);
+    const results = await collect(parseSSEStream(stream));
+    expect(results).toEqual(['{"content":"hello"}']);
+  });
+
+  it("stops at [DONE]", async () => {
+    const stream = createStream([
+      'data: {"content":"hello"}\n\ndata: [DONE]\n\ndata: {"content":"ignored"}\n\n',
+    ]);
+    const results = await collect(parseSSEStream(stream));
+    expect(results).toEqual(['{"content":"hello"}']);
+  });
+
+  it("ignores non-data lines", async () => {
+    const stream = createStream([
+      ': comment\nevent: something\ndata: {"content":"hello"}\n\n',
+    ]);
+    const results = await collect(parseSSEStream(stream));
+    expect(results).toEqual(['{"content":"hello"}']);
+  });
+
+  it("handles empty stream", async () => {
+    const stream = createStream([]);
+    const results = await collect(parseSSEStream(stream));
+    expect(results).toEqual([]);
+  });
+
+  it("handles multiple data lines in sequence", async () => {
+    const stream = createStream([
+      'data: {"a":1}\ndata: {"b":2}\n',
+      'data: {"c":3}\n',
+    ]);
+    const results = await collect(parseSSEStream(stream));
+    expect(results).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
+  });
+
+  it("handles \\r\\n line endings", async () => {
+    const stream = createStream([
+      'data: {"content":"hello"}\r\n\r\ndata: {"content":"world"}\r\n\r\n',
+    ]);
+    const results = await collect(parseSSEStream(stream));
+    expect(results).toEqual(['{"content":"hello"}', '{"content":"world"}']);
+  });
+
+  it("handles remaining buffer without trailing newline", async () => {
+    const stream = createStream(['data: {"content":"last"}']);
+    const results = await collect(parseSSEStream(stream));
+    expect(results).toEqual(['{"content":"last"}']);
+  });
+});

--- a/src/provider/sse.ts
+++ b/src/provider/sse.ts
@@ -1,0 +1,41 @@
+/**
+ * Parses a Server-Sent Events stream, yielding the data payload of each event.
+ * Handles buffering of partial lines across chunks.
+ * Returns when it encounters `data: [DONE]` or the stream ends.
+ */
+export async function* parseSSEStream(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const rawLine of lines) {
+        const line = rawLine.replace(/\r$/, "");
+        if (line.startsWith("data: ")) {
+          const data = line.slice(6);
+          if (data === "[DONE]") return;
+          yield data;
+        }
+      }
+    }
+
+    // Handle remaining buffer after stream ends
+    const remaining = buffer.replace(/\r$/, "");
+    if (remaining.startsWith("data: ")) {
+      const data = remaining.slice(6);
+      if (data !== "[DONE]") yield data;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["vitest/globals"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

Adds the foundational provider client for connecting to any OpenAI-compatible LLM endpoint (Ollama, llama.cpp, vLLM, etc.) with streaming support.

## GitHub Issue

Closes #36

## What Changed

Two new modules in `src/provider/`:

- **SSE parser** — async generator that reads a `ReadableStream<Uint8Array>`, buffers partial lines across chunks, yields `data:` payloads, and terminates on `[DONE]`. Handles both `\n` and `\r\n` line endings.
- **Provider client** — `streamChatCompletion()` function that POSTs to `{baseUrl}/v1/chat/completions` with `stream: true` and yields content strings via async generator. Wraps connection failures and HTTP errors with clear messages. Accepts an `AbortSignal` for cancellation (used later for Escape-to-interrupt).

Also added `vitest/globals` to `tsconfig.json` types to fix VS Code type resolution for test files.

16 new tests covering SSE parsing edge cases (chunked data, `[DONE]` sentinel, `\r\n`, trailing buffers) and client behaviour (request shape, error handling, abort signals, role-only deltas).