### PR TITLE
feat(chat): allow typing and queuing messages while streaming

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -47,6 +47,19 @@ export function App() {
         </Box>
       ) : null}
 
+      {chat.pendingMessage ? (
+        <Box marginBottom={1}>
+          <Text>
+            <Text color="yellow" bold>
+              {"Queued: "}
+            </Text>
+            <Text backgroundColor="gray" color="white">
+              {chat.pendingMessage}
+            </Text>
+          </Text>
+        </Box>
+      ) : null}
+
       {chat.streaming && !chat.streamingContent ? <ThinkingIndicator /> : null}
 
       {chat.activeCommand ? (
@@ -54,7 +67,6 @@ export function App() {
       ) : (
         <ChatInput
           onSubmit={chat.submit}
-          disabled={chat.streaming}
           onEscape={chat.cancel}
           contextPercent={
             chat.tokenUsage

--- a/src/hooks/use-chat.test.tsx
+++ b/src/hooks/use-chat.test.tsx
@@ -1,0 +1,193 @@
+import { render } from "ink-testing-library";
+import { Text } from "ink";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { streamChatCompletion } from "../provider/client";
+import { type ChatState, useChat } from "./use-chat";
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+
+// --- Controllable stream for testing ---
+
+interface DeferredStream {
+  complete: () => void;
+}
+
+const streams: DeferredStream[] = [];
+
+function createDeferredStream(signal?: AbortSignal) {
+  let resolve!: () => void;
+  const done = new Promise<void>((r) => {
+    resolve = r;
+  });
+
+  async function* content(): AsyncGenerator<string> {
+    yield "response";
+    const abortPromise = signal
+      ? new Promise<never>((_, reject) => {
+          if (signal.aborted) {
+            reject(new DOMException("aborted", "AbortError"));
+            return;
+          }
+          signal.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        })
+      : new Promise<never>(() => {});
+    await Promise.race([done, abortPromise]);
+  }
+
+  const stream = { complete: resolve };
+  streams.push(stream);
+
+  return {
+    content: content(),
+    getUsage: () => ({ promptTokens: 10, completionTokens: 5 }),
+  };
+}
+
+// --- Mocks ---
+
+vi.mock("../provider/client", () => ({
+  fetchContextWindow: vi.fn().mockResolvedValue(8192),
+  getDefaultContextWindow: () => 8192,
+  streamChatCompletion: vi.fn(),
+}));
+
+vi.mock("../session", () => ({
+  createSession: () => ({
+    id: "s1",
+    createdAt: "2025-01-01",
+    updatedAt: "2025-01-01",
+    provider: "test",
+    model: "test-model",
+    messages: [],
+  }),
+  appendMessage: vi.fn(),
+  loadSession: vi.fn(),
+}));
+
+vi.mock("../config", () => ({
+  getMaxTokens: () => 8192,
+  getProviderByName: vi.fn(),
+  updateActiveModel: vi.fn(),
+  updateActiveProvider: vi.fn(),
+}));
+
+vi.mock("../commands", () => ({
+  parse: () => null,
+  getCommand: vi.fn(),
+}));
+
+vi.mock("../context/truncate", () => ({
+  truncateMessages: (msgs: unknown[]) => msgs,
+}));
+
+const testProvider = {
+  name: "test",
+  type: "ollama" as const,
+  baseUrl: "http://localhost:11434",
+};
+
+const testConfig = {
+  activeProvider: "test",
+  activeModel: "test-model",
+  maxTokens: 8192,
+  providers: [testProvider],
+};
+
+const testSession = {
+  id: "s1",
+  createdAt: "2025-01-01",
+  updatedAt: "2025-01-01",
+  provider: "test",
+  model: "test-model",
+  messages: [] as [],
+};
+
+let chat: ChatState;
+
+function TestApp() {
+  chat = useChat(testConfig, testProvider, "test-model", testSession, null);
+  return <Text>{chat.streaming ? "streaming" : "idle"}</Text>;
+}
+
+describe("useChat message queuing", () => {
+  beforeEach(() => {
+    streams.length = 0;
+    vi.mocked(streamChatCompletion).mockImplementation(async (options) =>
+      createDeferredStream(options.signal),
+    );
+  });
+
+  it("queues a message during streaming and sends it after", async () => {
+    render(<TestApp />);
+    await flush();
+
+    chat.submit("first");
+    await flush();
+    expect(chat.streaming).toBe(true);
+
+    chat.submit("second");
+    await flush();
+    expect(streams).toHaveLength(1);
+    expect(chat.pendingMessage).toBe("second");
+
+    streams[0].complete();
+    await flush();
+    await flush();
+
+    expect(streams).toHaveLength(2);
+
+    streams[1].complete();
+    await flush();
+
+    expect(chat.messages).toHaveLength(4);
+    expect(chat.messages[0].content).toBe("first");
+    expect(chat.messages[1].role).toBe("assistant");
+    expect(chat.messages[2].content).toBe("second");
+    expect(chat.messages[3].role).toBe("assistant");
+    expect(chat.pendingMessage).toBeNull();
+  });
+
+  it("last queued message wins when multiple are submitted", async () => {
+    render(<TestApp />);
+    await flush();
+
+    chat.submit("first");
+    await flush();
+
+    chat.submit("second");
+    chat.submit("third");
+    await flush();
+
+    streams[0].complete();
+    await flush();
+    await flush();
+
+    streams[1].complete();
+    await flush();
+
+    expect(chat.messages).toHaveLength(4);
+    expect(chat.messages[2].content).toBe("third");
+  });
+
+  it("cancel clears the pending queue", async () => {
+    render(<TestApp />);
+    await flush();
+
+    chat.submit("first");
+    await flush();
+
+    chat.submit("second");
+    await flush();
+
+    chat.cancel();
+    await flush();
+    await flush();
+
+    expect(streams).toHaveLength(1);
+    expect(chat.streaming).toBe(false);
+    expect(chat.pendingMessage).toBeNull();
+    expect(chat.messages.filter((m) => m.role === "user")).toHaveLength(1);
+  });
+});

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -34,6 +34,7 @@ export interface ChatState {
   activeProvider: ProviderConfig;
   tokenUsage: TokenUsage | null;
   contextWindow: number;
+  pendingMessage: string | null;
   submit: (text: string) => void;
   cancel: () => void;
 }
@@ -62,6 +63,9 @@ export function useChat(
   );
   const abortRef = useRef<AbortController | null>(null);
   const sessionRef = useRef<Session>(initialSession);
+  const streamingRef = useRef(false);
+  const pendingMessageRef = useRef<string | null>(null);
+  const [pendingMessage, setPendingMessage] = useState<string | null>(null);
 
   // Detect context window from provider when model or provider changes.
   // Config override takes precedence — only fetch if no override is set.
@@ -96,6 +100,8 @@ export function useChat(
     const newSession = createSession(activeProvider.name, activeModel);
     sessionRef.current = newSession;
 
+    pendingMessageRef.current = null;
+    setPendingMessage(null);
     abortRef.current?.abort();
     setMessages([]);
     setStreaming(false);
@@ -106,6 +112,12 @@ export function useChat(
   };
 
   const submit = async (text: string) => {
+    if (streamingRef.current) {
+      pendingMessageRef.current = text;
+      setPendingMessage(text);
+      return;
+    }
+
     const parsed = parse(text);
 
     if (parsed) {
@@ -190,6 +202,7 @@ export function useChat(
 
     setMessages((prev) => [...prev, userMsg]);
     appendMessage(sessionRef.current, userMsg);
+    streamingRef.current = true;
     setStreaming(true);
     setStreamingContent("");
     setError(null);
@@ -257,12 +270,30 @@ export function useChat(
       appendMessage(sessionRef.current, assistantMsg);
     }
 
+    streamingRef.current = false;
     setStreaming(false);
     setStreamingContent("");
     abortRef.current = null;
   };
 
+  // Keep a ref to the latest submit so the pending-message effect
+  // always calls the version with up-to-date message history.
+  const submitRef = useRef(submit);
+  submitRef.current = submit;
+
+  // Process queued message after streaming completes.
+  useEffect(() => {
+    if (!streaming && pendingMessageRef.current !== null) {
+      const pending = pendingMessageRef.current;
+      pendingMessageRef.current = null;
+      setPendingMessage(null);
+      submitRef.current(pending);
+    }
+  }, [streaming]);
+
   const cancel = () => {
+    pendingMessageRef.current = null;
+    setPendingMessage(null);
     abortRef.current?.abort();
   };
 
@@ -276,6 +307,7 @@ export function useChat(
     activeProvider,
     tokenUsage,
     contextWindow,
+    pendingMessage,
     submit,
     cancel,
   };


### PR DESCRIPTION
## Summary

Chat input remains interactive during streaming, allowing users to type and submit their next
message without waiting. Submitted messages are queued and processed after the current stream
completes, with immediate visual feedback via a highlighted "Queued:" prefix.

## GitHub Issue

Closes #88

## What Changed

The `disabled={chat.streaming}` prop was removed from `ChatInput` in `app.tsx`, so the input
stays interactive during streaming. The queuing logic lives in the `useChat` hook:

- A `streamingRef` provides a synchronous guard — if streaming, the message is stored in
  `pendingMessageRef` instead of being sent immediately.
- A `useEffect` watching `streaming` state processes the pending message after the stream ends.
  A `submitRef` pattern ensures the effect always calls the latest `submit` with up-to-date
  message history.
- Cancel (Escape) clears both the active stream and the pending queue.
- Only the last queued message is kept (last-write-wins).

A `pendingMessage` display state is exposed from the hook and rendered in `app.tsx` with a bold
yellow "Queued:" prefix and user-message styling, so the user sees their input was accepted.

New `use-chat.test.tsx` covers the queuing behavior: queue-and-process, last-write-wins, and
cancel-clears-queue.

## Notes for Reviewers

This is the first test file for the `useChat` hook. It mocks all external dependencies
(provider client, session, config, commands, truncation) and uses a controllable deferred
stream to precisely control when streaming ends. The same test infrastructure can be extended
for broader hook coverage (tracked in #86).