### PR TITLE
fix(ui): restart Ink on /new to fully clear Static output

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -4,7 +4,7 @@ import { App } from "./app";
 
 describe("App", () => {
   it("renders the chat input", () => {
-    const { lastFrame } = render(<App />);
+    const { lastFrame } = render(<App onRestart={() => {}} />);
     const output = lastFrame() ?? "";
     expect(output).toContain(">");
   });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -41,14 +41,19 @@ type StaticItem =
   | { type: "warning"; id: string; text: string }
   | (DisplayMessage & { type?: undefined });
 
+interface AppProps {
+  onRestart: () => void;
+}
+
 /** Root application component. Renders the chat UI and delegates state to useChat. */
-export function App() {
+export function App({ onRestart }: AppProps) {
   const chat = useChat(
     config,
     initialProvider,
     config.activeModel,
     initialSession,
     instructions,
+    onRestart,
   );
 
   const headerItem = useMemo(

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -173,6 +173,7 @@ export function useChat(
   initialModel: string,
   initialSession: Session,
   systemMessage: string | null = null,
+  onRestart?: () => void,
 ): ChatState {
   const [messages, setMessages] = useState<DisplayMessage[]>(
     initialSession.messages,
@@ -225,6 +226,10 @@ export function useChat(
   };
 
   const clearMessages = () => {
+    if (onRestart) {
+      onRestart();
+      return;
+    }
     const newSession = createSession(activeProvider.name, activeModel);
     sessionRef.current = newSession;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,33 @@
 import chalk from "chalk";
 import { render } from "ink";
+import { createElement } from "react";
 import { App } from "./app";
 import { getLastSavedSessionId } from "./session";
 
-const { waitUntilExit } = render(<App />, { exitOnCtrlC: false });
-await waitUntilExit();
+let restarting = false;
+
+function start() {
+  restarting = false;
+  const instance = render(createElement(App, { onRestart: restart }), {
+    exitOnCtrlC: false,
+  });
+  return instance;
+}
+
+function restart() {
+  restarting = true;
+  instance.unmount();
+  process.stdout.write("\x1B[2J\x1B[H\x1B[3J");
+  instance = start();
+}
+
+let instance = start();
+
+// Re-await on restart — loop until a normal (non-restart) exit.
+while (true) {
+  await instance.waitUntilExit();
+  if (!restarting) break;
+}
 
 const sessionId = getLastSavedSessionId();
 if (sessionId) {


### PR DESCRIPTION
## Summary

Fixes `/new` leaving old conversation messages visible on screen. Ink's `Static` component is write-once and items persist in the terminal scrollback, so clearing state in-place had no visual effect.

## GitHub Issue

N/A

## What Changed

Instead of resetting state within the existing Ink render tree, `/new` now triggers a full restart — unmounting the Ink instance, clearing the terminal including scrollback buffer, and re-rendering a fresh app. The entry point (`index.tsx`) runs a restart loop that re-awaits `waitUntilExit` after each restart until the user exits normally. The `App` component accepts an `onRestart` prop threaded through `useChat` to `clearMessages`.