### PR TITLE
feat(tools): add read_file tool with parallel execution

### DIFF
--- a/src/components/tool-message.test.tsx
+++ b/src/components/tool-message.test.tsx
@@ -15,18 +15,24 @@ describe("ToolMessage", () => {
     expect(output).not.toContain("more lines");
   });
 
-  it("shows last 5 lines when collapsed and content exceeds 5 lines", () => {
-    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`);
+  it("shows header + last 5 body lines when collapsed and content exceeds 5 lines", () => {
+    // First line is the header, rest is body
+    const lines = [
+      "header line",
+      ...Array.from({ length: 10 }, (_, i) => `line ${i + 1}`),
+    ];
     const content = lines.join("\n");
     const { lastFrame } = render(
       <ToolMessage expanded={false}>{content}</ToolMessage>,
     );
 
     const output = lastFrame();
-    // Should show last 5 lines
+    // Header is always shown
+    expect(output).toContain("header line");
+    // Should show last 5 body lines
     expect(output).toContain("line 6");
     expect(output).toContain("line 10");
-    // Should NOT show early lines
+    // Should NOT show early body lines
     expect(output).not.toContain("line 1\n");
     // Should show hidden count
     expect(output).toContain("5 more lines");
@@ -34,13 +40,17 @@ describe("ToolMessage", () => {
   });
 
   it("shows full content when expanded", () => {
-    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`);
+    const lines = [
+      "header line",
+      ...Array.from({ length: 10 }, (_, i) => `line ${i + 1}`),
+    ];
     const content = lines.join("\n");
     const { lastFrame } = render(
       <ToolMessage expanded={true}>{content}</ToolMessage>,
     );
 
     const output = lastFrame();
+    expect(output).toContain("header line");
     expect(output).toContain("line 1");
     expect(output).toContain("line 10");
     expect(output).toContain("Tab to collapse");

--- a/src/components/tool-message.tsx
+++ b/src/components/tool-message.tsx
@@ -10,18 +10,22 @@ interface ToolMessageProps {
 /** Renders tool output with collapsed/expanded display. */
 export function ToolMessage({ children, expanded }: ToolMessageProps) {
   const lines = children.split("\n");
-  const totalLines = lines.length;
-  const needsCollapse = totalLines > COLLAPSED_LINES;
+  // First line is the tool header (styled with chalk), rest is body
+  const header = lines[0] ?? "";
+  const bodyLines = lines.slice(1);
+  const bodyTotal = bodyLines.length;
+  const needsCollapse = bodyTotal > COLLAPSED_LINES;
 
-  const displayContent =
+  const displayBody =
     !expanded && needsCollapse
-      ? lines.slice(-COLLAPSED_LINES).join("\n")
-      : children;
+      ? bodyLines.slice(-COLLAPSED_LINES).join("\n")
+      : bodyLines.join("\n");
 
-  const hiddenCount = totalLines - COLLAPSED_LINES;
+  const hiddenCount = bodyTotal - COLLAPSED_LINES;
 
   return (
     <Box flexDirection="column">
+      <Text>{header}</Text>
       {!expanded && needsCollapse ? (
         <Text dimColor>
           {"  ▸ "}
@@ -31,7 +35,7 @@ export function ToolMessage({ children, expanded }: ToolMessageProps) {
       {expanded && needsCollapse ? (
         <Text dimColor>{"  ▾ Tab to collapse"}</Text>
       ) : null}
-      <Text dimColor>{displayContent}</Text>
+      {displayBody ? <Text dimColor>{displayBody}</Text> : null}
     </Box>
   );
 }

--- a/src/hooks/use-chat.test.tsx
+++ b/src/hooks/use-chat.test.tsx
@@ -476,7 +476,7 @@ describe("useChat", () => {
       expect(chat.messages[0].role).toBe("user");
       expect(chat.messages[1].role).toBe("assistant");
       expect(chat.messages[2].role).toBe("tool");
-      expect(chat.messages[2].content).toBe("option A");
+      expect(chat.messages[2].content).toContain("option A");
       expect(chat.messages[3].role).toBe("assistant");
       expect(chat.messages[3].content).toBe("Great, you chose A");
     });
@@ -540,7 +540,10 @@ describe("useChat", () => {
       expect(vi.mocked(appendMessage)).toHaveBeenCalledTimes(4);
       expect(vi.mocked(appendMessage)).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ role: "tool", content: "result" }),
+        expect.objectContaining({
+          role: "tool",
+          content: expect.stringContaining("result"),
+        }),
       );
     });
 

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
+import chalk from "chalk";
 import { getCommand, parse } from "../commands";
 import type { DisplayMessage } from "../components/message-list";
 import {
@@ -50,36 +51,113 @@ class ToolDismissedError extends Error {
 }
 
 /** Executes tool calls and returns tool result messages. */
+const MAX_ARG_VALUE_LENGTH = 60;
+
+/** Truncates a string to a max length with ellipsis. */
+function truncateValue(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+/** Formats a single arg value for display. */
+function formatArgValue(value: unknown): string {
+  if (typeof value === "string") {
+    return truncateValue(value, MAX_ARG_VALUE_LENGTH);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.length} items]`;
+  }
+  return truncateValue(JSON.stringify(value), MAX_ARG_VALUE_LENGTH);
+}
+
+/** Formats a tool call header: bold yellow name + dim args summary. */
+function formatToolHeader(name: string, args: string): string {
+  let argsSummary = "";
+  try {
+    const parsed = JSON.parse(args);
+    argsSummary = Object.entries(parsed)
+      .map(([k, v]) => `${k}: ${formatArgValue(v)}`)
+      .join(", ");
+  } catch {
+    // Malformed args — skip summary
+  }
+  const header = argsSummary
+    ? `${chalk.bold.yellow(name)}  ${chalk.dim(argsSummary)}`
+    : chalk.bold.yellow(name);
+  return header;
+}
+
+/** Execute a single tool call and return a tool result message. */
+async function executeSingleToolCall(
+  tc: ToolCall,
+  toolContext: ToolContext,
+): Promise<DisplayMessage> {
+  const tool = getTool(tc.function.name);
+  let result: string;
+  if (!tool) {
+    result = `Error: unknown tool "${tc.function.name}"`;
+  } else {
+    try {
+      result = await tool.execute(tc.function.arguments, toolContext);
+    } catch (err) {
+      if (err instanceof ToolDismissedError) throw err;
+      result = `Error: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  const header = formatToolHeader(tc.function.name, tc.function.arguments);
+  return {
+    id: crypto.randomUUID(),
+    role: "tool",
+    content: `${header}\n${result}`,
+    tool_call_id: tc.id,
+  };
+}
+
+/** Executes tool calls. Non-interactive tools run in parallel, interactive ones run sequentially. */
 async function executeToolCalls(
   toolCalls: ToolCall[],
   signal: AbortSignal,
   toolContext: ToolContext,
 ): Promise<DisplayMessage[]> {
-  const results: DisplayMessage[] = [];
+  // Separate into non-interactive (can run in parallel) and interactive (must be sequential).
+  const nonInteractive: ToolCall[] = [];
+  const interactive: ToolCall[] = [];
+
   for (const tc of toolCalls) {
+    const tool = getTool(tc.function.name);
+    if (tool && tool.interactive === false) {
+      nonInteractive.push(tc);
+    } else {
+      interactive.push(tc);
+    }
+  }
+
+  // Run non-interactive tools in parallel.
+  const parallelResults =
+    nonInteractive.length > 0
+      ? await Promise.all(
+          nonInteractive.map((tc) => executeSingleToolCall(tc, toolContext)),
+        )
+      : [];
+
+  // Run interactive tools sequentially.
+  const sequentialResults: DisplayMessage[] = [];
+  for (const tc of interactive) {
     if (signal.aborted) {
       throw new DOMException("aborted", "AbortError");
     }
-    const tool = getTool(tc.function.name);
-    let result: string;
-    if (!tool) {
-      result = `Error: unknown tool "${tc.function.name}"`;
-    } else {
-      try {
-        result = await tool.execute(tc.function.arguments, toolContext);
-      } catch (err) {
-        if (err instanceof ToolDismissedError) throw err;
-        result = `Error: ${err instanceof Error ? err.message : String(err)}`;
-      }
-    }
-    results.push({
-      id: crypto.randomUUID(),
-      role: "tool",
-      content: result,
-      tool_call_id: tc.id,
-    });
+    sequentialResults.push(await executeSingleToolCall(tc, toolContext));
   }
-  return results;
+
+  // Return results in the original tool call order.
+  const allResults = [...parallelResults, ...sequentialResults];
+  const resultByCallId = new Map<string, DisplayMessage>();
+  for (const msg of allResults) {
+    if (msg.role === "tool") {
+      resultByCallId.set(msg.tool_call_id, msg);
+    }
+  }
+  return toolCalls.map((tc) => resultByCallId.get(tc.id) as DisplayMessage);
 }
 
 /** Manages conversation state and streaming for a chat session. */

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 // Register built-in tools
 import "./ask";
+import "./read-file";
 import "./run-command";
 
 // Re-export registry functions

--- a/src/tools/read-file.test.ts
+++ b/src/tools/read-file.test.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getTool } from "./registry";
+
+// Import to trigger registration
+import "./read-file";
+
+const tmpDir = resolve(import.meta.dirname, "../../.test-read-file-tmp");
+const mockContext = {
+  renderInteractive: vi.fn(),
+  reportProgress: vi.fn(),
+};
+
+beforeEach(() => {
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("read_file tool", () => {
+  it("is registered as non-interactive", () => {
+    const tool = getTool("read_file");
+    expect(tool).toBeDefined();
+    expect(tool?.name).toBe("read_file");
+    expect(tool?.interactive).toBe(false);
+  });
+
+  it("reads a file and returns numbered lines", async () => {
+    const filePath = resolve(tmpDir, "test.txt");
+    writeFileSync(filePath, "hello\nworld\n");
+
+    const tool = getTool("read_file");
+    const result = await tool?.execute(
+      JSON.stringify({ path: filePath }),
+      mockContext,
+    );
+
+    expect(result).toContain("hello");
+    expect(result).toContain("world");
+    expect(result).toContain("1 |");
+    expect(result).toContain("2 |");
+  });
+
+  it("returns error for non-existent file", async () => {
+    const tool = getTool("read_file");
+    const result = await tool?.execute(
+      JSON.stringify({ path: resolve(tmpDir, "nope.txt") }),
+      mockContext,
+    );
+
+    expect(result).toContain("Error: file not found");
+  });
+
+  it("returns error for empty path", async () => {
+    const tool = getTool("read_file");
+    const result = await tool?.execute(
+      JSON.stringify({ path: "" }),
+      mockContext,
+    );
+
+    expect(result).toBe("Error: no file path provided");
+  });
+
+  it("returns error for directories", async () => {
+    const tool = getTool("read_file");
+    const result = await tool?.execute(
+      JSON.stringify({ path: tmpDir }),
+      mockContext,
+    );
+
+    expect(result).toContain("is a directory");
+  });
+
+  it("truncates files exceeding 500 lines", async () => {
+    const lines = Array.from({ length: 600 }, (_, i) => `line ${i + 1}`);
+    const filePath = resolve(tmpDir, "big.txt");
+    writeFileSync(filePath, lines.join("\n"));
+
+    const tool = getTool("read_file");
+    const result = await tool?.execute(
+      JSON.stringify({ path: filePath }),
+      mockContext,
+    );
+
+    expect(result).toContain("showing first 500 of 600 lines");
+    expect(result).toContain("line 1");
+    expect(result).toContain("line 500");
+    expect(result).not.toContain("line 501");
+  });
+
+  it("supports startLine and endLine for range reads", async () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`);
+    const filePath = resolve(tmpDir, "range.txt");
+    writeFileSync(filePath, lines.join("\n"));
+
+    const tool = getTool("read_file");
+    const result = await tool?.execute(
+      JSON.stringify({ path: filePath, startLine: 5, endLine: 10 }),
+      mockContext,
+    );
+
+    expect(result).toContain("lines 5-10 of 20");
+    expect(result).toContain("line 5");
+    expect(result).toContain("line 10");
+    expect(result).not.toContain("line 4\n");
+    expect(result).not.toContain("line 11");
+  });
+
+  it("clamps line range to file bounds", async () => {
+    const filePath = resolve(tmpDir, "short.txt");
+    writeFileSync(filePath, "a\nb\nc\n");
+
+    const tool = getTool("read_file");
+    const result = await tool?.execute(
+      JSON.stringify({ path: filePath, startLine: 1, endLine: 100 }),
+      mockContext,
+    );
+
+    expect(result).toContain("lines 1-4 of 4");
+  });
+});

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -1,0 +1,86 @@
+import { readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { registerTool } from "./registry";
+
+const MAX_LINES = 500;
+
+registerTool({
+  name: "read_file",
+  description:
+    "Read the contents of a file. Returns the file content as text. Non-interactive — does not require user confirmation.",
+  parameters: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "The file path to read (absolute or relative to cwd)",
+      },
+      startLine: {
+        type: "number",
+        description:
+          "Optional 1-based start line for reading a range (inclusive)",
+      },
+      endLine: {
+        type: "number",
+        description:
+          "Optional 1-based end line for reading a range (inclusive)",
+      },
+    },
+    required: ["path"],
+  },
+  interactive: false,
+  async execute(args: string): Promise<string> {
+    const parsed = JSON.parse(args);
+    const rawPath: string = parsed.path ?? "";
+    const startLine: number | undefined = parsed.startLine;
+    const endLine: number | undefined = parsed.endLine;
+
+    if (!rawPath.trim()) {
+      return "Error: no file path provided";
+    }
+
+    const filePath = resolve(rawPath);
+
+    try {
+      const stat = statSync(filePath);
+      if (stat.isDirectory()) {
+        return `Error: ${filePath} is a directory, not a file`;
+      }
+    } catch {
+      return `Error: file not found: ${filePath}`;
+    }
+
+    try {
+      const content = readFileSync(filePath, "utf-8");
+      const allLines = content.split("\n");
+      const totalLines = allLines.length;
+
+      // Line range request
+      if (startLine !== undefined || endLine !== undefined) {
+        const start = Math.max(1, startLine ?? 1);
+        const end = Math.min(totalLines, endLine ?? totalLines);
+        const slice = allLines.slice(start - 1, end);
+        const numbered = slice.map(
+          (line, i) => `${String(start + i).padStart(4)} | ${line}`,
+        );
+        return `${filePath} (lines ${start}-${end} of ${totalLines})\n${numbered.join("\n")}`;
+      }
+
+      // Full file — truncate if needed
+      if (totalLines > MAX_LINES) {
+        const slice = allLines.slice(0, MAX_LINES);
+        const numbered = slice.map(
+          (line, i) => `${String(i + 1).padStart(4)} | ${line}`,
+        );
+        return `${filePath} (showing first ${MAX_LINES} of ${totalLines} lines, truncated)\n${numbered.join("\n")}`;
+      }
+
+      const numbered = allLines.map(
+        (line, i) => `${String(i + 1).padStart(4)} | ${line}`,
+      );
+      return `${filePath} (${totalLines} lines)\n${numbered.join("\n")}`;
+    } catch (err) {
+      return `Error reading file: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  },
+});

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -19,6 +19,8 @@ export interface Tool {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
+  /** Whether the tool requires user interaction (confirmation, input). Defaults to true. */
+  interactive?: boolean;
   execute: (args: string, context: ToolContext) => Promise<string>;
 }
 


### PR DESCRIPTION
## Summary

Adds the `read_file` tool for non-interactive file reading, introduces parallel execution for non-interactive tools, and adds styled tool headers to tool result messages.

## GitHub Issue

Closes #102

## What Changed

**read_file tool** — reads files with line numbers, 500-line truncation cap with a note, and optional `startLine`/`endLine` range for drilling into large files. Marked `interactive: false` so it skips user confirmation and runs in parallel when multiple files are requested.

**Parallel tool execution** — new `interactive` flag on the `Tool` interface (defaults to `true` for safety). `executeToolCalls` now separates tool calls by this flag: non-interactive tools run concurrently via `Promise.all`, interactive ones run sequentially. Results are returned in original tool call order regardless of execution order.

**Tool headers** — every tool result message now starts with a styled header line: bold yellow tool name + dim args summary. Arrays display as `[N items]` and long string values are truncated at 60 chars to prevent wrapping. The header renders with its own styling separate from the dim body text, and collapse/expand only applies to body lines.