### PR TITLE
feat(session): add session storage with JSONL append-only persistence

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,13 +7,20 @@ import { MessageList } from "./components/message-list";
 import { ThinkingIndicator } from "./components/thinking-indicator";
 import { getActiveProvider, loadConfig } from "./config";
 import { useChat } from "./hooks/use-chat";
+import { createSession } from "./session";
 
 const config = loadConfig();
 const initialProvider = getActiveProvider(config);
+const initialSession = createSession(initialProvider.name, config.activeModel);
 
 /** Root application component. Renders the chat UI and delegates state to useChat. */
 export function App() {
-  const chat = useChat(config, initialProvider, config.activeModel);
+  const chat = useChat(
+    config,
+    initialProvider,
+    config.activeModel,
+    initialSession,
+  );
 
   return (
     <Box flexDirection="column" paddingX={1}>

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -11,6 +11,7 @@ import {
 } from "../config";
 import type { ChatMessage } from "../provider/client";
 import { streamChatCompletion } from "../provider/client";
+import { type Session, appendMessage, createSession } from "../session";
 
 export interface ChatState {
   messages: DisplayMessage[];
@@ -29,8 +30,11 @@ export function useChat(
   config: Config,
   initialProvider: ProviderConfig,
   initialModel: string,
+  initialSession: Session,
 ): ChatState {
-  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [messages, setMessages] = useState<DisplayMessage[]>(
+    initialSession.messages,
+  );
   const [streaming, setStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -39,12 +43,19 @@ export function useChat(
   const [activeProvider, setActiveProviderState] =
     useState<ProviderConfig>(initialProvider);
   const abortRef = useRef<AbortController | null>(null);
+  const sessionRef = useRef<Session>(initialSession);
 
   const addMessages = (...msgs: DisplayMessage[]) => {
     setMessages((prev) => [...prev, ...msgs]);
+    for (const msg of msgs) {
+      appendMessage(sessionRef.current, msg);
+    }
   };
 
   const clearMessages = () => {
+    const newSession = createSession(activeProvider.name, activeModel);
+    sessionRef.current = newSession;
+
     abortRef.current?.abort();
     setMessages([]);
     setStreaming(false);
@@ -127,6 +138,7 @@ export function useChat(
     };
 
     setMessages((prev) => [...prev, userMsg]);
+    appendMessage(sessionRef.current, userMsg);
     setStreaming(true);
     setStreamingContent("");
     setError(null);
@@ -171,6 +183,7 @@ export function useChat(
         content,
       };
       setMessages((prev) => [...prev, assistantMsg]);
+      appendMessage(sessionRef.current, assistantMsg);
     }
 
     setStreaming(false);

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -1,0 +1,193 @@
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  appendMessage,
+  createSession,
+  listSessions,
+  loadMostRecentSession,
+  loadSession,
+} from "./session";
+
+const tmpDir = resolve(import.meta.dirname, "../.test-session-tmp");
+
+vi.mock("node:os", () => ({
+  homedir: () => tmpDir,
+}));
+
+beforeEach(() => {
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("createSession", () => {
+  it("creates a session with correct defaults", () => {
+    const session = createSession("ollama", "qwen3:8b");
+    expect(session.id).toBeDefined();
+    expect(session.name).toBe("New session");
+    expect(session.provider).toBe("ollama");
+    expect(session.model).toBe("qwen3:8b");
+    expect(session.messages).toEqual([]);
+    expect(session.createdAt).toBeDefined();
+    expect(session.updatedAt).toBeDefined();
+  });
+
+  it("generates unique IDs", () => {
+    const s1 = createSession("ollama", "qwen3:8b");
+    const s2 = createSession("ollama", "qwen3:8b");
+    expect(s1.id).not.toBe(s2.id);
+  });
+});
+
+describe("appendMessage / loadSession", () => {
+  it("round-trips messages through JSONL", () => {
+    const session = createSession("ollama", "qwen3:8b");
+    const msg1 = { id: "msg-1", role: "user" as const, content: "hello" };
+    const msg2 = {
+      id: "msg-2",
+      role: "assistant" as const,
+      content: "hi there",
+    };
+
+    appendMessage(session, msg1);
+    appendMessage(session, msg2);
+
+    const loaded = loadSession(session.id);
+    expect(loaded?.id).toBe(session.id);
+    expect(loaded?.name).toBe("New session");
+    expect(loaded?.provider).toBe("ollama");
+    expect(loaded?.model).toBe("qwen3:8b");
+    expect(loaded?.messages).toEqual([msg1, msg2]);
+  });
+
+  it("returns null for non-existent session", () => {
+    expect(loadSession("nonexistent")).toBeNull();
+  });
+
+  it("creates the sessions directory and file on first append", () => {
+    const session = createSession("ollama", "qwen3:8b");
+    const msg = { id: "msg-1", role: "user" as const, content: "hello" };
+
+    appendMessage(session, msg);
+
+    const loaded = loadSession(session.id);
+    expect(loaded?.messages).toEqual([msg]);
+  });
+
+  it("appends incrementally without rewriting earlier messages", () => {
+    const session = createSession("ollama", "qwen3:8b");
+
+    appendMessage(session, {
+      id: "msg-1",
+      role: "user",
+      content: "first",
+    });
+    appendMessage(session, {
+      id: "msg-2",
+      role: "assistant",
+      content: "second",
+    });
+    appendMessage(session, {
+      id: "msg-3",
+      role: "user",
+      content: "third",
+    });
+
+    const loaded = loadSession(session.id);
+    expect(loaded?.messages).toHaveLength(3);
+    expect(loaded?.messages[0].content).toBe("first");
+    expect(loaded?.messages[2].content).toBe("third");
+  });
+
+  it("preserves session metadata across appends", () => {
+    const session = createSession("ollama", "qwen3:8b");
+
+    appendMessage(session, {
+      id: "msg-1",
+      role: "user",
+      content: "hello",
+    });
+
+    const loaded = loadSession(session.id);
+    expect(loaded?.createdAt).toBe(session.createdAt);
+    expect(loaded?.provider).toBe(session.provider);
+    expect(loaded?.model).toBe(session.model);
+  });
+});
+
+describe("listSessions", () => {
+  it("returns empty array when no sessions exist", () => {
+    expect(listSessions()).toEqual([]);
+  });
+
+  it("returns sessions sorted by most recently updated", () => {
+    const s1 = createSession("ollama", "qwen3:8b");
+    appendMessage(s1, { id: "m1", role: "user", content: "old" });
+
+    const s2 = createSession("ollama", "qwen3:8b");
+    appendMessage(s2, { id: "m2", role: "user", content: "new" });
+
+    // Set explicit mtimes so ordering is deterministic
+    const sessDir = resolve(tmpDir, ".tomo", "sessions");
+    const older = new Date("2026-03-20T10:00:00Z");
+    const newer = new Date("2026-03-20T12:00:00Z");
+    utimesSync(resolve(sessDir, `${s1.id}.jsonl`), older, older);
+    utimesSync(resolve(sessDir, `${s2.id}.jsonl`), newer, newer);
+
+    const sessions = listSessions();
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].id).toBe(s2.id);
+    expect(sessions[1].id).toBe(s1.id);
+  });
+
+  it("returns sessions without messages loaded", () => {
+    const session = createSession("ollama", "qwen3:8b");
+    appendMessage(session, { id: "m1", role: "user", content: "hello" });
+
+    const sessions = listSessions();
+    expect(sessions[0].messages).toEqual([]);
+  });
+
+  it("skips malformed files", () => {
+    const dir = resolve(tmpDir, ".tomo", "sessions");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, "bad.jsonl"), "not json\n", "utf-8");
+
+    const session = createSession("ollama", "qwen3:8b");
+    appendMessage(session, { id: "m1", role: "user", content: "hello" });
+
+    const sessions = listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe(session.id);
+  });
+});
+
+describe("loadMostRecentSession", () => {
+  it("returns null when no sessions exist", () => {
+    expect(loadMostRecentSession()).toBeNull();
+  });
+
+  it("returns the most recently updated session with messages", () => {
+    const s1 = createSession("ollama", "qwen3:8b");
+    appendMessage(s1, { id: "m1", role: "user", content: "old" });
+
+    const s2 = createSession("ollama", "qwen3:8b");
+    appendMessage(s2, { id: "m2", role: "user", content: "new" });
+
+    // Set explicit mtimes so ordering is deterministic
+    const sessDir = resolve(tmpDir, ".tomo", "sessions");
+    const older = new Date("2026-03-20T10:00:00Z");
+    const newer = new Date("2026-03-20T12:00:00Z");
+    utimesSync(resolve(sessDir, `${s1.id}.jsonl`), older, older);
+    utimesSync(resolve(sessDir, `${s2.id}.jsonl`), newer, newer);
+
+    const most = loadMostRecentSession();
+    expect(most?.id).toBe(s2.id);
+    expect(most?.messages).toHaveLength(1);
+    expect(most?.messages[0].content).toBe("new");
+  });
+});

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,193 @@
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import type { DisplayMessage } from "./components/message-list";
+
+export interface Session {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  provider: string;
+  model: string;
+  messages: DisplayMessage[];
+}
+
+interface MetaEntry {
+  type: "meta";
+  id: string;
+  name: string;
+  createdAt: string;
+  provider: string;
+  model: string;
+}
+
+interface MessageEntry {
+  type: "message";
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+/** Returns the path to the sessions directory (~/.tomo/sessions/). */
+function sessionsDir(): string {
+  return resolve(homedir(), ".tomo", "sessions");
+}
+
+/** Returns the file path for a session by ID. */
+function sessionPath(id: string): string {
+  return resolve(sessionsDir(), `${id}.jsonl`);
+}
+
+/** Creates the sessions directory if it doesn't exist. */
+function ensureSessionsDir(): void {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+/** Reads the first line of a file efficiently (up to 4KB). */
+function readFirstLine(path: string): string {
+  const fd = openSync(path, "r");
+  try {
+    const buf = Buffer.alloc(4096);
+    const bytesRead = readSync(fd, buf, 0, 4096, 0);
+    const content = buf.toString("utf-8", 0, bytesRead);
+    const idx = content.indexOf("\n");
+    return idx === -1 ? content : content.slice(0, idx);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Creates a new empty session in memory. No disk I/O. */
+export function createSession(provider: string, model: string): Session {
+  return {
+    id: crypto.randomUUID(),
+    name: "New session",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    provider,
+    model,
+    messages: [],
+  };
+}
+
+/** Appends a message to the session's JSONL file. Creates the file with a meta line if needed. */
+export function appendMessage(session: Session, message: DisplayMessage): void {
+  ensureSessionsDir();
+
+  const path = sessionPath(session.id);
+  if (!existsSync(path)) {
+    const meta: MetaEntry = {
+      type: "meta",
+      id: session.id,
+      name: session.name,
+      createdAt: session.createdAt,
+      provider: session.provider,
+      model: session.model,
+    };
+    writeFileSync(path, `${JSON.stringify(meta)}\n`, "utf-8");
+  }
+
+  const entry: MessageEntry = {
+    type: "message",
+    id: message.id,
+    role: message.role,
+    content: message.content,
+  };
+  appendFileSync(path, `${JSON.stringify(entry)}\n`, "utf-8");
+}
+
+/** Loads a session by ID. Returns null if not found. */
+export function loadSession(id: string): Session | null {
+  const path = sessionPath(id);
+  if (!existsSync(path)) return null;
+
+  const content = readFileSync(path, "utf-8");
+  const lines = content.trim().split("\n").filter(Boolean);
+  if (lines.length === 0) return null;
+
+  const meta = JSON.parse(lines[0]) as MetaEntry;
+  const messages: DisplayMessage[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    try {
+      const entry = JSON.parse(lines[i]) as MessageEntry;
+      if (entry.type === "message") {
+        messages.push({
+          id: entry.id,
+          role: entry.role,
+          content: entry.content,
+        });
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  const stat = statSync(path);
+
+  return {
+    id: meta.id,
+    name: meta.name,
+    createdAt: meta.createdAt,
+    updatedAt: stat.mtime.toISOString(),
+    provider: meta.provider,
+    model: meta.model,
+    messages,
+  };
+}
+
+/** Returns all sessions sorted by most recently updated. Messages are not loaded. */
+export function listSessions(): Session[] {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) return [];
+
+  const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+  const sessions: Session[] = [];
+
+  for (const file of files) {
+    try {
+      const path = resolve(dir, file);
+      const firstLine = readFirstLine(path);
+      const meta = JSON.parse(firstLine) as MetaEntry;
+      const stat = statSync(path);
+
+      sessions.push({
+        id: meta.id,
+        name: meta.name,
+        createdAt: meta.createdAt,
+        updatedAt: stat.mtime.toISOString(),
+        provider: meta.provider,
+        model: meta.model,
+        messages: [],
+      });
+    } catch {
+      // Skip malformed session files
+    }
+  }
+
+  return sessions.sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
+}
+
+/** Loads the most recently updated session, or null if none exist. */
+export function loadMostRecentSession(): Session | null {
+  const sessions = listSessions();
+  if (sessions.length === 0) return null;
+  return loadSession(sessions[0].id);
+}


### PR DESCRIPTION
## Summary

Persist conversations to disk as JSONL files so they survive app restarts and can be loaded by future session management commands. Each message is appended as a single line (O(1) writes), avoiding full-file rewrites that would degrade with long conversations.

## GitHub Issue

Closes #54

## What Changed

New `session.ts` module with append-only JSONL storage at `~/.tomo/sessions/{id}.jsonl`. Each file starts with a meta line (id, name, timestamps, provider, model) followed by one line per message. Key design decisions:

- **Append-only writes** — `appendMessage` appends a single JSON line per message rather than rewriting the entire session. This scales to sessions with hundreds of thousands of tokens.
- **Fresh session per instance** — each tomo startup creates a new session rather than auto-loading the last one, avoiding conflicts when running multiple instances.
- **Lazy file creation** — session files are only created on disk when the first message is sent, so `/new` followed by quit doesn't leave empty session files.
- **Efficient listing** — `listSessions` reads only the first 4KB of each file (the meta line) and uses file mtime for sort order, avoiding loading full message histories.

The `useChat` hook now tracks the current session in a ref and calls `appendMessage` at each point where messages are added. `clearMessages` (used by `/new`) creates a new session in memory.

## Notes for Reviewers

`loadSession` and `loadMostRecentSession` are included but not yet called at startup — they exist for the upcoming `/session` command (#55). The `listSessions` function similarly supports that feature.