### PR TITLE
refactor: extract conversation state into useChat hook

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,99 +1,34 @@
-import { useRef, useState } from "react";
 import { Box, Text } from "ink";
 import { AssistantMessage } from "./components/assistant-message";
 import { ChatInput } from "./components/chat-input";
 import { Header } from "./components/header";
-import type { DisplayMessage } from "./components/message-list";
 import { MessageList } from "./components/message-list";
 import { getActiveProvider, loadConfig } from "./config";
-import type { ChatMessage } from "./provider/client";
-import { streamChatCompletion } from "./provider/client";
+import { useChat } from "./hooks/use-chat";
 
 const config = loadConfig();
 const provider = getActiveProvider(config);
 
-/** Root application component. Manages the conversation loop and renders the chat UI. */
+/** Root application component. Renders the chat UI and delegates state to useChat. */
 export function App() {
-  const [messages, setMessages] = useState<DisplayMessage[]>([]);
-  const [streaming, setStreaming] = useState(false);
-  const [streamingContent, setStreamingContent] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
-
-  const handleSubmit = async (text: string) => {
-    const userMsg: DisplayMessage = {
-      id: crypto.randomUUID(),
-      role: "user",
-      content: text,
-    };
-
-    setMessages((prev) => [...prev, userMsg]);
-    setStreaming(true);
-    setStreamingContent("");
-    setError(null);
-
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    const chatMessages: ChatMessage[] = [
-      ...messages.map((m) => ({ role: m.role, content: m.content })),
-      { role: "user" as const, content: text },
-    ];
-
-    let content = "";
-
-    try {
-      for await (const token of streamChatCompletion({
-        baseUrl: provider.baseUrl,
-        model: provider.model,
-        messages: chatMessages,
-        signal: controller.signal,
-      })) {
-        content += token;
-        setStreamingContent(content);
-      }
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") {
-        // User cancelled — keep what we have
-      } else {
-        setError(err instanceof Error ? err.message : String(err));
-      }
-    }
-
-    if (content) {
-      const assistantMsg: DisplayMessage = {
-        id: crypto.randomUUID(),
-        role: "assistant",
-        content,
-      };
-      setMessages((prev) => [...prev, assistantMsg]);
-    }
-
-    setStreaming(false);
-    setStreamingContent("");
-    abortRef.current = null;
-  };
-
-  const handleEscape = () => {
-    abortRef.current?.abort();
-  };
+  const chat = useChat(provider);
 
   return (
     <Box flexDirection="column" paddingX={1}>
       <Header model={provider.model} />
 
-      <MessageList messages={messages} />
+      <MessageList messages={chat.messages} />
 
-      {streaming && streamingContent ? (
-        <AssistantMessage>{streamingContent}</AssistantMessage>
+      {chat.streaming && chat.streamingContent ? (
+        <AssistantMessage>{chat.streamingContent}</AssistantMessage>
       ) : null}
 
-      {error ? <Text color="red">{`Error: ${error}`}</Text> : null}
+      {chat.error ? <Text color="red">{`Error: ${chat.error}`}</Text> : null}
 
       <ChatInput
-        onSubmit={handleSubmit}
-        disabled={streaming}
-        onEscape={handleEscape}
+        onSubmit={chat.submit}
+        disabled={chat.streaming}
+        onEscape={chat.cancel}
       />
     </Box>
   );

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -1,0 +1,83 @@
+import { useRef, useState } from "react";
+import type { DisplayMessage } from "../components/message-list";
+import type { ProviderConfig } from "../config";
+import type { ChatMessage } from "../provider/client";
+import { streamChatCompletion } from "../provider/client";
+
+export interface ChatState {
+  messages: DisplayMessage[];
+  streaming: boolean;
+  streamingContent: string;
+  error: string | null;
+  submit: (text: string) => void;
+  cancel: () => void;
+}
+
+/** Manages conversation state and streaming for a chat session. */
+export function useChat(provider: ProviderConfig): ChatState {
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const [streamingContent, setStreamingContent] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const submit = async (text: string) => {
+    const userMsg: DisplayMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    };
+
+    setMessages((prev) => [...prev, userMsg]);
+    setStreaming(true);
+    setStreamingContent("");
+    setError(null);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const chatMessages: ChatMessage[] = [
+      ...messages.map((m) => ({ role: m.role, content: m.content })),
+      { role: "user" as const, content: text },
+    ];
+
+    let content = "";
+
+    try {
+      for await (const token of streamChatCompletion({
+        baseUrl: provider.baseUrl,
+        model: provider.model,
+        messages: chatMessages,
+        signal: controller.signal,
+      })) {
+        content += token;
+        setStreamingContent(content);
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        // User cancelled — keep what we have
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    if (content) {
+      const assistantMsg: DisplayMessage = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        content,
+      };
+      setMessages((prev) => [...prev, assistantMsg]);
+    }
+
+    setStreaming(false);
+    setStreamingContent("");
+    abortRef.current = null;
+  };
+
+  const cancel = () => {
+    abortRef.current?.abort();
+  };
+
+  return { messages, streaming, streamingContent, error, submit, cancel };
+}


### PR DESCRIPTION
## Summary

Extracts all conversation state and streaming logic from App into a dedicated `useChat` hook. App becomes a thin UI shell.

## GitHub Issue

Closes #42

## What Changed

New `useChat(provider)` hook in `src/hooks/use-chat.ts` that owns message history, streaming state, submit, and cancel logic. Returns a `ChatState` object with `messages`, `streaming`, `streamingContent`, `error`, `submit()`, and `cancel()`.

App now calls `useChat(provider)` and wires the returned state directly to the UI components — no local state or async logic in the component itself.