### PR TITLE
feat(ui): add chat UI components for message display

### DIFF
--- a/src/components/assistant-message.test.tsx
+++ b/src/components/assistant-message.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect } from "vitest";
+import { AssistantMessage } from "./assistant-message";
+
+describe("AssistantMessage", () => {
+  it("renders content as markdown", () => {
+    const { lastFrame } = render(
+      <AssistantMessage>{"**bold text**"}</AssistantMessage>,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("bold text");
+  });
+
+  it("renders thinking text when provided", () => {
+    const { lastFrame } = render(
+      <AssistantMessage thinking="Let me consider this...">
+        {"The answer is 42."}
+      </AssistantMessage>,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Let me consider this...");
+    expect(output).toContain("The answer is 42.");
+  });
+
+  it("does not render thinking section when not provided", () => {
+    const { lastFrame } = render(
+      <AssistantMessage>{"Just content."}</AssistantMessage>,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Just content.");
+  });
+
+  it("handles empty content during streaming", () => {
+    const { lastFrame } = render(
+      <AssistantMessage thinking="Thinking...">{""}</AssistantMessage>,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Thinking...");
+  });
+
+  it("re-renders with updated content (streaming)", () => {
+    const { lastFrame, rerender } = render(
+      <AssistantMessage>{"Hello"}</AssistantMessage>,
+    );
+    expect(lastFrame() ?? "").toContain("Hello");
+
+    rerender(
+      <AssistantMessage>{"Hello, the answer is **42**."}</AssistantMessage>,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("42");
+  });
+});

--- a/src/components/assistant-message.tsx
+++ b/src/components/assistant-message.tsx
@@ -1,0 +1,25 @@
+import { Box, Text } from "ink";
+import { Markdown } from "./markdown";
+
+interface AssistantMessageProps {
+  children: string;
+  thinking?: string;
+}
+
+export function AssistantMessage({
+  children,
+  thinking,
+}: AssistantMessageProps) {
+  return (
+    <Box flexDirection="column">
+      {thinking ? (
+        <Box marginLeft={2}>
+          <Text dimColor italic>
+            {thinking}
+          </Text>
+        </Box>
+      ) : null}
+      {children ? <Markdown>{children}</Markdown> : null}
+    </Box>
+  );
+}

--- a/src/components/message-list.test.tsx
+++ b/src/components/message-list.test.tsx
@@ -1,0 +1,59 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect } from "vitest";
+import { MessageList } from "./message-list";
+
+describe("MessageList", () => {
+  it("renders user and assistant messages", () => {
+    const { lastFrame } = render(
+      <MessageList
+        messages={[
+          { id: "1", role: "user", content: "Hi" },
+          { id: "2", role: "assistant", content: "Hello!" },
+        ]}
+      />,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Hi");
+    expect(output).toContain("Hello!");
+  });
+
+  it("renders empty message list", () => {
+    const { lastFrame } = render(<MessageList messages={[]} />);
+    const output = lastFrame() ?? "";
+    expect(output).toBe("");
+  });
+
+  it("renders thinking text on assistant messages", () => {
+    const { lastFrame } = render(
+      <MessageList
+        messages={[
+          {
+            id: "1",
+            role: "assistant",
+            content: "42",
+            thinking: "Let me think...",
+          },
+        ]}
+      />,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Let me think...");
+    expect(output).toContain("42");
+  });
+
+  it("renders multiple messages in order", () => {
+    const { lastFrame } = render(
+      <MessageList
+        messages={[
+          { id: "1", role: "user", content: "First" },
+          { id: "2", role: "assistant", content: "Second" },
+          { id: "3", role: "user", content: "Third" },
+        ]}
+      />,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("First");
+    expect(output).toContain("Second");
+    expect(output).toContain("Third");
+  });
+});

--- a/src/components/message-list.tsx
+++ b/src/components/message-list.tsx
@@ -1,0 +1,30 @@
+import { Box } from "ink";
+import { AssistantMessage } from "./assistant-message";
+import { UserMessage } from "./user-message";
+
+export interface DisplayMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  thinking?: string;
+}
+
+interface MessageListProps {
+  messages: DisplayMessage[];
+}
+
+export function MessageList({ messages }: MessageListProps) {
+  return (
+    <Box flexDirection="column" gap={1}>
+      {messages.map((msg) =>
+        msg.role === "user" ? (
+          <UserMessage key={msg.id}>{msg.content}</UserMessage>
+        ) : (
+          <AssistantMessage key={msg.id} thinking={msg.thinking}>
+            {msg.content}
+          </AssistantMessage>
+        ),
+      )}
+    </Box>
+  );
+}

--- a/src/components/user-message.test.tsx
+++ b/src/components/user-message.test.tsx
@@ -1,0 +1,13 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect } from "vitest";
+import { UserMessage } from "./user-message";
+
+describe("UserMessage", () => {
+  it("renders the message content", () => {
+    const { lastFrame } = render(
+      <UserMessage>{"How does this work?"}</UserMessage>,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("How does this work?");
+  });
+});

--- a/src/components/user-message.tsx
+++ b/src/components/user-message.tsx
@@ -1,0 +1,13 @@
+import { Text } from "ink";
+
+interface UserMessageProps {
+  children: string;
+}
+
+export function UserMessage({ children }: UserMessageProps) {
+  return (
+    <Text backgroundColor="gray" color="white">
+      {children}
+    </Text>
+  );
+}


### PR DESCRIPTION
## Summary

Adds Ink components for rendering chat messages — user messages with a gray background for distinction, and assistant messages with optional thinking text and markdown-formatted content.

## GitHub Issue

Closes #39

## What Changed

Three new components:

- **UserMessage** — renders user input with a gray background to visually distinguish it from assistant responses
- **AssistantMessage** — renders optional thinking text (dimmed/italic) above markdown-formatted content
- **MessageList** — takes a `DisplayMessage[]` array and dispatches each to the appropriate component by role, with gap spacing between messages

The `DisplayMessage` type includes an `id` field for stable React keys since messages are append-only but Biome's linter disallows array index keys.