### PR TITLE
feat(commands): add /models command and refactor config

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,11 +13,11 @@ const provider = getActiveProvider(config);
 
 /** Root application component. Renders the chat UI and delegates state to useChat. */
 export function App() {
-  const chat = useChat(provider);
+  const chat = useChat(provider, config.activeModel);
 
   return (
     <Box flexDirection="column" paddingX={1}>
-      <Header model={provider.model} />
+      <Header model={config.activeModel} />
 
       {chat.messages.length > 0 ? (
         <Box flexDirection="column" marginBottom={1}>

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 // Register built-in commands
 import "./help";
+import "./models";
 import "./new";
 
 // Re-export registry functions

--- a/src/commands/models.test.ts
+++ b/src/commands/models.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getCommand } from "./registry";
+import "./models";
+
+const mockCallbacks = () => ({
+  onComplete: vi.fn(),
+  onCancel: vi.fn(),
+  clearMessages: vi.fn(),
+  providerBaseUrl: "http://localhost:11434",
+  activeModel: "qwen3:8b",
+});
+
+describe("/models command", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is registered", () => {
+    expect(getCommand("models")).toBeDefined();
+  });
+
+  it("lists available models and highlights the active one", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ id: "qwen3:8b" }, { id: "llama3:70b" }],
+        }),
+      ),
+    );
+
+    const command = getCommand("models")!;
+    const result = await command.execute("", mockCallbacks());
+
+    expect(result).toHaveProperty("output");
+    const output = (result as { output: string }).output;
+    expect(output).toContain("* qwen3:8b (active)");
+    expect(output).toContain("llama3:70b");
+  });
+
+  it("handles empty model list", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [] })),
+    );
+
+    const command = getCommand("models")!;
+    const result = await command.execute("", mockCallbacks());
+
+    expect(result).toHaveProperty("output");
+    const output = (result as { output: string }).output;
+    expect(output).toContain("No models available");
+  });
+
+  it("handles connection errors gracefully", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new TypeError("fetch failed"),
+    );
+
+    const command = getCommand("models")!;
+    const result = await command.execute("", mockCallbacks());
+
+    expect(result).toHaveProperty("output");
+    const output = (result as { output: string }).output;
+    expect(output).toContain("Failed to fetch models");
+  });
+});

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -1,0 +1,25 @@
+import { fetchModels } from "../provider/client";
+import { register } from "./registry";
+import type { Command } from "./types";
+
+const models: Command = {
+  name: "models",
+  description: "List available models from the active provider",
+  execute: async (_args, { providerBaseUrl, activeModel }) => {
+    try {
+      const available = await fetchModels(providerBaseUrl);
+      if (available.length === 0) {
+        return { output: "No models available from the active provider." };
+      }
+      const lines = available.map((m) =>
+        m.id === activeModel ? `  * ${m.id} (active)` : `    ${m.id}`,
+      );
+      return { output: lines.join("\n") };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { output: `Failed to fetch models: ${message}` };
+    }
+  },
+};
+
+register(models);

