### PR TITLE
ci(publish): add update-homebrew job to auto-update tap formula

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,3 +35,63 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: tomo-darwin-arm64.zip
+
+  update-homebrew:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download release asset
+        run: |
+          curl -sL -o tomo-darwin-arm64.zip \
+            "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/tomo-darwin-arm64.zip"
+
+      - name: Compute sha256
+        id: sha
+        run: echo "sha256=$(sha256sum tomo-darwin-arm64.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Generate formula
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p Formula
+          cat > Formula/tomo.rb << 'FORMULA'
+          class Tomo < Formula
+            desc "Terminal-native AI chat client — local-first, OpenAI-compatible"
+            homepage "https://github.com/LeeCheneler/tomo"
+            version "VERSION_PLACEHOLDER"
+            license "MIT"
+
+            on_macos do
+              on_arm do
+                url "URL_PLACEHOLDER"
+                sha256 "SHA256_PLACEHOLDER"
+              end
+            end
+
+            def install
+              bin.install "tomo"
+            end
+
+            test do
+              assert_predicate bin/"tomo", :executable?
+            end
+          end
+          FORMULA
+
+          sed -i "s|VERSION_PLACEHOLDER|${VERSION}|g" Formula/tomo.rb
+          sed -i "s|URL_PLACEHOLDER|https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/tomo-darwin-arm64.zip|g" Formula/tomo.rb
+          sed -i "s|SHA256_PLACEHOLDER|${{ steps.sha.outputs.sha256 }}|g" Formula/tomo.rb
+
+      - name: Push formula to tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/LeeCheneler/homebrew-tomo.git" tap
+          cp Formula/tomo.rb tap/Formula/tomo.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/tomo.rb
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "Update tomo to ${GITHUB_REF_NAME#v}"
+          git push


### PR DESCRIPTION
## Summary

Adds an `update-homebrew` job to the publish workflow that automatically updates the Homebrew tap formula when a new release is published.

## GitHub Issue

Closes #129

## What Changed

The publish workflow gains a new job that runs after the binary build completes. It downloads the release asset, computes the sha256 checksum, generates a Homebrew formula with the correct version/URL/hash, and pushes it to the `LeeCheneler/homebrew-tomo` tap repo. Requires a `HOMEBREW_TAP_TOKEN` secret with write access to the tap repo.