### PR TITLE
feat(tools): add tool enable/disable toggle

### DIFF
--- a/src/commands/tools.test.ts
+++ b/src/commands/tools.test.ts
@@ -9,17 +9,17 @@ describe("/tools command", () => {
     const cmd = getCommand("tools");
     expect(cmd).toBeDefined();
     expect(cmd?.name).toBe("tools");
-    expect(cmd?.description).toBe("List available tools");
+    expect(cmd?.description).toBe("Manage tool availability");
   });
 
-  it("lists registered tools with name and description", () => {
+  it("returns an interactive element", () => {
     const cmd = getCommand("tools");
-    const result = cmd?.execute("", {} as never);
-    expect(result).toBeDefined();
+    const result = cmd?.execute("", {
+      onComplete: () => {},
+      onCancel: () => {},
+    } as never);
 
-    if (result && "output" in result) {
-      // The "ask" tool should be registered from the tools index
-      expect(result.output).toContain("ask");
-    }
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("interactive");
   });
 });

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -1,20 +1,29 @@
-import chalk from "chalk";
-import { getAllTools } from "../tools";
+import { createElement } from "react";
+import { ToolSelector } from "../components/tool-selector";
+import { loadConfig, updateLocalToolConfig } from "../config";
+import { getAllTools, resolveToolAvailability } from "../tools";
 import { register } from "./registry";
 import type { Command } from "./types";
 
 const tools: Command = {
   name: "tools",
-  description: "List available tools",
-  execute: () => {
-    const all = getAllTools();
-    if (all.length === 0) {
-      return { output: "No tools available." };
-    }
-    const lines = all.map(
-      (t) => `  ${chalk.bold.yellow(t.name)} — ${t.description}`,
-    );
-    return { output: lines.join("\n") };
+  description: "Manage tool availability",
+  execute: (_args, callbacks) => {
+    const config = loadConfig();
+    const allTools = getAllTools();
+    const current = resolveToolAvailability(config.tools);
+
+    return {
+      interactive: createElement(ToolSelector, {
+        tools: allTools.map((t) => t.name),
+        currentAvailability: current,
+        onSave: (updated: Record<string, boolean>) => {
+          updateLocalToolConfig(updated);
+          callbacks.onComplete({ output: "Tool availability updated." });
+        },
+        onCancel: callbacks.onCancel,
+      }),
+    };
   },
 };
 

--- a/src/components/tool-selector.test.tsx
+++ b/src/components/tool-selector.test.tsx
@@ -1,0 +1,160 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { ToolSelector } from "./tool-selector";
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+
+const toolNames = ["read_file", "write_file", "glob", "grep"];
+const defaults: Record<string, boolean> = {
+  read_file: true,
+  write_file: true,
+  glob: true,
+  grep: true,
+};
+
+describe("ToolSelector", () => {
+  it("renders all tools with their current availability", () => {
+    const { lastFrame } = render(
+      <ToolSelector
+        tools={toolNames}
+        currentAvailability={defaults}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain("Tool Availability");
+    expect(output).toContain("read_file");
+    expect(output).toContain("write_file");
+    expect(output).toContain("glob");
+    expect(output).toContain("grep");
+  });
+
+  it("shows enabled tools as [✔] and disabled as [ ]", () => {
+    const availability = { ...defaults, grep: false };
+    const { lastFrame } = render(
+      <ToolSelector
+        tools={toolNames}
+        currentAvailability={availability}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const output = lastFrame() ?? "";
+    const grepLine = output.split("\n").find((l) => l.includes("grep"));
+    expect(grepLine).toContain("[ ]");
+    const readLine = output.split("\n").find((l) => l.includes("read_file"));
+    expect(readLine).toContain("[✔]");
+  });
+
+  it("toggles tool with Space", async () => {
+    const onSave = vi.fn();
+    const { stdin } = render(
+      <ToolSelector
+        tools={toolNames}
+        currentAvailability={defaults}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Toggle first tool (read_file) off
+    stdin.write(" ");
+    await flush();
+    // Save with Esc
+    stdin.write("\x1B");
+    await flush();
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ read_file: false }),
+    );
+  });
+
+  it("toggles tool with Enter", async () => {
+    const onSave = vi.fn();
+    const { stdin } = render(
+      <ToolSelector
+        tools={toolNames}
+        currentAvailability={defaults}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Move to write_file (index 1)
+    stdin.write("\x1B[B");
+    await flush();
+    // Toggle with Enter
+    stdin.write("\r");
+    await flush();
+    // Save
+    stdin.write("\x1B");
+    await flush();
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ write_file: false }),
+    );
+  });
+
+  it("navigates with arrow keys and wraps around", async () => {
+    const onSave = vi.fn();
+    const { stdin } = render(
+      <ToolSelector
+        tools={toolNames}
+        currentAvailability={defaults}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Move up from first item should wrap to last
+    stdin.write("\x1B[A");
+    await flush();
+    // Toggle last tool (grep)
+    stdin.write(" ");
+    await flush();
+    // Save
+    stdin.write("\x1B");
+    await flush();
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ grep: false }),
+    );
+  });
+
+  it("calls onCancel on q", async () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(
+      <ToolSelector
+        tools={toolNames}
+        currentAvailability={defaults}
+        onSave={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    stdin.write("q");
+    await flush();
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("saves unchanged state on Esc", async () => {
+    const onSave = vi.fn();
+    const { stdin } = render(
+      <ToolSelector
+        tools={toolNames}
+        currentAvailability={defaults}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    stdin.write("\x1B");
+    await flush();
+
+    expect(onSave).toHaveBeenCalledWith(defaults);
+  });
+});

--- a/src/components/tool-selector.tsx
+++ b/src/components/tool-selector.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+interface ToolSelectorProps {
+  tools: string[];
+  currentAvailability: Record<string, boolean>;
+  onSave: (availability: Record<string, boolean>) => void;
+  onCancel: () => void;
+}
+
+/** Interactive tool enable/disable UI for the /tools command. */
+export function ToolSelector({
+  tools,
+  currentAvailability,
+  onSave,
+  onCancel,
+}: ToolSelectorProps) {
+  const [cursor, setCursor] = useState(0);
+  const [availability, setAvailability] = useState({
+    ...currentAvailability,
+  });
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onSave(availability);
+      return;
+    }
+
+    if (input === "q" || input === "Q") {
+      onCancel();
+      return;
+    }
+
+    if (key.upArrow) {
+      setCursor((c) => (c > 0 ? c - 1 : tools.length - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setCursor((c) => (c < tools.length - 1 ? c + 1 : 0));
+      return;
+    }
+
+    if (input === " " || key.return) {
+      const name = tools[cursor];
+      setAvailability((prev) => ({
+        ...prev,
+        [name]: !prev[name],
+      }));
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color="yellow">
+        {"  Tool Availability"}
+      </Text>
+      <Text>{""}</Text>
+      {tools.map((name, i) => {
+        const isCurrent = i === cursor;
+        const enabled = availability[name] ?? true;
+
+        return (
+          <Text key={name} color={isCurrent ? "cyan" : undefined}>
+            {"  "}
+            {isCurrent ? "❯" : " "} {enabled ? "[✔]" : "[ ]"} {name}
+          </Text>
+        );
+      })}
+      <Text>{""}</Text>
+      <Text dimColor>
+        {"  ↑↓ navigate, Space/Enter toggle, Esc save & close, q cancel"}
+      </Text>
+    </Box>
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,8 @@ const permissionsSchema = z
   })
   .optional();
 
+const toolsSchema = z.record(z.string(), z.boolean()).optional();
+
 const configSchema = z
   .object({
     activeProvider: z.string().min(1, "activeProvider is required"),
@@ -35,6 +37,7 @@ const configSchema = z
       .array(providerSchema)
       .min(1, "providers must be a non-empty array"),
     permissions: permissionsSchema,
+    tools: toolsSchema,
   })
   .check((ctx) => {
     const names = ctx.value.providers.map((p) => p.name);
@@ -165,6 +168,17 @@ export function updateLocalPermissions(
 
   const raw = loadYaml(path) ?? {};
   raw.permissions = permissions;
+  writeFileSync(path, stringify(raw), "utf-8");
+}
+
+/** Updates tool availability in the local project config (.tomo/config.yaml). Creates the file if absent. */
+export function updateLocalToolConfig(tools: Record<string, boolean>): void {
+  const path = localConfigPath();
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+
+  const raw = loadYaml(path) ?? {};
+  raw.tools = tools;
   writeFileSync(path, stringify(raw), "utf-8");
 }
 

--- a/src/hooks/use-chat.test.tsx
+++ b/src/hooks/use-chat.test.tsx
@@ -91,6 +91,7 @@ vi.mock("../context/truncate", () => ({
 vi.mock("../tools", () => ({
   getTool: vi.fn(),
   getToolDefinitions: vi.fn().mockReturnValue([]),
+  resolveToolAvailability: vi.fn().mockReturnValue({}),
 }));
 
 const testProvider = {

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -26,7 +26,12 @@ import {
   loadSession,
 } from "../session";
 import { resolvePermissions } from "../permissions";
-import { type ToolContext, getTool, getToolDefinitions } from "../tools";
+import {
+  type ToolContext,
+  getTool,
+  getToolDefinitions,
+  resolveToolAvailability,
+} from "../tools";
 
 export interface ChatState {
   messages: DisplayMessage[];
@@ -366,7 +371,8 @@ export function useChat(
     let currentMessages: DisplayMessage[] = [...messages, userMsg];
 
     const maxTokens = getMaxTokens(config, activeProvider, activeModel);
-    const toolDefs = getToolDefinitions();
+    const toolAvailability = resolveToolAvailability(loadConfig().tools);
+    const toolDefs = getToolDefinitions(toolAvailability);
 
     const permissions = resolvePermissions(loadConfig().permissions);
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,5 +13,6 @@ export {
   getTool,
   getAllTools,
   getToolDefinitions,
+  resolveToolAvailability,
 } from "./registry";
 export type { Tool, ToolContext } from "./types";

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -4,6 +4,7 @@ import {
   getTool,
   getToolDefinitions,
   registerTool,
+  resolveToolAvailability,
 } from "./registry";
 import type { Tool } from "./types";
 
@@ -63,5 +64,70 @@ describe("tool registry", () => {
     registerTool(tool2);
 
     expect(getTool("test-overwrite")?.description).toBe("updated");
+  });
+
+  it("resolves tool availability defaulting all to enabled", () => {
+    registerTool(makeTool("test-avail-a"));
+    registerTool(makeTool("test-avail-b"));
+
+    const result = resolveToolAvailability();
+    expect(result["test-avail-a"]).toBe(true);
+    expect(result["test-avail-b"]).toBe(true);
+  });
+
+  it("resolves tool availability with overrides from config", () => {
+    registerTool(makeTool("test-avail-c"));
+    registerTool(makeTool("test-avail-d"));
+
+    const result = resolveToolAvailability({ "test-avail-c": false });
+    expect(result["test-avail-c"]).toBe(false);
+    expect(result["test-avail-d"]).toBe(true);
+  });
+
+  it("filters tool definitions by availability", () => {
+    registerTool(makeTool("test-filter-on"));
+    registerTool(makeTool("test-filter-off"));
+
+    const defs = getToolDefinitions({
+      "test-filter-on": true,
+      "test-filter-off": false,
+    });
+
+    expect(
+      defs.find((d) => d.function.name === "test-filter-on"),
+    ).toBeDefined();
+    expect(
+      defs.find((d) => d.function.name === "test-filter-off"),
+    ).toBeUndefined();
+  });
+
+  it("returns all tools when no availability passed", () => {
+    registerTool(makeTool("test-nofilter"));
+    const defs = getToolDefinitions();
+    expect(defs.find((d) => d.function.name === "test-nofilter")).toBeDefined();
+  });
+
+  it("respects tool enabled default when no config override", () => {
+    const disabledTool = makeTool("test-disabled-default");
+    disabledTool.enabled = false;
+    registerTool(disabledTool);
+
+    const enabledTool = makeTool("test-enabled-default");
+    registerTool(enabledTool);
+
+    const result = resolveToolAvailability();
+    expect(result["test-disabled-default"]).toBe(false);
+    expect(result["test-enabled-default"]).toBe(true);
+  });
+
+  it("config override takes priority over tool enabled default", () => {
+    const disabledTool = makeTool("test-override-default");
+    disabledTool.enabled = false;
+    registerTool(disabledTool);
+
+    const result = resolveToolAvailability({
+      "test-override-default": true,
+    });
+    expect(result["test-override-default"]).toBe(true);
   });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -19,7 +19,28 @@ export function getAllTools(): Tool[] {
   return [...tools.values()];
 }
 
-/** Returns all registered tools as OpenAI tool definitions for the API request. */
-export function getToolDefinitions(): ToolDefinition[] {
-  return getAllTools().map(toToolDefinition);
+/**
+ * Resolves which tools are enabled. Config overrides take priority,
+ * then the tool's own `enabled` default, then true.
+ * Returns a map of tool name → boolean.
+ */
+export function resolveToolAvailability(
+  config?: Record<string, boolean>,
+): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  for (const tool of getAllTools()) {
+    result[tool.name] = config?.[tool.name] ?? tool.enabled ?? true;
+  }
+  return result;
+}
+
+/** Returns enabled tools as OpenAI tool definitions for the API request. */
+export function getToolDefinitions(
+  availability?: Record<string, boolean>,
+): ToolDefinition[] {
+  const all = getAllTools();
+  if (!availability) return all.map(toToolDefinition);
+  return all
+    .filter((t) => availability[t.name] !== false)
+    .map(toToolDefinition);
 }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -23,6 +23,8 @@ export interface Tool {
   parameters: Record<string, unknown>;
   /** Whether the tool requires user interaction (confirmation, input). Defaults to true. */
   interactive?: boolean;
+  /** Whether the tool is enabled by default. Defaults to true. */
+  enabled?: boolean;
   execute: (args: string, context: ToolContext) => Promise<string>;
 }
 


### PR DESCRIPTION
## Summary

Converts the `/tools` command from a static list into an interactive selector for enabling/disabling individual tools. Disabled tools are excluded from chat completion requests sent to the model.

## GitHub Issue

Closes #118

## What Changed

The `/tools` command now renders an interactive toggle UI (same pattern as `/grant`) where users can enable or disable individual tools with arrow keys and Space/Enter. Tool availability is persisted in `.tomo/config.yaml` under a `tools` key — tools not listed default to enabled.

Each tool can optionally declare `enabled: false` in its registration to default to disabled (e.g. for future tools like `web_search` that should be opt-in). Resolution priority: config override > tool's `enabled` default > `true`.

The filtering is wired into `use-chat.ts` so disabled tools are never included in the `tools` array sent to the provider.