### PR TITLE
feat(input): add visible cursor with full keyboard navigation

### DIFF
--- a/src/components/chat-input.test.tsx
+++ b/src/components/chat-input.test.tsx
@@ -179,6 +179,212 @@ describe("ChatInput", () => {
     expect(output).toContain("Ctrl+C again");
   });
 
+  it("moves cursor left with arrow key", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("abc");
+    await flush();
+    // Move cursor left once (before 'c'), type 'X'
+    stdin.write("\x1B[D");
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("abXc");
+  });
+
+  it("moves cursor right with arrow key", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("abc");
+    await flush();
+    // Move left twice, then right once
+    stdin.write("\x1B[D");
+    await flush();
+    stdin.write("\x1B[D");
+    await flush();
+    stdin.write("\x1B[C");
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("abXc");
+  });
+
+  it("backspace deletes character before cursor", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("abc");
+    await flush();
+    // Move left once (before 'c'), backspace removes 'b'
+    stdin.write("\x1B[D");
+    await flush();
+    stdin.write("\x7f");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("ac");
+  });
+
+  it("Ctrl+A moves cursor to start", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("abc");
+    await flush();
+    stdin.write("\x01"); // Ctrl+A
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("Xabc");
+  });
+
+  it("Ctrl+E moves cursor to end", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("abc");
+    await flush();
+    stdin.write("\x01"); // Ctrl+A (go to start)
+    await flush();
+    stdin.write("\x05"); // Ctrl+E (go to end)
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("abcX");
+  });
+
+  it("cursor does not move past start", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("ab");
+    await flush();
+    // Move left 5 times (more than string length)
+    for (let i = 0; i < 5; i++) {
+      stdin.write("\x1B[D");
+      await flush();
+    }
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("Xab");
+  });
+
+  it("up arrow moves cursor to previous line at same column", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    // Type "abc", newline, "defgh" — cursor ends at position 9 (end of "defgh")
+    stdin.write("abc");
+    await flush();
+    // Shift+Enter for newline
+    stdin.write("\x1B[13;2u");
+    await flush();
+    stdin.write("defgh");
+    await flush();
+    // Up arrow should move to line 1, column clamped to line length
+    stdin.write("\x1B[A");
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    // Cursor was at col 5 on line 2, line 1 is "abc" (length 3), so clamp to col 3
+    expect(onSubmit).toHaveBeenCalledWith("abcX\ndefgh");
+  });
+
+  it("down arrow moves cursor to next line at same column", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("abcde");
+    await flush();
+    stdin.write("\x1B[13;2u");
+    await flush();
+    stdin.write("fg");
+    await flush();
+    // Go to start of first line
+    stdin.write("\x01");
+    await flush();
+    // Move right 2 (cursor on 'c', col 2)
+    stdin.write("\x1B[C");
+    await flush();
+    stdin.write("\x1B[C");
+    await flush();
+    // Down arrow should move to line 2, col 2 (on end since "fg" is len 2)
+    stdin.write("\x1B[B");
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("abcde\nfgX");
+  });
+
+  it("up arrow does nothing on first line", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("abc");
+    await flush();
+    stdin.write("\x1B[A");
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("abcX");
+  });
+
+  it("down arrow does nothing on last line", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("abc");
+    await flush();
+    stdin.write("\x1B[B");
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("abcX");
+  });
+
+  it("Option+Left skips to previous word boundary", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("hello world foo");
+    await flush();
+    // Alt+B / Option+Left — skip back one word
+    stdin.write("\x1bb");
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("hello world Xfoo");
+  });
+
+  it("Option+Right skips to next word boundary", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("hello world");
+    await flush();
+    // Go to start
+    stdin.write("\x01");
+    await flush();
+    // Alt+F / Option+Right — skip forward one word
+    stdin.write("\x1bf");
+    await flush();
+    stdin.write("X");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("helloX world");
+  });
+
   it("Ctrl+C shows exit warning when disabled", async () => {
     const onEscape = vi.fn();
     const { lastFrame, stdin } = render(

--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import chalk from "chalk";
 import { Box, Text, useApp, useInput, useStdout } from "ink";
 import { getAllCommands } from "../commands";
 
@@ -9,14 +10,32 @@ interface ChatInputProps {
 }
 
 const MAX_SUGGESTIONS = 5;
+const BLINK_INTERVAL_MS = 530;
 
-/** Text input with Enter to submit, slash command autocomplete, and Escape to cancel. */
+function findPrevWordBoundary(text: string, pos: number): number {
+  let i = pos - 1;
+  while (i > 0 && /\s/.test(text[i])) i--;
+  while (i > 0 && !/\s/.test(text[i - 1])) i--;
+  return Math.max(0, i);
+}
+
+function findNextWordBoundary(text: string, pos: number): number {
+  let i = pos;
+  while (i < text.length && /\s/.test(text[i])) i++;
+  while (i < text.length && !/\s/.test(text[i])) i++;
+  return i;
+}
+
+/** Text input with cursor navigation, slash command autocomplete, and Ctrl+C confirmation. */
 export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [columns, setColumns] = useState(stdout.columns || 80);
   const [value, setValue] = useState("");
+  const [cursor, setCursor] = useState(0);
+  const [cursorVisible, setCursorVisible] = useState(true);
   const [exitWarning, setExitWarning] = useState(false);
+  const blinkRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     const onResize = () => setColumns(stdout.columns || 80);
@@ -25,6 +44,31 @@ export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
       stdout.off("resize", onResize);
     };
   }, [stdout]);
