### PR TITLE
feat(ui): add thinking indicator with spinner and shimmer effect

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import { AssistantMessage } from "./components/assistant-message";
 import { ChatInput } from "./components/chat-input";
 import { Header } from "./components/header";
 import { MessageList } from "./components/message-list";
+import { ThinkingIndicator } from "./components/thinking-indicator";
 import { getActiveProvider, loadConfig } from "./config";
 import { useChat } from "./hooks/use-chat";
 
@@ -17,13 +18,25 @@ export function App() {
     <Box flexDirection="column" paddingX={1}>
       <Header model={provider.model} />
 
-      <MessageList messages={chat.messages} />
-
-      {chat.streaming && chat.streamingContent ? (
-        <AssistantMessage>{chat.streamingContent}</AssistantMessage>
+      {chat.messages.length > 0 ? (
+        <Box flexDirection="column" marginBottom={1}>
+          <MessageList messages={chat.messages} />
+        </Box>
       ) : null}
 
-      {chat.error ? <Text color="red">{`Error: ${chat.error}`}</Text> : null}
+      {chat.streaming && chat.streamingContent ? (
+        <Box flexDirection="column" marginBottom={1}>
+          <AssistantMessage>{chat.streamingContent}</AssistantMessage>
+        </Box>
+      ) : null}
+
+      {chat.error ? (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text color="red">{`Error: ${chat.error}`}</Text>
+        </Box>
+      ) : null}
+
+      {chat.streaming && !chat.streamingContent ? <ThinkingIndicator /> : null}
 
       <ChatInput
         onSubmit={chat.submit}

--- a/src/components/thinking-indicator.test.tsx
+++ b/src/components/thinking-indicator.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect, vi } from "vitest";
+import { ThinkingIndicator } from "./thinking-indicator";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("ThinkingIndicator", () => {
+  it("renders a spinner frame and the first verb", () => {
+    const { lastFrame } = render(<ThinkingIndicator />);
+    const output = lastFrame() ?? "";
+    expect(output).toContain("⠋");
+    expect(output).toContain("Thinking");
+  });
+
+  it("animates the spinner over time", async () => {
+    const { lastFrame } = render(<ThinkingIndicator />);
+    const initial = lastFrame() ?? "";
+
+    // Wait enough ticks for the frame to advance
+    await wait(200);
+
+    const after = lastFrame() ?? "";
+    // The spinner frame should have changed
+    expect(after).not.toBe(initial);
+  });
+
+  it("eventually cycles to a different verb", async () => {
+    const { lastFrame } = render(<ThinkingIndicator />);
+    // "Thinking" shimmer cycle = (3 + 8 + 4) * 80ms = 1200ms
+    // After that, verb should change to "Reasoning"
+    await wait(1400);
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Reasoning");
+  });
+
+  it("cleans up the interval on unmount", () => {
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+    const { unmount } = render(<ThinkingIndicator />);
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/src/components/thinking-indicator.tsx
+++ b/src/components/thinking-indicator.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { Box, Text } from "ink";
+import chalk from "chalk";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+const VERBS = [
+  "Thinking",
+  "Reasoning",
+  "Pondering",
+  "Analyzing",
+  "Considering",
+  "Processing",
+  "Reflecting",
+  "Contemplating",
+  "Evaluating",
+  "Deliberating",
+];
+
+const SHIMMER_WIDTH = 3;
+const TICK_MS = 80;
+
+/** Animated spinner with cycling verbs and a shimmer effect across the text. */
+export function ThinkingIndicator() {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const spinnerFrame = SPINNER_FRAMES[tick % SPINNER_FRAMES.length] as string;
+
+  const firstVerbLength = (VERBS[0] as string).length;
+  const verbIndex =
+    Math.floor(tick / (SHIMMER_WIDTH + firstVerbLength + 4)) % VERBS.length;
+  const verb = VERBS[verbIndex] as string;
+
+  const shimmerPos = (tick % (verb.length + SHIMMER_WIDTH + 4)) - SHIMMER_WIDTH;
+
+  const styledChars = [...verb].map((char, i) => {
+    const dist = i - shimmerPos;
+    if (dist >= 0 && dist < SHIMMER_WIDTH) {
+      const brightness = 1 - dist / SHIMMER_WIDTH;
+      const grey = Math.round(100 + brightness * 155);
+      return chalk.rgb(grey, grey, grey)(char);
+    }
+    return chalk.gray(char);
+  });
+
+  return (
+    <Box>
+      <Text color="cyan">{spinnerFrame} </Text>
+      <Text>{styledChars.join("")}</Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Adds an animated thinking indicator that displays while waiting for the first LLM token. A braille spinner cycles alongside rotating verbs (Thinking, Reasoning, Pondering, etc.) with a character-level shimmer sweep effect.

## GitHub Issue

N/A

## What Changed

New `ThinkingIndicator` component that combines three animations: a braille dot spinner, a rotating set of 10 verbs, and a shimmer highlight that sweeps across each verb character-by-character using per-character RGB coloring. The shimmer completing a pass triggers the next verb.

The component is shown in `app.tsx` when `streaming && !streamingContent` — the window between the user submitting and the first token arriving. Once tokens flow, it's replaced by the streaming `AssistantMessage`.

Layout spacing in `app.tsx` was also adjusted so messages, streaming content, and errors all have consistent `marginBottom={1}` spacing above the input area.

Tests cover initial render, animation progression, verb cycling, and interval cleanup on unmount.