### PR TITLE
fix(input): use ghost character as cursor block during autocomplete

### DIFF
--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -233,12 +233,16 @@ export function ChatInput({ onSubmit, disabled, onEscape }: ChatInputProps) {
           ? cursorVisible
             ? chalk.inverse(charAtCursor)
             : charAtCursor
-          : cursorVisible
-            ? chalk.inverse(" ")
-            : "";
+          : showGhost
+            ? cursorVisible
+              ? chalk.inverse(ghost[0])
+              : chalk.dim(ghost[0])
+            : cursorVisible
+              ? chalk.inverse(" ")
+              : "";
     inputDisplay = before + cursorStr + after;
     if (showGhost) {
-      inputDisplay += chalk.dim(ghost);
+      inputDisplay += chalk.dim(ghost.slice(1));
     }
   }
 


### PR DESCRIPTION
## Summary

Fix the cursor adding an extra space character before autocomplete ghost text, pushing the completion to the right.

## GitHub Issue

N/A

## What Changed

When the cursor is at the end of input with ghost text visible (e.g. typing `/se` with ghost `ssion`), the cursor block now uses the first ghost character instead of an extra space. Previously `/se█ssion` (with a space gap), now `/se█sion` where the cursor overlays the `s`.