### PR TITLE
feat(provider): support openai-compatible provider type and bump default context window

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,8 +10,8 @@ const modelOverrideSchema = z.object({
 
 const providerSchema = z.object({
   name: z.string().min(1, "provider name is required"),
-  type: z.enum(["ollama"], {
-    message: 'unsupported provider type. Supported: "ollama"',
+  type: z.enum(["ollama", "openai"], {
+    message: 'unsupported provider type. Supported: "ollama", "openai"',
   }),
   baseUrl: z.string().url("baseUrl must be a valid URL"),
   contextWindow: z.number().int().positive().optional(),

--- a/src/provider/client.test.ts
+++ b/src/provider/client.test.ts
@@ -310,7 +310,7 @@ describe("fetchContextWindow", () => {
       "unknown",
       "ollama",
     );
-    expect(result).toBe(4096);
+    expect(result).toBe(8192);
   });
 
   it("returns default on HTTP error", async () => {
@@ -323,7 +323,7 @@ describe("fetchContextWindow", () => {
       "missing",
       "ollama",
     );
-    expect(result).toBe(4096);
+    expect(result).toBe(8192);
   });
 
   it("returns default on network failure", async () => {
@@ -334,7 +334,7 @@ describe("fetchContextWindow", () => {
       "model",
       "ollama",
     );
-    expect(result).toBe(4096);
+    expect(result).toBe(8192);
   });
 
   it("caches results per baseUrl + model", async () => {
@@ -375,7 +375,7 @@ describe("fetchContextWindow", () => {
       "model",
       "openai",
     );
-    expect(result).toBe(4096);
+    expect(result).toBe(8192);
     expect(vi.mocked(fetch)).not.toHaveBeenCalled();
   });
 });

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -33,7 +33,7 @@ export async function fetchModels(baseUrl: string): Promise<ModelInfo[]> {
   return models.map((m) => ({ id: m.id }));
 }
 
-const DEFAULT_CONTEXT_WINDOW = 4096;
+const DEFAULT_CONTEXT_WINDOW = 8192;
 
 const contextWindowCache = new Map<string, number>();
 


### PR DESCRIPTION
## Summary

The config schema only accepted `"ollama"` as a provider type, even though the client code already
works with any OpenAI-compatible endpoint. This adds `"openai"` as a valid provider type for
generic providers (LM Studio, vLLM, llama.cpp, etc.) and bumps the default context window from
4096 to 8192 for a more realistic fallback with modern models.

## GitHub Issue

Closes #89

## What Changed

Two small but connected changes:

1. **Provider type enum** — expanded from `["ollama"]` to `["ollama", "openai"]` in the Zod config
   schema. The `"openai"` type covers any provider exposing standard `/v1/models` and
   `/v1/chat/completions` endpoints. No new code paths needed — the client already handles this
   correctly; only the validation was blocking it.

2. **Default context window** — bumped from 4096 to 8192. When context window detection isn't
   available (non-Ollama providers without a `contextWindow` config override), 4096 was
   unnecessarily restrictive for modern models.