### PR TITLE
feat(input): add Ctrl+C confirmation before exit

### DIFF
--- a/src/components/chat-input.test.tsx
+++ b/src/components/chat-input.test.tsx
@@ -138,4 +138,55 @@ describe("ChatInput", () => {
     // Should not show suggestion list since there's a space (args mode)
     expect(output).not.toContain("List available commands");
   });
+
+  it("Ctrl+C clears input when text is present", async () => {
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("hello");
+    await flush();
+    stdin.write("\x03");
+    await flush();
+    const output = lastFrame() ?? "";
+    expect(output).not.toContain("hello");
+    expect(output).not.toContain("Ctrl+C again");
+  });
+
+  it("Ctrl+C shows exit warning on empty input", async () => {
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x03");
+    await flush();
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Ctrl+C again to close Tomo");
+  });
+
+  it("any input after exit warning dismisses it", async () => {
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x03");
+    await flush();
+    expect(lastFrame()).toContain("Ctrl+C again");
+    stdin.write("a");
+    await flush();
+    const output = lastFrame() ?? "";
+    expect(output).not.toContain("Ctrl+C again");
+    expect(output).toContain("a");
+  });
+
+  it("Ctrl+C does not close app on first press", async () => {
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x03");
+    await flush();
+    // App should still be rendering
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Ctrl+C again");
+  });
+
+  it("Ctrl+C shows exit warning when disabled", async () => {
+    const onEscape = vi.fn();
+    const { lastFrame, stdin } = render(
+      <ChatInput onSubmit={vi.fn()} disabled onEscape={onEscape} />,
+    );
+    stdin.write("\x03");
+    await flush();
+    expect(onEscape).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain("Ctrl+C again to close Tomo");
+  });
 });

--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Box, Text, useInput, useStdout } from "ink";
+import { Box, Text, useApp, useInput, useStdout } from "ink";
 import { getAllCommands } from "../commands";
 
 interface ChatInputProps {
@@ -12,9 +12,11 @@ const MAX_SUGGESTIONS = 5;
 
 /** Text input with Enter to submit, slash command autocomplete, and Escape to cancel. */
 export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
+  const { exit } = useApp();
   const { stdout } = useStdout();
   const [columns, setColumns] = useState(stdout.columns || 80);
   const [value, setValue] = useState("");
+  const [exitWarning, setExitWarning] = useState(false);
 
   useEffect(() => {
     const onResize = () => setColumns(stdout.columns || 80);
@@ -40,6 +42,30 @@ export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
         : "";
 
   useInput((input, key) => {
+    const isCtrlC = input === "c" && key.ctrl;
+
+    if (isCtrlC) {
+      if (exitWarning) {
+        exit();
+        return;
+      }
+      if (disabled) {
+        setExitWarning(true);
+        return;
+      }
+      if (value) {
+        setValue("");
+        return;
+      }
+      setExitWarning(true);
+      return;
+    }
+
+    // Any other input dismisses the exit warning
+    if (exitWarning) {
+      setExitWarning(false);
+    }
+
     if (key.escape) {
       onEscape?.();
       return;
@@ -92,6 +118,9 @@ export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
             </Text>
           ))}
         </Box>
+      ) : null}
+      {exitWarning ? (
+        <Text dimColor>{"  Ctrl+C again to close Tomo"}</Text>
       ) : null}
     </Box>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { render } from "ink";
 import { App } from "./app";
 import { getLastSavedSessionId } from "./session";
 
-const { waitUntilExit } = render(<App />);
+const { waitUntilExit } = render(<App />, { exitOnCtrlC: false });
 await waitUntilExit();
 
 const sessionId = getLastSavedSessionId();


### PR DESCRIPTION
## Summary

Replace Ink's default immediate-exit Ctrl+C with a confirmation state machine. Ctrl+C now clears input, warns on empty input, and only exits on a deliberate double-tap.

## GitHub Issue

Closes #68

## What Changed

Ctrl+C behavior in `ChatInput` follows a state machine:
- **Text present** → clears the input
- **Empty input** → shows "Ctrl+C again to close Tomo" warning
- **Warning showing** → exits the app via `useApp().exit()`
- **Any other keypress while warning is showing** → dismisses the warning and processes the key normally

During streaming (input disabled), Ctrl+C shows the exit warning rather than cancelling the stream — only Escape cancels streaming.

Ink's default `exitOnCtrlC` is disabled in `index.tsx` so the raw byte reaches `useInput`.