### PR TITLE
feat(provider): add thinking text extraction from streamed responses

### DIFF
--- a/src/provider/thinking.test.ts
+++ b/src/provider/thinking.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { extractThinking, type ThinkingChunk } from "./thinking";
+
+async function* tokensFrom(strings: string[]): AsyncGenerator<string> {
+  for (const s of strings) {
+    yield s;
+  }
+}
+
+async function collect(
+  gen: AsyncGenerator<ThinkingChunk>,
+): Promise<ThinkingChunk[]> {
+  const results: ThinkingChunk[] = [];
+  for await (const chunk of gen) {
+    results.push(chunk);
+  }
+  return results;
+}
+
+describe("extractThinking", () => {
+  it("passes through content with no thinking tags", async () => {
+    const result = await collect(
+      extractThinking(tokensFrom(["Hello ", "world"])),
+    );
+    expect(result).toEqual([
+      { type: "content", text: "Hello " },
+      { type: "content", text: "world" },
+    ]);
+  });
+
+  it("extracts thinking block in a single token", async () => {
+    const result = await collect(
+      extractThinking(
+        tokensFrom(["<think>reasoning here</think>The answer is 42"]),
+      ),
+    );
+    expect(result).toEqual([
+      { type: "thinking", text: "reasoning here" },
+      { type: "content", text: "The answer is 42" },
+    ]);
+  });
+
+  it("handles thinking tags split across tokens", async () => {
+    const result = await collect(
+      extractThinking(
+        tokensFrom(["<thi", "nk>", "I think", "</thi", "nk>", "Answer"]),
+      ),
+    );
+    expect(result).toEqual([
+      { type: "thinking", text: "I think" },
+      { type: "content", text: "Answer" },
+    ]);
+  });
+
+  it("handles partial open tag at chunk boundary", async () => {
+    const result = await collect(
+      extractThinking(tokensFrom(["Hello <", "think>thinking</think>done"])),
+    );
+    expect(result).toEqual([
+      { type: "content", text: "Hello " },
+      { type: "thinking", text: "thinking" },
+      { type: "content", text: "done" },
+    ]);
+  });
+
+  it("handles partial close tag at chunk boundary", async () => {
+    const result = await collect(
+      extractThinking(tokensFrom(["<think>thoughts</", "think>content"])),
+    );
+    expect(result).toEqual([
+      { type: "thinking", text: "thoughts" },
+      { type: "content", text: "content" },
+    ]);
+  });
+
+  it("handles thinking at the very start of response", async () => {
+    const result = await collect(
+      extractThinking(
+        tokensFrom([
+          "<think>",
+          "Let me reason",
+          "</think>",
+          "\n\nHere's the answer",
+        ]),
+      ),
+    );
+    expect(result).toEqual([
+      { type: "thinking", text: "Let me reason" },
+      { type: "content", text: "\n\nHere's the answer" },
+    ]);
+  });
+
+  it("handles multiple thinking blocks", async () => {
+    const result = await collect(
+      extractThinking(
+        tokensFrom([
+          "<think>first thought</think>response one<think>second thought</think>response two",
+        ]),
+      ),
+    );
+    expect(result).toEqual([
+      { type: "thinking", text: "first thought" },
+      { type: "content", text: "response one" },
+      { type: "thinking", text: "second thought" },
+      { type: "content", text: "response two" },
+    ]);
+  });
+
+  it("handles empty thinking block", async () => {
+    const result = await collect(
+      extractThinking(tokensFrom(["<think></think>content"])),
+    );
+    expect(result).toEqual([{ type: "content", text: "content" }]);
+  });
+
+  it("handles < characters that are not tags", async () => {
+    const result = await collect(
+      extractThinking(tokensFrom(["x < y and a <b> tag"])),
+    );
+    expect(result).toEqual([{ type: "content", text: "x < y and a <b> tag" }]);
+  });
+
+  it("flushes unterminated thinking block as thinking", async () => {
+    const result = await collect(
+      extractThinking(tokensFrom(["<think>still thinking..."])),
+    );
+    expect(result).toEqual([{ type: "thinking", text: "still thinking..." }]);
+  });
+
+  it("handles empty token stream", async () => {
+    const result = await collect(extractThinking(tokensFrom([])));
+    expect(result).toEqual([]);
+  });
+
+  it("handles single-character tokens through a tag", async () => {
+    const result = await collect(
+      extractThinking(
+        tokensFrom([
+          "<",
+          "t",
+          "h",
+          "i",
+          "n",
+          "k",
+          ">",
+          "ok",
+          "<",
+          "/",
+          "t",
+          "h",
+          "i",
+          "n",
+          "k",
+          ">",
+          "done",
+        ]),
+      ),
+    );
+    expect(result).toEqual([
+      { type: "thinking", text: "ok" },
+      { type: "content", text: "done" },
+    ]);
+  });
+});

--- a/src/provider/thinking.ts
+++ b/src/provider/thinking.ts
@@ -1,0 +1,68 @@
+const THINK_OPEN = "<think>";
+const THINK_CLOSE = "</think>";
+
+export interface ThinkingChunk {
+  type: "thinking" | "content";
+  text: string;
+}
+
+/**
+ * Returns the length of the longest suffix of `text` that is a prefix of `tag`.
+ * Used to detect partial tags at chunk boundaries.
+ */
+function findPartialTagLength(text: string, tag: string): number {
+  for (let len = Math.min(tag.length - 1, text.length); len >= 1; len--) {
+    if (text.endsWith(tag.slice(0, len))) {
+      return len;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Extracts `<think>...</think>` blocks from a streamed token sequence.
+ * Yields chunks tagged as either "thinking" or "content".
+ * Handles tags split across multiple tokens by buffering partial matches.
+ * Models that don't emit thinking tags pass through as pure content.
+ */
+export async function* extractThinking(
+  tokens: AsyncIterable<string>,
+): AsyncGenerator<ThinkingChunk> {
+  let buffer = "";
+  let state: "thinking" | "content" = "content";
+
+  for await (const token of tokens) {
+    buffer += token;
+
+    while (buffer.length > 0) {
+      const tag = state === "content" ? THINK_OPEN : THINK_CLOSE;
+      const tagIndex = buffer.indexOf(tag);
+
+      if (tagIndex !== -1) {
+        const before = buffer.slice(0, tagIndex);
+        if (before) {
+          yield { type: state, text: before };
+        }
+        buffer = buffer.slice(tagIndex + tag.length);
+        state = state === "content" ? "thinking" : "content";
+      } else {
+        const partialLen = findPartialTagLength(buffer, tag);
+        if (partialLen > 0) {
+          const safe = buffer.slice(0, -partialLen);
+          if (safe) {
+            yield { type: state, text: safe };
+          }
+          buffer = buffer.slice(-partialLen);
+        } else {
+          yield { type: state, text: buffer };
+          buffer = "";
+        }
+        break;
+      }
+    }
+  }
+
+  if (buffer) {
+    yield { type: state, text: buffer };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a stateful async generator that extracts `<think>...</think>` blocks from streamed LLM token output, separating model reasoning from response content.

## GitHub Issue

Closes #37

## What Changed

New `extractThinking()` generator that consumes the raw token stream from the provider client and yields chunks tagged as either `"thinking"` or `"content"`. Uses a state machine with buffering to handle think tags split across arbitrary chunk boundaries — including single-character tokens.

Composes directly with the existing provider client:
```typescript
const tokens = streamChatCompletion({ ... });
for await (const chunk of extractThinking(tokens)) {
  // chunk.type is "thinking" or "content"
}
```

Models that don't emit thinking tags pass through as pure content with zero overhead.