### PR TITLE
feat(context): auto-truncate messages and add /context command

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -1,0 +1,37 @@
+import { register } from "./registry";
+import type { Command } from "./types";
+
+function formatTokens(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+const context: Command = {
+  name: "context",
+  description: "Show context window usage stats",
+  execute: (_args, callbacks) => {
+    const { tokenUsage, contextWindow, maxTokens, messageCount } = callbacks;
+
+    if (!tokenUsage) {
+      return { output: "No token usage data yet — send a message first." };
+    }
+
+    const total = tokenUsage.promptTokens + tokenUsage.completionTokens;
+    const percent = Math.round((total / contextWindow) * 100);
+    const inputBudget = contextWindow - maxTokens;
+
+    const lines = [
+      `  Context window:    ${formatTokens(contextWindow)} tokens`,
+      `  Prompt tokens:     ${formatTokens(tokenUsage.promptTokens)}`,
+      `  Response tokens:   ${formatTokens(tokenUsage.completionTokens)}`,
+      `  Total used:        ${formatTokens(total)} (${percent}%)`,
+      `  Input budget:      ${formatTokens(inputBudget)} (window - ${formatTokens(maxTokens)} reserved)`,
+      `  Max tokens:        ${formatTokens(maxTokens)}`,
+      `  Messages:          ${messageCount}`,
+    ];
+
+    return { output: lines.join("\n") };
+  },
+};
+
+register(context);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,5 @@
 // Register built-in commands
+import "./context";
 import "./help";
 import "./models";
 import "./new";

--- a/src/commands/models.test.ts
+++ b/src/commands/models.test.ts
@@ -14,6 +14,10 @@ const mockCallbacks = () => ({
   activeModel: "qwen3:8b",
   activeProvider: "ollama",
   providerNames: ["ollama"],
+  contextWindow: 8192,
+  maxTokens: 8192,
+  tokenUsage: null,
+  messageCount: 0,
 });
 
 describe("/models command", () => {

--- a/src/commands/new.test.ts
+++ b/src/commands/new.test.ts
@@ -22,6 +22,10 @@ describe("/new command", () => {
       activeModel: "qwen3:8b",
       activeProvider: "ollama",
       providerNames: ["ollama"],
+      contextWindow: 8192,
+      maxTokens: 8192,
+      tokenUsage: null,
+      messageCount: 0,
     };
 
     const result = command.execute("", callbacks);

--- a/src/commands/session.test.ts
+++ b/src/commands/session.test.ts
@@ -14,6 +14,10 @@ const mockCallbacks = () => ({
   activeModel: "qwen3:8b",
   activeProvider: "ollama",
   providerNames: ["ollama"],
+  contextWindow: 8192,
+  maxTokens: 8192,
+  tokenUsage: null,
+  messageCount: 0,
 });
 
 describe("/session command", () => {

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -22,6 +22,10 @@ export interface CommandCallbacks {
   activeModel: string;
   activeProvider: string;
   providerNames: string[];
+  contextWindow: number;
+  maxTokens: number;
+  tokenUsage: { promptTokens: number; completionTokens: number } | null;
+  messageCount: number;
 }
 
 /** A registered slash command with a name, description, and execute handler. */

--- a/src/commands/use.test.ts
+++ b/src/commands/use.test.ts
@@ -14,6 +14,10 @@ const mockCallbacks = () => ({
   activeModel: "qwen3:8b",
   activeProvider: "ollama",
   providerNames: ["ollama"],
+  contextWindow: 8192,
+  maxTokens: 8192,
+  tokenUsage: null,
+  messageCount: 0,
 });
 
 const mockModelsResponse = (ids: string[]) =>

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -168,6 +168,7 @@ describe("getActiveProvider", () => {
     const config: Config = {
       activeProvider: "ollama",
       activeModel: "qwen3:8b",
+      maxTokens: 8192,
       providers: [
         {
           name: "ollama",
@@ -185,6 +186,7 @@ describe("getActiveProvider", () => {
     const config: Config = {
       activeProvider: "missing",
       activeModel: "qwen3:8b",
+      maxTokens: 8192,
       providers: [
         {
           name: "ollama",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,10 @@ import { dirname, resolve } from "node:path";
 import { parse, stringify } from "yaml";
 import { z } from "zod";
 
+const modelOverrideSchema = z.object({
+  maxTokens: z.number().int().positive().optional(),
+});
+
 const providerSchema = z.object({
   name: z.string().min(1, "provider name is required"),
   type: z.enum(["ollama"], {
@@ -11,12 +15,14 @@ const providerSchema = z.object({
   }),
   baseUrl: z.string().url("baseUrl must be a valid URL"),
   contextWindow: z.number().int().positive().optional(),
+  models: z.record(z.string(), modelOverrideSchema).optional(),
 });
 
 const configSchema = z
   .object({
     activeProvider: z.string().min(1, "activeProvider is required"),
     activeModel: z.string().min(1, "activeModel is required"),
+    maxTokens: z.number().int().positive().default(8192),
     providers: z
       .array(providerSchema)
       .min(1, "providers must be a non-empty array"),
@@ -39,6 +45,7 @@ export type Config = z.infer<typeof configSchema>;
 const DEFAULT_CONFIG: Config = {
   activeProvider: "ollama",
   activeModel: "qwen3:8b",
+  maxTokens: 8192,
   providers: [
     {
       name: "ollama",
@@ -50,6 +57,7 @@ const DEFAULT_CONFIG: Config = {
 
 const DEFAULT_CONFIG_YAML = `activeProvider: ollama
 activeModel: qwen3:8b
+maxTokens: 8192
 
 providers:
   - name: ollama
@@ -144,6 +152,15 @@ export function getProviderByName(
   name: string,
 ): ProviderConfig | undefined {
   return config.providers.find((p) => p.name === name);
+}
+
+/** Resolves the effective maxTokens for a model: model override > global default. */
+export function getMaxTokens(
+  config: Config,
+  provider: ProviderConfig,
+  model: string,
+): number {
+  return provider.models?.[model]?.maxTokens ?? config.maxTokens;
 }
 
 /** Returns the provider config matching the activeProvider name. Throws if not found. */

--- a/src/context/truncate.test.ts
+++ b/src/context/truncate.test.ts
@@ -9,7 +9,7 @@ function msg(role: ChatMessage["role"], content: string): ChatMessage {
 describe("truncateMessages", () => {
   it("returns messages unchanged when no usage data is available", () => {
     const messages = [msg("user", "hi"), msg("assistant", "hello")];
-    expect(truncateMessages(messages, 4096, null)).toEqual(messages);
+    expect(truncateMessages(messages, 8192, 4096, null)).toEqual(messages);
   });
 
   it("returns messages unchanged when under budget", () => {
@@ -18,9 +18,8 @@ describe("truncateMessages", () => {
       msg("user", "hi"),
       msg("assistant", "hello"),
     ];
-    // 100 prompt tokens for 2 non-system messages, context window 4096
-    // budget = 3072, estimated ~100, well under
-    expect(truncateMessages(messages, 4096, 100)).toEqual(messages);
+    // 100 prompt tokens, budget = 8192 - 4096 = 4096, well under
+    expect(truncateMessages(messages, 8192, 4096, 100)).toEqual(messages);
   });
 
   it("drops oldest non-system messages when over budget", () => {
@@ -32,17 +31,12 @@ describe("truncateMessages", () => {
       msg("assistant", "resp2"),
       msg("user", "msg3"),
     ];
-    // 5 non-system messages, 2500 prompt tokens => 500 tokens/msg avg
-    // system overhead ~250, total estimate ~2750
-    // budget for contextWindow=1000 => 750
-    // Need to drop messages until under 750
-    const result = truncateMessages(messages, 1000, 2500);
+    // 5 non-system messages, 10000 prompt tokens
+    // budget = 8192 - 4096 = 4096, estimated ~10000, over budget
+    const result = truncateMessages(messages, 8192, 4096, 10000);
 
-    // System message preserved
     expect(result[0]).toEqual(msg("system", "sys"));
-    // Oldest messages dropped
     expect(result.length).toBeLessThan(messages.length);
-    // Last message (most recent) preserved
     expect(result[result.length - 1]).toEqual(msg("user", "msg3"));
   });
 
@@ -51,8 +45,7 @@ describe("truncateMessages", () => {
       msg("system", "important system prompt"),
       msg("user", "hi"),
     ];
-    // Even with tiny context window, system message stays
-    const result = truncateMessages(messages, 100, 5000);
+    const result = truncateMessages(messages, 8192, 4096, 50000);
     expect(result[0]).toEqual(msg("system", "important system prompt"));
   });
 
@@ -63,14 +56,13 @@ describe("truncateMessages", () => {
       msg("assistant", "resp1"),
       msg("user", "latest"),
     ];
-    const result = truncateMessages(messages, 10, 50000);
-    // System + at least the latest message
+    const result = truncateMessages(messages, 8192, 4096, 50000);
     expect(result.length).toBeGreaterThanOrEqual(2);
     expect(result[result.length - 1]).toEqual(msg("user", "latest"));
   });
 
   it("returns empty array unchanged", () => {
-    expect(truncateMessages([], 4096, 100)).toEqual([]);
+    expect(truncateMessages([], 8192, 4096, 100)).toEqual([]);
   });
 
   it("works without a system message", () => {
@@ -81,9 +73,25 @@ describe("truncateMessages", () => {
       msg("assistant", "resp2"),
       msg("user", "msg3"),
     ];
-    // 5 messages, 2500 tokens => 500/msg, budget for 1000 = 750
-    const result = truncateMessages(messages, 1000, 2500);
+    // 5 messages, 10000 tokens, budget = 8192 - 4096 = 4096
+    const result = truncateMessages(messages, 8192, 4096, 10000);
     expect(result.length).toBeLessThan(messages.length);
     expect(result[result.length - 1]).toEqual(msg("user", "msg3"));
+  });
+
+  it("respects different maxTokens values", () => {
+    const messages = [
+      msg("system", "sys"),
+      msg("user", "msg1"),
+      msg("assistant", "resp1"),
+      msg("user", "msg2"),
+    ];
+    // With large maxTokens (small budget), should truncate
+    const small = truncateMessages(messages, 8192, 7000, 5000);
+    // With small maxTokens (large budget), should keep all
+    const large = truncateMessages(messages, 8192, 1000, 5000);
+
+    expect(small.length).toBeLessThan(messages.length);
+    expect(large).toEqual(messages);
   });
 });

--- a/src/context/truncate.ts
+++ b/src/context/truncate.ts
@@ -1,40 +1,36 @@
 import type { ChatMessage } from "../provider/client";
 
-/** The fraction of the context window reserved for the model's response. */
-const RESPONSE_RESERVE = 0.25;
-
 /**
  * Truncates messages to fit within a context window budget.
+ *
+ * The input budget is `contextWindow - maxTokens`, where maxTokens is the
+ * number of tokens reserved for the model's response.
  *
  * Uses the last known prompt token count to estimate whether the next request
  * will exceed the budget. If so, drops the oldest non-system messages until
  * the estimated token count fits.
- *
- * Estimation: calculates a tokens-per-message average from the last request,
- * then uses it to estimate the cost of the current message list.
  *
  * The system message (first message if role is "system") is never dropped.
  */
 export function truncateMessages(
   messages: ChatMessage[],
   contextWindow: number,
+  maxTokens: number,
   lastPromptTokens: number | null,
 ): ChatMessage[] {
   if (!lastPromptTokens || messages.length === 0) return messages;
 
-  const budget = Math.floor(contextWindow * (1 - RESPONSE_RESERVE));
+  const budget = contextWindow - maxTokens;
+  if (budget <= 0) return messages;
 
   // Find where non-system messages start
   const systemCount = messages[0]?.role === "system" ? 1 : 0;
 
-  // Count how many non-system messages were in the last request.
-  // The current messages list may have grown since then (new user msg + assistant response),
-  // but we use the last known count as a baseline.
   const lastNonSystemCount = messages.length - systemCount;
   if (lastNonSystemCount <= 0) return messages;
 
   // Estimate tokens per non-system message from the last request's prompt_tokens.
-  // Subtract a rough system message overhead (use 1/4 of prompt tokens as a floor).
+  // Subtract a rough system message overhead estimate.
   const systemOverhead =
     systemCount > 0 ? Math.floor(lastPromptTokens * 0.1) : 0;
   const tokensForMessages = lastPromptTokens - systemOverhead;

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -5,6 +5,7 @@ import type { DisplayMessage } from "../components/message-list";
 import {
   type Config,
   type ProviderConfig,
+  getMaxTokens,
   getProviderByName,
   updateActiveModel,
   updateActiveProvider,
@@ -162,6 +163,10 @@ export function useChat(
         activeModel,
         activeProvider: activeProvider.name,
         providerNames: config.providers.map((p) => p.name),
+        contextWindow,
+        maxTokens: getMaxTokens(config, activeProvider, activeModel),
+        tokenUsage,
+        messageCount: messages.length,
       });
 
       if ("interactive" in result) {
@@ -205,9 +210,12 @@ export function useChat(
       { role: "user" as const, content: text },
     ];
 
+    const maxTokens = getMaxTokens(config, activeProvider, activeModel);
+
     const chatMessages = truncateMessages(
       allMessages,
       contextWindow,
+      maxTokens,
       tokenUsage?.promptTokens ?? null,
     );
 
@@ -218,6 +226,7 @@ export function useChat(
         baseUrl: activeProvider.baseUrl,
         model: activeModel,
         messages: chatMessages,
+        maxTokens,
         signal: controller.signal,
       });
 

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -115,6 +115,7 @@ export interface CompletionOptions {
   baseUrl: string;
   model: string;
   messages: ChatMessage[];
+  maxTokens?: number;
   signal?: AbortSignal;
 }
 
@@ -134,7 +135,7 @@ export interface CompletionStream {
 export async function streamChatCompletion(
   options: CompletionOptions,
 ): Promise<CompletionStream> {
-  const { baseUrl, model, messages, signal } = options;
+  const { baseUrl, model, messages, maxTokens, signal } = options;
   const url = `${baseUrl.replace(/\/+$/, "")}/v1/chat/completions`;
 
   let response: Response;
@@ -147,6 +148,7 @@ export async function streamChatCompletion(
         messages,
         stream: true,
         stream_options: { include_usage: true },
+        ...(maxTokens != null && { max_tokens: maxTokens }),
       }),
       signal,
     });


### PR DESCRIPTION
## Summary

Automatically truncates oldest messages when the conversation approaches the context window limit,
and adds a `/context` command to inspect token usage stats. The response token budget (`maxTokens`)
is configurable globally and per-model.

## GitHub Issue

Closes #80

## What Changed

**Message truncation** — New `truncateMessages` function estimates token usage based on the last
known `prompt_tokens` from the provider. When the estimated input exceeds the budget
(`contextWindow - maxTokens`), the oldest non-system messages are dropped. The system message is
never removed and at least one non-system message is always kept. Full history remains on disk.

**Configurable maxTokens** — Top-level `maxTokens` config field (default 8192) controls how many
tokens are reserved for the model's response. Per-model overrides are supported via
`providers[].models.<name>.maxTokens`. The resolved value is sent as `max_tokens` in the completion
request, giving the provider explicit control over response length.

**`/context` command** — Displays context window size, prompt/response token counts, total usage
percentage, input budget, maxTokens, and message count.

## Notes for Reviewers

The previous approach used a hardcoded 25% reserve for responses, which wasted significant context
on large windows (e.g. 66k tokens unused on a 264k window). The fixed `maxTokens` approach matches
how other tools handle this — the reserve is a fixed amount rather than a proportion.