### PR TITLE
feat(markdown): add table rendering for markdown and HTML tables

### DIFF
--- a/src/components/markdown.test.tsx
+++ b/src/components/markdown.test.tsx
@@ -73,6 +73,38 @@ describe("Markdown", () => {
     expect(output).not.toContain("&quot;");
   });
 
+  it("renders markdown tables with box drawing", () => {
+    const table = "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |";
+    const { lastFrame } = render(<Markdown>{table}</Markdown>);
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Name");
+    expect(output).toContain("Alice");
+    expect(output).toContain("Bob");
+    expect(output).toContain("┌");
+    expect(output).toContain("│");
+    expect(output).toContain("└");
+  });
+
+  it("renders HTML tables with box drawing", () => {
+    const html =
+      "<table><thead><tr><th>Task</th><th>Status</th></tr></thead><tbody><tr><td>Build</td><td>Done</td></tr></tbody></table>";
+    const { lastFrame } = render(<Markdown>{html}</Markdown>);
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Task");
+    expect(output).toContain("Build");
+    expect(output).toContain("Done");
+    expect(output).toContain("┌");
+    expect(output).not.toContain("<table>");
+    expect(output).not.toContain("<td>");
+  });
+
+  it("strips non-table HTML tags", () => {
+    const { lastFrame } = render(<Markdown>{"<div>hello</div>"}</Markdown>);
+    const output = lastFrame() ?? "";
+    expect(output).toContain("hello");
+    expect(output).not.toContain("<div>");
+  });
+
   it("re-renders with updated content (streaming simulation)", () => {
     const { lastFrame, rerender } = render(<Markdown>{"Hello"}</Markdown>);
     expect(lastFrame() ?? "").toContain("Hello");

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -2,6 +2,71 @@ import chalk from "chalk";
 import { highlight } from "cli-highlight";
 import { Text } from "ink";
 import { Marked } from "marked";
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape codes requires control characters
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+
+/** Strips ANSI escape codes to get the visible character length. */
+function stripAnsi(str: string): string {
+  return str.replace(ANSI_REGEX, "");
+}
+
+/** Pads a string to a visible width, accounting for ANSI codes. */
+function padEnd(str: string, width: number): string {
+  const visible = stripAnsi(str).length;
+  return str + " ".repeat(Math.max(0, width - visible));
+}
+
+/** Renders structured table data (headers + rows) as a box-drawn terminal table. */
+function renderTableData(headers: string[], rows: string[][]): string {
+  const colWidths = headers.map((h, i) => {
+    const cellWidths = rows.map((row) => stripAnsi(row[i] ?? "").length);
+    return Math.max(stripAnsi(h).length, ...cellWidths);
+  });
+
+  const top = `┌${colWidths.map((w) => "─".repeat(w + 2)).join("┬")}┐`;
+  const mid = `├${colWidths.map((w) => "─".repeat(w + 2)).join("┼")}┤`;
+  const bot = `└${colWidths.map((w) => "─".repeat(w + 2)).join("┴")}┘`;
+
+  const headerRow = `│${headers.map((h, i) => ` ${chalk.bold(padEnd(h, colWidths[i] as number))} `).join("│")}│`;
+  const dataRows = rows.map(
+    (row) =>
+      `│${row.map((cell, i) => ` ${padEnd(cell, colWidths[i] as number)} `).join("│")}│`,
+  );
+
+  return [
+    chalk.dim(top),
+    headerRow,
+    chalk.dim(mid),
+    ...dataRows,
+    chalk.dim(bot),
+  ].join("\n");
+}
+
+/**
+ * Extracts text content from an HTML table string.
+ * Returns rows of cell text, with the first row being the header.
+ */
+function parseHtmlTable(html: string): string[][] | null {
+  const rowMatches = html.match(/<tr[^>]*>[\s\S]*?<\/tr>/gi);
+  if (!rowMatches) return null;
+
+  const rows: string[][] = [];
+  for (const rowHtml of rowMatches) {
+    const cellMatches = rowHtml.match(
+      /<(?:td|th)[^>]*>[\s\S]*?<\/(?:td|th)>/gi,
+    );
+    if (!cellMatches) continue;
+    const cells = cellMatches.map((c) => c.replace(/<[^>]*>/g, "").trim());
+    if (cells.length > 0) rows.push(cells);
+  }
+  return rows.length > 0 ? rows : null;
+}
+
+/** Renders parsed HTML table rows as a box-drawn terminal table. */
+function renderHtmlTable(rows: string[][]): string {
+  const [header, ...dataRows] = rows;
+  return renderTableData(header as string[], dataRows);
+}
 
 const md = new Marked({
   renderer: {
@@ -44,6 +109,15 @@ const md = new Marked({
     listitem({ tokens }) {
       return this.parser.parse(tokens).replace(/\n+$/, "");
     },
+    table(token) {
+      const headers = token.header.map((cell) =>
+        this.parser.parseInline(cell.tokens),
+      );
+      const rows = token.rows.map((row) =>
+        row.map((cell) => this.parser.parseInline(cell.tokens)),
+      );
+      return `${renderTableData(headers, rows)}\n\n`;
+    },
     hr() {
       return `${chalk.dim("─".repeat(40))}\n\n`;
     },
@@ -69,7 +143,10 @@ const md = new Marked({
       return "\n";
     },
     html({ text }) {
-      return text;
+      const tableRows = parseHtmlTable(text);
+      if (tableRows) return `${renderHtmlTable(tableRows)}\n\n`;
+      // Strip remaining HTML tags, keep text content
+      return text.replace(/<[^>]*>/g, "").trim();
     },
   },
 });


### PR DESCRIPTION
## Summary

Tables from LLM output (both markdown pipe-syntax and raw HTML) now render as box-drawn terminal tables instead of passing through as raw markup. Non-table HTML tags are stripped to plain text.

## GitHub Issue

Closes #59

## What Changed

Added a shared `renderTableData()` function that draws box-character tables (┌─┬─┐ style) with ANSI-aware column width calculation and bold headers. This is used by two new rendering paths:

1. **Markdown tables** — new `table()` renderer on the Marked instance that extracts headers and rows from the structured `Tokens.Table` token.
2. **HTML tables** — the `html()` renderer now detects `<table>` markup via regex, extracts cell text from `<tr>/<td>/<th>` tags, and renders through the same table drawing function.

Non-table HTML tags (e.g. `<div>`, `<span>`) are now stripped to their text content rather than passing through raw.