--- a/src/commands/new.test.ts
+++ b/src/commands/new.test.ts
@@ -14,6 +14,8 @@ describe("/new command", () => {
       onComplete: vi.fn(),
       onCancel: vi.fn(),
       clearMessages,
+      providerBaseUrl: "http://localhost:11434",
+      activeModel: "qwen3:8b",
     };
 
     const result = command!.execute("", callbacks);

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -10,16 +10,21 @@ export type CommandExecuteResult =
   | CommandResult
   | { interactive: ReactElement };
 
-/** Callbacks provided to commands for state changes, completion, and cancellation. */
+/** Context and callbacks provided to commands for state changes and provider access. */
 export interface CommandCallbacks {
   onComplete: (result: CommandResult) => void;
   onCancel: () => void;
   clearMessages: () => void;
+  providerBaseUrl: string;
+  activeModel: string;
 }
 
 /** A registered slash command with a name, description, and execute handler. */
 export interface Command {
   name: string;
   description: string;
-  execute: (args: string, callbacks: CommandCallbacks) => CommandExecuteResult;
+  execute: (
+    args: string,
+    callbacks: CommandCallbacks,
+  ) => CommandExecuteResult | Promise<CommandExecuteResult>;
 }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -33,6 +33,7 @@ describe("loadConfig", () => {
   it("creates default config when none exists", () => {
     const config = loadConfig();
     expect(config.activeProvider).toBe("ollama");
+    expect(config.activeModel).toBe("qwen3:8b");
     expect(config.providers).toHaveLength(1);
     expect(config.providers[0].name).toBe("ollama");
     expect(existsSync(globalPath)).toBe(true);
@@ -43,17 +44,17 @@ describe("loadConfig", () => {
       globalPath,
       `
 activeProvider: my-ollama
+activeModel: llama3
 providers:
   - name: my-ollama
     type: ollama
     baseUrl: http://localhost:9999
-    model: llama3
 `,
     );
     const config = loadConfig();
     expect(config.activeProvider).toBe("my-ollama");
+    expect(config.activeModel).toBe("llama3");
     expect(config.providers[0].baseUrl).toBe("http://localhost:9999");
-    expect(config.providers[0].model).toBe("llama3");
   });
 
   it("merges local config on top of global", () => {
@@ -61,27 +62,27 @@ providers:
       globalPath,
       `
 activeProvider: ollama
+activeModel: qwen3:8b
 providers:
   - name: ollama
     type: ollama
     baseUrl: http://localhost:11434
-    model: qwen3:8b
 `,
     );
     writeYaml(
       localPath,
       `
 activeProvider: local-ollama
+activeModel: mistral
 providers:
   - name: local-ollama
     type: ollama
     baseUrl: http://localhost:5555
-    model: mistral
 `,
     );
     const config = loadConfig();
     expect(config.activeProvider).toBe("local-ollama");
-    expect(config.providers[0].model).toBe("mistral");
+    expect(config.activeModel).toBe("mistral");
   });
 
   it("throws on empty providers", () => {
@@ -89,6 +90,7 @@ providers:
       globalPath,
       `
 activeProvider: ollama
+activeModel: qwen3:8b
 providers: []
 `,
     );
@@ -100,10 +102,10 @@ providers: []
       globalPath,
       `
 activeProvider: ollama
+activeModel: qwen3:8b
 providers:
   - type: ollama
     baseUrl: http://localhost:11434
-    model: qwen3:8b
 `,
     );
     expect(() => loadConfig()).toThrow("validation failed");
@@ -114,11 +116,11 @@ providers:
       globalPath,
       `
 activeProvider: test
+activeModel: qwen3:8b
 providers:
   - name: test
     type: unsupported
     baseUrl: http://localhost:11434
-    model: qwen3:8b
 `,
     );
     expect(() => loadConfig()).toThrow("unsupported provider type");
@@ -129,27 +131,13 @@ providers:
       globalPath,
       `
 activeProvider: test
+activeModel: qwen3:8b
 providers:
   - name: test
     type: ollama
-    model: qwen3:8b
 `,
     );
     expect(() => loadConfig()).toThrow("validation failed");
-  });
-
-  it("throws on missing model", () => {
-    writeYaml(
-      globalPath,
-      `
-activeProvider: test
-providers:
-  - name: test
-    type: ollama
-    baseUrl: http://localhost:11434
-`,
-    );
-    expect(() => loadConfig()).toThrow("model");
   });
 
   it("throws when activeProvider does not match any provider", () => {
@@ -157,11 +145,11 @@ providers:
       globalPath,
       `
 activeProvider: nonexistent
+activeModel: qwen3:8b
 providers:
   - name: ollama
     type: ollama
     baseUrl: http://localhost:11434
-    model: qwen3:8b
 `,
     );
     expect(() => loadConfig()).toThrow(
@@ -174,12 +162,12 @@ describe("getActiveProvider", () => {
   it("returns the active provider", () => {
     const config: Config = {
       activeProvider: "ollama",
+      activeModel: "qwen3:8b",
       providers: [
         {
           name: "ollama",
           type: "ollama",
           baseUrl: "http://localhost:11434",
-          model: "qwen3:8b",
         },
       ],
     };
@@ -191,12 +179,12 @@ describe("getActiveProvider", () => {
   it("throws when active provider not found", () => {
     const config: Config = {
       activeProvider: "missing",
+      activeModel: "qwen3:8b",
       providers: [
         {
           name: "ollama",
           type: "ollama",
           baseUrl: "http://localhost:11434",
-          model: "qwen3:8b",
         },
       ],
     };

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,12 +10,12 @@ const providerSchema = z.object({
     message: 'unsupported provider type. Supported: "ollama"',
   }),
   baseUrl: z.string().url("baseUrl must be a valid URL"),
-  model: z.string().min(1, "model is required"),
 });
 
 const configSchema = z
   .object({
     activeProvider: z.string().min(1, "activeProvider is required"),
+    activeModel: z.string().min(1, "activeModel is required"),
     providers: z
       .array(providerSchema)
       .min(1, "providers must be a non-empty array"),
@@ -37,23 +37,23 @@ export type Config = z.infer<typeof configSchema>;
 
 const DEFAULT_CONFIG: Config = {
   activeProvider: "ollama",
+  activeModel: "qwen3:8b",
   providers: [
     {
       name: "ollama",
       type: "ollama",
       baseUrl: "http://localhost:11434",
-      model: "qwen3:8b",
     },
   ],
 };
 
 const DEFAULT_CONFIG_YAML = `activeProvider: ollama
+activeModel: qwen3:8b
 
 providers:
   - name: ollama
     type: ollama
     baseUrl: http://localhost:11434
-    model: qwen3:8b
 `;
 
 /** Returns the path to the global config file (~/.tomo/config.yaml). */

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -17,7 +17,7 @@ export interface ChatState {
 }
 
 /** Manages conversation state and streaming for a chat session. */
-export function useChat(provider: ProviderConfig): ChatState {
+export function useChat(provider: ProviderConfig, model: string): ChatState {
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const [streaming, setStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState("");
@@ -59,7 +59,7 @@ export function useChat(provider: ProviderConfig): ChatState {
         return;
       }
 
-      const result = command.execute(parsed.args, {
+      const result = await command.execute(parsed.args, {
         onComplete: (completionResult) => {
           addMessages({
             id: crypto.randomUUID(),
@@ -72,6 +72,8 @@ export function useChat(provider: ProviderConfig): ChatState {
           setActiveCommand(null);
         },
         clearMessages,
+        providerBaseUrl: provider.baseUrl,
+        activeModel: model,
       });
 
       if ("interactive" in result) {
@@ -116,7 +118,7 @@ export function useChat(provider: ProviderConfig): ChatState {
     try {
       for await (const token of streamChatCompletion({
         baseUrl: provider.baseUrl,
-        model: provider.model,
+        model,
         messages: chatMessages,
         signal: controller.signal,
       })) {

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -1,5 +1,38 @@
 import { parseSSEStream } from "./sse";
 
+/** A model available from the provider. */
+export interface ModelInfo {
+  id: string;
+}
+
+/** Fetches available models from an OpenAI-compatible /v1/models endpoint. */
+export async function fetchModels(baseUrl: string): Promise<ModelInfo[]> {
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/models`;
+
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error(
+        `Failed to connect to provider at ${url}: ${error.message}`,
+      );
+    }
+    throw error;
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Provider returned HTTP ${response.status}${body ? `: ${body}` : ""}`,
+    );
+  }
+
+  const json = await response.json();
+  const models = (json.data ?? []) as Array<{ id: string }>;
+  return models.map((m) => ({ id: m.id }));
+}
+
 export interface ChatMessage {
   role: "user" | "assistant" | "system";
   content: string;


### PR DESCRIPTION
## Summary

Adds a `/models` command that fetches and displays available models from the active provider, and refactors the config so providers represent connections while the active model is a separate top-level field.

## GitHub Issue

Closes #52

## What Changed

**Config refactor** — `model` removed from the provider schema and replaced with a top-level `activeModel` field. Providers now represent just the connection (name, type, baseUrl), so multiple models on the same provider don't require duplicate entries.

**`/models` command** — fetches from the provider's `/v1/models` endpoint via a new `fetchModels()` client function. Lists all available models with the active one marked with `*`. Connection errors are caught and displayed gracefully.

**Async command support** — `Command.execute` can now return a `Promise<CommandExecuteResult>`, enabling commands that make network requests. `CommandCallbacks` extended with `providerBaseUrl` and `activeModel` so commands have provider context.

## Notes for Reviewers

This is a **breaking config change** — existing `~/.tomo/config.yaml` files need `model` moved from under the provider to a top-level `activeModel` field.