### PR TITLE
feat(tools): add glob tool for file pattern matching

### DIFF
--- a/src/tools/edit-file.ts
+++ b/src/tools/edit-file.ts
@@ -90,7 +90,7 @@ registerTool({
 
     const diffPreview = formatDiff(content, newContent);
 
-    const approved = await context.renderInteractive((onResult, onCancel) =>
+    const approved = await context.renderInteractive((onResult, _onCancel) =>
       createElement(WriteFileConfirm, {
         filePath,
         isNewFile: false,

--- a/src/tools/glob.test.ts
+++ b/src/tools/glob.test.ts
@@ -1,0 +1,224 @@
+import { execSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getTool } from "./registry";
+
+// Import to trigger registration
+import "./glob";
+
+const tmpDir = resolve(import.meta.dirname, "../../.test-glob-tmp");
+const mockContext = {
+  renderInteractive: vi.fn().mockResolvedValue("approved"),
+  reportProgress: vi.fn(),
+  permissions: { read_file: true },
+};
+
+/** Initialise a git repo inside tmpDir with a .gitignore and committed + ignored files. */
+function setupGitRepo() {
+  execSync("git init", { cwd: tmpDir, stdio: "pipe" });
+  execSync("git config user.email test@test.com", {
+    cwd: tmpDir,
+    stdio: "pipe",
+  });
+  execSync("git config user.name Test", { cwd: tmpDir, stdio: "pipe" });
+  writeFileSync(resolve(tmpDir, ".gitignore"), "dist/\n");
+  mkdirSync(resolve(tmpDir, "dist"), { recursive: true });
+  writeFileSync(resolve(tmpDir, "dist/bundle.js"), "// built");
+  execSync("git add -A && git commit -m init", { cwd: tmpDir, stdio: "pipe" });
+}
+
+beforeEach(() => {
+  mkdirSync(resolve(tmpDir, "src"), { recursive: true });
+  writeFileSync(resolve(tmpDir, "readme.md"), "# Hello");
+  writeFileSync(resolve(tmpDir, "src/index.ts"), "export {}");
+  writeFileSync(resolve(tmpDir, "src/app.tsx"), "<App />");
+  writeFileSync(resolve(tmpDir, "src/utils.test.ts"), "test()");
+  vi.clearAllMocks();
+  mockContext.renderInteractive.mockResolvedValue("approved");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("glob tool", () => {
+  it("is registered as non-interactive", () => {
+    const tool = getTool("glob");
+    expect(tool).toBeDefined();
+    expect(tool?.name).toBe("glob");
+    expect(tool?.interactive).toBe(false);
+  });
+
+  it("matches files by pattern", async () => {
+    const tool = getTool("glob");
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.ts", path: tmpDir }),
+      mockContext,
+    );
+
+    expect(result).toContain("src/index.ts");
+    expect(result).toContain("src/utils.test.ts");
+    expect(result).not.toContain("readme.md");
+    expect(result).not.toContain("app.tsx");
+  });
+
+  it("matches files with tsx extension", async () => {
+    const tool = getTool("glob");
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.tsx", path: tmpDir }),
+      mockContext,
+    );
+
+    expect(result).toContain("src/app.tsx");
+    expect(result).not.toContain("index.ts");
+  });
+
+  it("returns message when no files match", async () => {
+    const tool = getTool("glob");
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.go", path: tmpDir }),
+      mockContext,
+    );
+
+    expect(result).toBe("No files matched the pattern.");
+  });
+
+  it("returns error for empty pattern", async () => {
+    const tool = getTool("glob");
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "" }),
+      mockContext,
+    );
+
+    expect(result).toBe("Error: no glob pattern provided");
+  });
+
+  it("defaults to cwd when no path provided", async () => {
+    const tool = getTool("glob");
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "package.json" }),
+      mockContext,
+    );
+
+    // Running from project root, should find the project's package.json
+    expect(result).toContain("package.json");
+  });
+
+  it("does not prompt when read_file permission is granted and path in cwd", async () => {
+    const tool = getTool("glob");
+    await tool?.execute(
+      JSON.stringify({ pattern: "**/*.ts", path: tmpDir }),
+      mockContext,
+    );
+
+    expect(mockContext.renderInteractive).not.toHaveBeenCalled();
+  });
+
+  it("prompts when read_file permission is not granted", async () => {
+    const tool = getTool("glob");
+    const ctx = {
+      ...mockContext,
+      permissions: { read_file: false },
+    };
+
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.ts", path: tmpDir }),
+      ctx,
+    );
+
+    expect(ctx.renderInteractive).toHaveBeenCalledTimes(1);
+    expect(result).toContain("src/index.ts");
+  });
+
+  it("returns denial when user denies search", async () => {
+    const tool = getTool("glob");
+    const ctx = {
+      ...mockContext,
+      renderInteractive: vi.fn().mockResolvedValue("denied"),
+      permissions: { read_file: false },
+    };
+
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.ts", path: tmpDir }),
+      ctx,
+    );
+
+    expect(result).toBe("The user denied this search.");
+  });
+
+  it("prompts for paths outside cwd even with permission granted", async () => {
+    const tool = getTool("glob");
+
+    await tool?.execute(
+      JSON.stringify({ pattern: "*.txt", path: "/tmp" }),
+      mockContext,
+    );
+
+    expect(mockContext.renderInteractive).toHaveBeenCalledTimes(1);
+  });
+
+  it("excludes gitignored files by default", async () => {
+    setupGitRepo();
+    const tool = getTool("glob");
+
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.js", path: tmpDir }),
+      mockContext,
+    );
+
+    expect(result).toBe("No files matched the pattern.");
+  });
+
+  it("excludes gitignored files when gitignore is true", async () => {
+    setupGitRepo();
+    const tool = getTool("glob");
+
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.js", path: tmpDir, gitignore: true }),
+      mockContext,
+    );
+
+    expect(result).toBe("No files matched the pattern.");
+  });
+
+  it("includes gitignored files when gitignore is false", async () => {
+    setupGitRepo();
+    const tool = getTool("glob");
+
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.js", path: tmpDir, gitignore: false }),
+      mockContext,
+    );
+
+    expect(result).toContain("dist/bundle.js");
+  });
+
+  it("includes untracked non-ignored files with gitignore on", async () => {
+    setupGitRepo();
+    // Add a new file that isn't committed yet but also isn't ignored
+    writeFileSync(resolve(tmpDir, "src/new.ts"), "// new");
+    const tool = getTool("glob");
+
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.ts", path: tmpDir }),
+      mockContext,
+    );
+
+    expect(result).toContain("src/index.ts");
+    expect(result).toContain("src/new.ts");
+  });
+
+  it("falls back to fs.globSync for non-git directories", async () => {
+    // tmpDir is not a git repo (no setupGitRepo call)
+    const tool = getTool("glob");
+
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "**/*.ts", path: tmpDir }),
+      mockContext,
+    );
+
+    expect(result).toContain("src/index.ts");
+    expect(result).toContain("src/utils.test.ts");
+  });
+});

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -1,0 +1,118 @@
+import { execSync } from "node:child_process";
+import { globSync } from "node:fs";
+import { resolve } from "node:path";
+import { createElement } from "react";
+import { FileAccessConfirm } from "../components/file-access-confirm";
+import { isPathWithinCwd } from "../permissions";
+import { registerTool } from "./registry";
+import type { ToolContext } from "./types";
+
+registerTool({
+  name: "glob",
+  description:
+    "Find files matching a glob pattern. Returns matching file paths, one per line. By default, gitignored files are excluded.",
+  parameters: {
+    type: "object",
+    properties: {
+      pattern: {
+        type: "string",
+        description:
+          "The glob pattern to match (e.g. **/*.ts, src/**/*.test.ts)",
+      },
+      path: {
+        type: "string",
+        description:
+          "Optional directory to search in (absolute or relative to cwd). Defaults to cwd.",
+      },
+      gitignore: {
+        type: "boolean",
+        description:
+          "Whether to respect .gitignore rules and exclude ignored files. Defaults to true. Set to false to include gitignored files.",
+      },
+    },
+    required: ["pattern"],
+  },
+  interactive: false,
+  async execute(args: string, context: ToolContext): Promise<string> {
+    const parsed = JSON.parse(args);
+    const pattern: string = parsed.pattern ?? "";
+    const rawPath: string | undefined = parsed.path;
+    const gitignore: boolean = parsed.gitignore ?? true;
+
+    if (!pattern.trim()) {
+      return "Error: no glob pattern provided";
+    }
+
+    const searchDir = rawPath ? resolve(rawPath) : process.cwd();
+
+    // Permission granted and path in cwd — search immediately
+    if (context.permissions.read_file && isPathWithinCwd(searchDir)) {
+      return runGlob(pattern, searchDir, gitignore);
+    }
+
+    // Permission not granted or outside cwd — ask for approval
+    const approved = await context.renderInteractive((onResult) =>
+      createElement(FileAccessConfirm, {
+        filePath: searchDir,
+        action: `Search for files matching "${pattern}"?`,
+        onApprove: () => onResult("approved"),
+        onDeny: () => onResult("denied"),
+      }),
+    );
+
+    if (approved !== "approved") {
+      return "The user denied this search.";
+    }
+
+    return runGlob(pattern, searchDir, gitignore);
+  },
+});
+
+/** Check whether a directory is inside a git repository. */
+function isGitRepo(cwd: string): boolean {
+  try {
+    execSync("git rev-parse --is-inside-work-tree", {
+      cwd,
+      stdio: "pipe",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Use `git ls-files` to list tracked + untracked-but-not-ignored files
+ * matching the pattern. Falls back to `fs.globSync` if not in a git repo.
+ */
+function gitGlob(pattern: string, cwd: string): string[] {
+  // tracked files matching the pattern
+  const tracked = execSync(`git ls-files -- ${JSON.stringify(pattern)}`, {
+    cwd,
+    encoding: "utf-8",
+  });
+  // untracked files that aren't ignored
+  const untracked = execSync(
+    `git ls-files --others --exclude-standard -- ${JSON.stringify(pattern)}`,
+    { cwd, encoding: "utf-8" },
+  );
+
+  const combined = `${tracked}${untracked}`;
+  return combined.split("\n").filter((line) => line.length > 0);
+}
+
+function runGlob(pattern: string, cwd: string, gitignore: boolean): string {
+  try {
+    const matches =
+      gitignore && isGitRepo(cwd)
+        ? gitGlob(pattern, cwd)
+        : globSync(pattern, { cwd });
+
+    if (matches.length === 0) {
+      return "No files matched the pattern.";
+    }
+    return matches.join("\n");
+  } catch (err) {
+    return `Error: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 // Register built-in tools
 import "./ask";
 import "./edit-file";
+import "./glob";
 import "./read-file";
 import "./run-command";
 import "./write-file";

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -98,7 +98,7 @@ registerTool({
     }
 
     // Permission not granted or outside cwd — ask for approval
-    const approved = await context.renderInteractive((onResult, onCancel) =>
+    const approved = await context.renderInteractive((onResult, _onCancel) =>
       createElement(FileAccessConfirm, {
         filePath,
         action: "Read this file?",

--- a/src/tools/run-command.ts
+++ b/src/tools/run-command.ts
@@ -74,7 +74,7 @@ registerTool({
       return "Error: no command provided";
     }
 
-    const approved = await context.renderInteractive((onResult, onCancel) =>
+    const approved = await context.renderInteractive((onResult, _onCancel) =>
       createElement(CommandConfirm, {
         command,
         onApprove: () => onResult("approved"),

--- a/src/tools/write-file.ts
+++ b/src/tools/write-file.ts
@@ -61,7 +61,7 @@ registerTool({
       diffPreview = formatDiff(existing, content);
     }
 
-    const approved = await context.renderInteractive((onResult, onCancel) =>
+    const approved = await context.renderInteractive((onResult, _onCancel) =>
       createElement(WriteFileConfirm, {
         filePath,
         isNewFile,


### PR DESCRIPTION
## Summary

Adds a new `glob` tool that lets the model find files by glob pattern. Uses `git ls-files` under the hood to respect `.gitignore` by default, falling back to `fs.globSync` for non-git directories or when the model explicitly opts out.

## GitHub Issue

Closes #116

## What Changed

New `glob` tool registered in the tool registry with three parameters:
- `pattern` (required) — the glob pattern to match
- `path` (optional) — directory to scope the search, defaults to cwd
- `gitignore` (optional, default `true`) — when true, uses `git ls-files` to exclude gitignored files; when false, uses `fs.globSync` which includes everything

The tool reuses the existing `read_file` permission and `isPathWithinCwd` boundary check — searches within cwd with permission granted run immediately, otherwise the user is prompted for approval.

Also fixes pre-existing unused `onCancel` parameter lint warnings across `edit-file.ts`, `write-file.ts`, `run-command.ts`, and `read-file.ts` (required to pass the biome lint pre-commit hook).

15 unit tests covering pattern matching, permission gating, gitignore filtering, fallback behavior, and edge cases.