### PR TITLE
feat(markdown): render code blocks progressively during streaming

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import "./commands";
 import { AssistantMessage } from "./components/assistant-message";
 import { ChatInput } from "./components/chat-input";
 import { Header } from "./components/header";
+import { completePartialMarkdown } from "./components/markdown";
 import { MessageList } from "./components/message-list";
 import { ThinkingIndicator } from "./components/thinking-indicator";
 import { getActiveProvider, loadConfig } from "./config";
@@ -37,7 +38,9 @@ export function App() {
 
       {chat.streaming && chat.streamingContent ? (
         <Box flexDirection="column" marginBottom={1}>
-          <AssistantMessage>{chat.streamingContent}</AssistantMessage>
+          <AssistantMessage>
+            {completePartialMarkdown(chat.streamingContent)}
+          </AssistantMessage>
         </Box>
       ) : null}
 

--- a/src/components/markdown.test.tsx
+++ b/src/components/markdown.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "ink-testing-library";
 import { describe, it, expect } from "vitest";
-import { Markdown } from "./markdown";
+import { Markdown, completePartialMarkdown } from "./markdown";
 
 describe("Markdown", () => {
   it("renders bold text", () => {
@@ -111,5 +111,50 @@ describe("Markdown", () => {
 
     rerender(<Markdown>{"Hello **world**"}</Markdown>);
     expect(lastFrame() ?? "").toContain("world");
+  });
+});
+
+describe("completePartialMarkdown", () => {
+  it("returns text unchanged when no code fences", () => {
+    expect(completePartialMarkdown("hello world")).toBe("hello world");
+  });
+
+  it("returns text unchanged when code fences are balanced", () => {
+    const text = "```js\nconst x = 1;\n```";
+    expect(completePartialMarkdown(text)).toBe(text);
+  });
+
+  it("closes an unclosed backtick fence", () => {
+    const text = "```python\nprint('hi')";
+    expect(completePartialMarkdown(text)).toBe(`${text}\n\`\`\``);
+  });
+
+  it("closes an unclosed tilde fence", () => {
+    const text = "~~~\nsome code";
+    expect(completePartialMarkdown(text)).toBe(`${text}\n~~~`);
+  });
+
+  it("matches fence length when closing", () => {
+    const text = "````\ncode";
+    expect(completePartialMarkdown(text)).toBe(`${text}\n\`\`\`\``);
+  });
+
+  it("handles multiple code blocks with last one unclosed", () => {
+    const text = "```js\nconst x = 1;\n```\n\ntext\n\n```py\nprint('hi')";
+    expect(completePartialMarkdown(text)).toBe(`${text}\n\`\`\``);
+  });
+
+  it("does not close when shorter fence appears inside block", () => {
+    const text = "````\nsome ```\nstill open";
+    expect(completePartialMarkdown(text)).toBe(`${text}\n\`\`\`\``);
+  });
+
+  it("handles fence with only opening line and no content", () => {
+    const text = "some text\n```";
+    expect(completePartialMarkdown(text)).toBe(`${text}\n\`\`\``);
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(completePartialMarkdown("")).toBe("");
   });
 });

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -159,6 +159,45 @@ function indentBlock(text: string): string {
     .join("\n");
 }
 
+/**
+ * Closes unclosed code fences in partial markdown so streaming content
+ * renders as a code block instead of plain text while the response is
+ * still arriving.
+ */
+export function completePartialMarkdown(text: string): string {
+  const lines = text.split("\n");
+  let inCodeBlock = false;
+  let fenceChar = "";
+  let fenceLength = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (!inCodeBlock) {
+      const match = trimmed.match(/^(`{3,}|~{3,})/);
+      if (match) {
+        inCodeBlock = true;
+        fenceChar = match[1][0];
+        fenceLength = match[1].length;
+      }
+    } else {
+      const match = trimmed.match(/^(`{3,}|~{3,})\s*$/);
+      if (
+        match &&
+        match[1][0] === fenceChar &&
+        match[1].length >= fenceLength
+      ) {
+        inCodeBlock = false;
+      }
+    }
+  }
+
+  if (inCodeBlock) {
+    return `${text}\n${fenceChar.repeat(fenceLength)}`;
+  }
+
+  return text;
+}
+
 interface MarkdownProps {
   children: string;
 }


### PR DESCRIPTION
## Summary

Streaming content now renders code blocks with syntax highlighting as tokens arrive, instead of
showing raw text until the closing fence appears and then snapping to a formatted block.

## GitHub Issue

Closes #87

## What Changed

Added a `completePartialMarkdown` function that detects unclosed code fences (backtick and tilde,
with matching fence length) and appends a closing fence before the content is passed to the
markdown renderer. This runs only on streaming content in `app.tsx` — completed messages render
as before.

The function handles standard edge cases: mixed fence characters, varying fence lengths (e.g.
````), multiple code blocks where only the last is unclosed, and shorter fences appearing inside
a block without closing it.

## Notes for Reviewers

Markdown was already rendering during streaming via `<AssistantMessage>` — the issue was
specifically about incomplete constructs. Code fences are the only construct that causes a
significant visual disruption when incomplete; other incomplete markdown (unclosed bold, partial
links) is momentary and self-correcting, so only fences are handled here.