+
+  useEffect(() => {
+    if (disabled) {
+      setCursorVisible(false);
+      if (blinkRef.current) clearInterval(blinkRef.current);
+      blinkRef.current = null;
+      return;
+    }
+    blinkRef.current = setInterval(() => {
+      setCursorVisible((v) => !v);
+    }, BLINK_INTERVAL_MS);
+    return () => {
+      if (blinkRef.current) clearInterval(blinkRef.current);
+    };
+  }, [disabled]);
+
+  const resetBlink = () => {
+    setCursorVisible(true);
+    if (blinkRef.current) clearInterval(blinkRef.current);
+    if (!disabled) {
+      blinkRef.current = setInterval(() => {
+        setCursorVisible((v) => !v);
+      }, BLINK_INTERVAL_MS);
+    }
+  };
 
   const isAutocomplete = value.startsWith("/") && !value.includes(" ");
   const partial = isAutocomplete ? value.slice(1) : "";
@@ -40,8 +84,11 @@ export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
       : topMatch
         ? topMatch.name
         : "";
+  const showGhost = isAutocomplete && ghost && cursor === value.length;
 
   useInput((input, key) => {
+    resetBlink();
+
     const isCtrlC = input === "c" && key.ctrl;
 
     if (isCtrlC) {
@@ -55,13 +102,13 @@ export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
       }
       if (value) {
         setValue("");
+        setCursor(0);
         return;
       }
       setExitWarning(true);
       return;
     }
 
-    // Any other input dismisses the exit warning
     if (exitWarning) {
       setExitWarning(false);
     }
@@ -73,37 +120,135 @@ export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
 
     if (disabled) return;
 
+    // Word-skip: Option/Alt+Arrow or Alt+B/F
+    if (key.leftArrow && key.meta) {
+      setCursor((c) => findPrevWordBoundary(value, c));
+      return;
+    }
+    if (key.rightArrow && key.meta) {
+      setCursor((c) => findNextWordBoundary(value, c));
+      return;
+    }
+    if (input === "b" && key.meta) {
+      setCursor((c) => findPrevWordBoundary(value, c));
+      return;
+    }
+    if (input === "f" && key.meta) {
+      setCursor((c) => findNextWordBoundary(value, c));
+      return;
+    }
+
+    // Vertical cursor movement across lines
+    if (key.upArrow) {
+      const lineStart = value.lastIndexOf("\n", cursor - 1);
+      if (lineStart >= 0) {
+        const col = cursor - lineStart - 1;
+        const prevLineStart =
+          lineStart === 0 ? 0 : value.lastIndexOf("\n", lineStart - 1) + 1;
+        const prevLineLength = lineStart - prevLineStart;
+        setCursor(prevLineStart + Math.min(col, prevLineLength));
+      }
+      return;
+    }
+    if (key.downArrow) {
+      const lineStart = value.lastIndexOf("\n", cursor - 1) + 1;
+      const col = cursor - lineStart;
+      const nextLineBreak = value.indexOf("\n", cursor);
+      if (nextLineBreak >= 0) {
+        const nextLineStart = nextLineBreak + 1;
+        const nextNextLineBreak = value.indexOf("\n", nextLineStart);
+        const nextLineLength =
+          nextNextLineBreak >= 0
+            ? nextNextLineBreak - nextLineStart
+            : value.length - nextLineStart;
+        setCursor(nextLineStart + Math.min(col, nextLineLength));
+      }
+      return;
+    }
+
+    // Cursor navigation
+    if (key.leftArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+      return;
+    }
+    if (key.rightArrow) {
+      setCursor((c) => Math.min(value.length, c + 1));
+      return;
+    }
+    if (input === "a" && key.ctrl) {
+      setCursor(0);
+      return;
+    }
+    if (input === "e" && key.ctrl) {
+      setCursor(value.length);
+      return;
+    }
+
     if (key.return) {
       if (key.shift) {
-        setValue((v) => `${v}\n`);
+        setValue((v) => `${v.slice(0, cursor)}\n${v.slice(cursor)}`);
+        setCursor((c) => c + 1);
       } else if (isAutocomplete && topMatch) {
         onSubmit(`/${topMatch.name}`);
         setValue("");
+        setCursor(0);
       } else if (value.trim()) {
         onSubmit(value);
         setValue("");
+        setCursor(0);
       }
       return;
     }
 
     if (key.backspace || key.delete) {
-      setValue((v) => v.slice(0, -1));
+      if (cursor > 0) {
+        setValue((v) => v.slice(0, cursor - 1) + v.slice(cursor));
+        setCursor((c) => c - 1);
+      }
       return;
     }
 
     if (input && !key.ctrl && !key.meta) {
-      setValue((v) => v + input);
+      setValue((v) => v.slice(0, cursor) + input + v.slice(cursor));
+      setCursor((c) => c + input.length);
     }
   });
