### PR TITLE
ci: derive version from release tag at build time

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Set version from release tag
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
+
       - run: pnpm build:sea
 
       - name: Zip binary

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tomo",
-  "version": "0.4.0",
+  "version": "0.0.0",
   "type": "module",
   "bin": {
     "tomo": "dist/tomo.js"


### PR DESCRIPTION
## Summary

Removes manual version management from source. Sets package.json to 0.0.0 and injects the real version from the GitHub release tag during the publish workflow, so version bump commits are no longer needed.

## GitHub Issue

N/A

## What Changed

Added a step to the publish workflow that runs `npm version` with the release tag (stripping the `v` prefix) before building the SEA binary. The version imported by `header.tsx` is now set at build time rather than maintained in source. package.json stays at 0.0.0 in the repository.