### PR TITLE
feat(commands): add /tools command to list available tools

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ import "./help";
 import "./models";
 import "./new";
 import "./session";
+import "./tools";
 import "./use";
 
 // Re-export registry functions

--- a/src/commands/tools.test.ts
+++ b/src/commands/tools.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getCommand } from "./registry";
+
+// Import to trigger registration
+import "./tools";
+
+describe("/tools command", () => {
+  it("is registered", () => {
+    const cmd = getCommand("tools");
+    expect(cmd).toBeDefined();
+    expect(cmd?.name).toBe("tools");
+    expect(cmd?.description).toBe("List available tools");
+  });
+
+  it("lists registered tools with name and description", () => {
+    const cmd = getCommand("tools");
+    const result = cmd?.execute("", {} as never);
+    expect(result).toBeDefined();
+
+    if (result && "output" in result) {
+      // The "ask" tool should be registered from the tools index
+      expect(result.output).toContain("ask");
+    }
+  });
+});

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -1,0 +1,21 @@
+import chalk from "chalk";
+import { getAllTools } from "../tools";
+import { register } from "./registry";
+import type { Command } from "./types";
+
+const tools: Command = {
+  name: "tools",
+  description: "List available tools",
+  execute: () => {
+    const all = getAllTools();
+    if (all.length === 0) {
+      return { output: "No tools available." };
+    }
+    const lines = all.map(
+      (t) => `  ${chalk.bold.yellow(t.name)} — ${t.description}`,
+    );
+    return { output: lines.join("\n") };
+  },
+};
+
+register(tools);


### PR DESCRIPTION
## Summary

Adds a `/tools` slash command that lists all registered model-initiated tools with their name and description. Tool names render in bold yellow for visual distinction.

## GitHub Issue

Closes #101

## What Changed

New `/tools` command following the same pattern as `/help` — iterates over the tool registry and formats each tool as `name — description`. Tool names are styled with `chalk.bold.yellow` to stand out from the cyan system message wrapper.