+
+  // Build input display as a single string so newlines render correctly
+  const before = value.slice(0, cursor);
+  const after = cursor < value.length ? value.slice(cursor + 1) : "";
+  const prompt = chalk.dim(disabled ? "  " : "> ");
+
+  let inputDisplay: string;
+  if (disabled) {
+    inputDisplay = value;
+  } else {
+    const charAtCursor = cursor < value.length ? value[cursor] : null;
+    const cursorStr =
+      charAtCursor === "\n"
+        ? cursorVisible
+          ? `${chalk.inverse(" ")}\n`
+          : "\n"
+        : charAtCursor !== null
+          ? cursorVisible
+            ? chalk.inverse(charAtCursor)
+            : charAtCursor
+          : cursorVisible
+            ? chalk.inverse(" ")
+            : "";
+    inputDisplay = before + cursorStr + after;
+    if (showGhost) {
+      inputDisplay += chalk.dim(ghost);
+    }
+  }
 
   return (
     <Box flexDirection="column">
       <Text dimColor>{"─".repeat(columns - 2)}</Text>
-      <Box>
-        <Text dimColor>{disabled ? "  " : "> "}</Text>
-        <Text>{value}</Text>
-        {isAutocomplete && ghost ? <Text dimColor>{ghost}</Text> : null}
-      </Box>
+      <Text>
+        {prompt}
+        {inputDisplay}
+      </Text>
       <Text dimColor>{"─".repeat(columns - 2)}</Text>
       {isAutocomplete && matches.length > 0 ? (
         <Box flexDirection="column">


### PR DESCRIPTION
## Summary

Add a visible blinking cursor to the chat input with full keyboard navigation including arrow keys, word-skipping, and multiline support.

## GitHub Issue

Closes #67

## What Changed

The input was previously append-only with no visible cursor. Now it has a blinking inverse-block cursor that can be moved freely through the text.

**Cursor rendering** — the entire input line is rendered as a single chalk-formatted string (previously split across multiple `<Text>` elements). This fixes newline rendering in multiline input and allows the cursor to appear correctly on any character, including newlines (rendered as an inverse space before the line break).

**Navigation keys:**
- Left/Right arrows — move one character
- Up/Down arrows — move to the same column on the adjacent line, clamping to line length
- Ctrl+A / Ctrl+E — jump to start/end of input
- Option+Arrow / Alt+B/F — skip to previous/next word boundary

**Editing at cursor** — text inserts at cursor position, backspace deletes before cursor. All operations (submit, Ctrl+C clear, etc.) reset the cursor to 0.