### PR TITLE
chore: add MIT license, Zod tool validation, and security hardening

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Lee Cheneler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -93,7 +93,11 @@ export function App({ onRestart }: AppProps) {
       return chalk.cyan(msg.content);
     });
     const content = parts.filter(Boolean).join("\n\n");
+    const ALLOWED_PAGERS = new Set(["less", "more", "most", "bat", "cat"]);
     const pager = process.env.PAGER || "less";
+    if (!ALLOWED_PAGERS.has(pager)) {
+      return;
+    }
     spawnSync(pager, ["-R", "+G"], {
       input: content,
       stdio: ["pipe", "inherit", "inherit"],

--- a/src/tools/ask.test.ts
+++ b/src/tools/ask.test.ts
@@ -30,7 +30,7 @@ describe("ask tool", () => {
     });
   });
 
-  it("returns error when no options provided", async () => {
+  it("throws when no options provided", async () => {
     const tool = getTool("ask");
     const context = {
       renderInteractive: vi.fn(),
@@ -38,11 +38,9 @@ describe("ask tool", () => {
       permissions: {},
     };
 
-    const result = await tool?.execute(
-      JSON.stringify({ question: "pick", options: [] }),
-      context,
-    );
-    expect(result).toBe("Error: no options provided");
+    await expect(
+      tool?.execute(JSON.stringify({ question: "pick", options: [] }), context),
+    ).rejects.toThrow("no options provided");
     expect(context.renderInteractive).not.toHaveBeenCalled();
   });
 

--- a/src/tools/ask.ts
+++ b/src/tools/ask.ts
@@ -1,7 +1,13 @@
 import React from "react";
+import { z } from "zod";
 import { AskSelector } from "../components/ask-selector";
 import { registerTool } from "./registry";
-import type { ToolContext } from "./types";
+import { type ToolContext, parseToolArgs } from "./types";
+
+const argsSchema = z.object({
+  question: z.string().default("Please choose:"),
+  options: z.array(z.string()).min(1, "no options provided"),
+});
 
 registerTool({
   name: "ask",
@@ -23,13 +29,7 @@ registerTool({
     required: ["question", "options"],
   },
   async execute(args: string, context: ToolContext): Promise<string> {
-    const parsed = JSON.parse(args);
-    const question: string = parsed.question ?? "Please choose:";
-    const options: string[] = parsed.options ?? [];
-
-    if (options.length === 0) {
-      return "Error: no options provided";
-    }
+    const { question, options } = parseToolArgs(argsSchema, args);
 
     return context.renderInteractive((onResult, onCancel) =>
       React.createElement(AskSelector, {

--- a/src/tools/edit-file.test.ts
+++ b/src/tools/edit-file.test.ts
@@ -100,28 +100,28 @@ describe("edit_file tool", () => {
     expect(result).toContain("file not found");
   });
 
-  it("returns error for empty path", async () => {
+  it("throws for empty path", async () => {
     const tool = getTool("edit_file");
-    const result = await tool?.execute(
-      JSON.stringify({ path: "", old_string: "x", new_string: "y" }),
-      mockContext,
-    );
-
-    expect(result).toBe("Error: no file path provided");
+    await expect(
+      tool?.execute(
+        JSON.stringify({ path: "", old_string: "x", new_string: "y" }),
+        mockContext,
+      ),
+    ).rejects.toThrow("no file path provided");
   });
 
-  it("returns error for empty old_string", async () => {
+  it("throws for empty old_string", async () => {
     const tool = getTool("edit_file");
-    const result = await tool?.execute(
-      JSON.stringify({
-        path: resolve(tmpDir, "test.txt"),
-        old_string: "",
-        new_string: "y",
-      }),
-      mockContext,
-    );
-
-    expect(result).toBe("Error: old_string must not be empty");
+    await expect(
+      tool?.execute(
+        JSON.stringify({
+          path: resolve(tmpDir, "test.txt"),
+          old_string: "",
+          new_string: "y",
+        }),
+        mockContext,
+      ),
+    ).rejects.toThrow("old_string must not be empty");
   });
 
   it("returns error when old_string equals new_string", async () => {

--- a/src/tools/edit-file.ts
+++ b/src/tools/edit-file.ts
@@ -1,11 +1,18 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { createElement } from "react";
+import { z } from "zod";
 import { WriteFileConfirm } from "../components/write-file-confirm";
 import { isPathWithinCwd } from "../permissions";
 import { formatDiff } from "./format-diff";
 import { registerTool } from "./registry";
-import type { ToolContext } from "./types";
+import { type ToolContext, parseToolArgs } from "./types";
+
+const argsSchema = z.object({
+  path: z.string().min(1, "no file path provided"),
+  old_string: z.string().min(1, "old_string must not be empty"),
+  new_string: z.string(),
+});
 
 function performEdit(filePath: string, content: string): string {
   try {
@@ -40,24 +47,14 @@ registerTool({
     required: ["path", "old_string", "new_string"],
   },
   async execute(args: string, context: ToolContext): Promise<string> {
-    const parsed = JSON.parse(args);
-    const rawPath: string = parsed.path ?? "";
-    const oldString: string = parsed.old_string ?? "";
-    const newString: string = parsed.new_string ?? "";
-
-    if (!rawPath.trim()) {
-      return "Error: no file path provided";
-    }
-
-    if (!oldString) {
-      return "Error: old_string must not be empty";
-    }
+    const parsed = parseToolArgs(argsSchema, args);
+    const { old_string: oldString, new_string: newString } = parsed;
 
     if (oldString === newString) {
       return "Error: old_string and new_string are identical";
     }
 
-    const filePath = resolve(rawPath);
+    const filePath = resolve(parsed.path);
 
     if (!existsSync(filePath)) {
       return `Error: file not found: ${filePath}`;

--- a/src/tools/git.ts
+++ b/src/tools/git.ts
@@ -1,0 +1,14 @@
+import { execSync } from "node:child_process";
+
+/** Check whether a directory is inside a git repository. */
+export function isGitRepo(cwd: string): boolean {
+  try {
+    execSync("git rev-parse --is-inside-work-tree", {
+      cwd,
+      stdio: "pipe",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/tools/glob.test.ts
+++ b/src/tools/glob.test.ts
@@ -84,14 +84,11 @@ describe("glob tool", () => {
     expect(result).toBe("No files matched the pattern.");
   });
 
-  it("returns error for empty pattern", async () => {
+  it("throws for empty pattern", async () => {
     const tool = getTool("glob");
-    const result = await tool?.execute(
-      JSON.stringify({ pattern: "" }),
-      mockContext,
-    );
-
-    expect(result).toBe("Error: no glob pattern provided");
+    await expect(
+      tool?.execute(JSON.stringify({ pattern: "" }), mockContext),
+    ).rejects.toThrow("no glob pattern provided");
   });
 
   it("defaults to cwd when no path provided", async () => {

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -2,10 +2,18 @@ import { execSync } from "node:child_process";
 import { globSync } from "node:fs";
 import { resolve } from "node:path";
 import { createElement } from "react";
+import { z } from "zod";
 import { FileAccessConfirm } from "../components/file-access-confirm";
 import { isPathWithinCwd } from "../permissions";
+import { isGitRepo } from "./git";
 import { registerTool } from "./registry";
-import type { ToolContext } from "./types";
+import { type ToolContext, parseToolArgs } from "./types";
+
+const argsSchema = z.object({
+  pattern: z.string().min(1, "no glob pattern provided"),
+  path: z.string().optional(),
+  gitignore: z.boolean().default(true),
+});
 
 registerTool({
   name: "glob",
@@ -34,16 +42,10 @@ registerTool({
   },
   interactive: false,
   async execute(args: string, context: ToolContext): Promise<string> {
-    const parsed = JSON.parse(args);
-    const pattern: string = parsed.pattern ?? "";
-    const rawPath: string | undefined = parsed.path;
-    const gitignore: boolean = parsed.gitignore ?? true;
+    const parsed = parseToolArgs(argsSchema, args);
+    const { pattern, gitignore } = parsed;
 
-    if (!pattern.trim()) {
-      return "Error: no glob pattern provided";
-    }
-
-    const searchDir = rawPath ? resolve(rawPath) : process.cwd();
+    const searchDir = parsed.path ? resolve(parsed.path) : process.cwd();
 
     // Permission granted and path in cwd — search immediately
     if (context.permissions.read_file && isPathWithinCwd(searchDir)) {
@@ -67,19 +69,6 @@ registerTool({
     return runGlob(pattern, searchDir, gitignore);
   },
 });
-
-/** Check whether a directory is inside a git repository. */
-function isGitRepo(cwd: string): boolean {
-  try {
-    execSync("git rev-parse --is-inside-work-tree", {
-      cwd,
-      stdio: "pipe",
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Use `git ls-files` to list tracked + untracked-but-not-ignored files

--- a/src/tools/grep.test.ts
+++ b/src/tools/grep.test.ts
@@ -97,14 +97,11 @@ describe("grep tool", () => {
     expect(result).toBe("No matches found.");
   });
 
-  it("returns error for empty pattern", async () => {
+  it("throws for empty pattern", async () => {
     const tool = getTool("grep");
-    const result = await tool?.execute(
-      JSON.stringify({ pattern: "" }),
-      mockContext,
-    );
-
-    expect(result).toBe("Error: no search pattern provided");
+    await expect(
+      tool?.execute(JSON.stringify({ pattern: "" }), mockContext),
+    ).rejects.toThrow("no search pattern provided");
   });
 
   it("filters by include glob pattern", async () => {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,10 +1,19 @@
 import { execSync } from "node:child_process";
 import { resolve } from "node:path";
 import { createElement } from "react";
+import { z } from "zod";
 import { FileAccessConfirm } from "../components/file-access-confirm";
 import { isPathWithinCwd } from "../permissions";
+import { isGitRepo } from "./git";
 import { registerTool } from "./registry";
-import type { ToolContext } from "./types";
+import { type ToolContext, parseToolArgs } from "./types";
+
+const argsSchema = z.object({
+  pattern: z.string().min(1, "no search pattern provided"),
+  path: z.string().optional(),
+  include: z.string().optional(),
+  gitignore: z.boolean().default(true),
+});
 
 registerTool({
   name: "grep",
@@ -38,17 +47,10 @@ registerTool({
   },
   interactive: false,
   async execute(args: string, context: ToolContext): Promise<string> {
-    const parsed = JSON.parse(args);
-    const pattern: string = parsed.pattern ?? "";
-    const rawPath: string | undefined = parsed.path;
-    const include: string | undefined = parsed.include;
-    const gitignore: boolean = parsed.gitignore ?? true;
+    const parsed = parseToolArgs(argsSchema, args);
+    const { pattern, include, gitignore } = parsed;
 
-    if (!pattern.trim()) {
-      return "Error: no search pattern provided";
-    }
-
-    const searchDir = rawPath ? resolve(rawPath) : process.cwd();
+    const searchDir = parsed.path ? resolve(parsed.path) : process.cwd();
 
     // Permission granted and path in cwd — search immediately
     if (context.permissions.read_file && isPathWithinCwd(searchDir)) {
@@ -72,19 +74,6 @@ registerTool({
     return runGrep(pattern, searchDir, include, gitignore);
   },
 });
-
-/** Check whether a directory is inside a git repository. */
-function isGitRepo(cwd: string): boolean {
-  try {
-    execSync("git rev-parse --is-inside-work-tree", {
-      cwd,
-      stdio: "pipe",
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function runGrep(
   pattern: string,

--- a/src/tools/read-file.test.ts
+++ b/src/tools/read-file.test.ts
@@ -57,14 +57,11 @@ describe("read_file tool", () => {
     expect(result).toContain("Error: file not found");
   });
 
-  it("returns error for empty path", async () => {
+  it("throws for empty path", async () => {
     const tool = getTool("read_file");
-    const result = await tool?.execute(
-      JSON.stringify({ path: "" }),
-      mockContext,
-    );
-
-    expect(result).toBe("Error: no file path provided");
+    await expect(
+      tool?.execute(JSON.stringify({ path: "" }), mockContext),
+    ).rejects.toThrow("no file path provided");
   });
 
   it("returns error for directories", async () => {

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -1,10 +1,17 @@
 import { readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { createElement } from "react";
+import { z } from "zod";
 import { FileAccessConfirm } from "../components/file-access-confirm";
 import { isPathWithinCwd } from "../permissions";
 import { registerTool } from "./registry";
-import type { ToolContext } from "./types";
+import { type ToolContext, parseToolArgs } from "./types";
+
+const argsSchema = z.object({
+  path: z.string().min(1, "no file path provided"),
+  startLine: z.number().optional(),
+  endLine: z.number().optional(),
+});
 
 const MAX_LINES = 500;
 
@@ -81,16 +88,10 @@ registerTool({
   },
   interactive: false,
   async execute(args: string, context: ToolContext): Promise<string> {
-    const parsed = JSON.parse(args);
-    const rawPath: string = parsed.path ?? "";
-    const startLine: number | undefined = parsed.startLine;
-    const endLine: number | undefined = parsed.endLine;
+    const parsed = parseToolArgs(argsSchema, args);
+    const { startLine, endLine } = parsed;
 
-    if (!rawPath.trim()) {
-      return "Error: no file path provided";
-    }
-
-    const filePath = resolve(rawPath);
+    const filePath = resolve(parsed.path);
 
     // Permission granted and path in cwd — read immediately
     if (context.permissions.read_file && isPathWithinCwd(filePath)) {

--- a/src/tools/run-command.test.ts
+++ b/src/tools/run-command.test.ts
@@ -25,7 +25,7 @@ describe("run_command tool", () => {
     });
   });
 
-  it("returns error when no command provided", async () => {
+  it("throws when no command provided", async () => {
     const tool = getTool("run_command");
     const context = {
       renderInteractive: vi.fn(),
@@ -33,11 +33,9 @@ describe("run_command tool", () => {
       permissions: {},
     };
 
-    const result = await tool?.execute(
-      JSON.stringify({ command: "" }),
-      context,
-    );
-    expect(result).toBe("Error: no command provided");
+    await expect(
+      tool?.execute(JSON.stringify({ command: "" }), context),
+    ).rejects.toThrow("no command provided");
     expect(context.renderInteractive).not.toHaveBeenCalled();
   });
 

--- a/src/tools/run-command.ts
+++ b/src/tools/run-command.ts
@@ -1,8 +1,13 @@
 import { spawn } from "node:child_process";
 import { createElement } from "react";
+import { z } from "zod";
 import { CommandConfirm } from "../components/command-confirm";
 import { registerTool } from "./registry";
-import type { ToolContext } from "./types";
+import { type ToolContext, parseToolArgs } from "./types";
+
+const argsSchema = z.object({
+  command: z.string().min(1, "no command provided"),
+});
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -67,12 +72,7 @@ registerTool({
     required: ["command"],
   },
   async execute(args: string, context: ToolContext): Promise<string> {
-    const parsed = JSON.parse(args);
-    const command: string = parsed.command ?? "";
-
-    if (!command.trim()) {
-      return "Error: no command provided";
-    }
+    const { command } = parseToolArgs(argsSchema, args);
 
     const approved = await context.renderInteractive((onResult, _onCancel) =>
       createElement(CommandConfirm, {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import type { z } from "zod";
 import type { ToolDefinition } from "../provider/client";
 
 /** Context provided to a tool's execute function. */
@@ -28,6 +29,20 @@ export interface Tool {
   /** Returns a warning message when the tool is enabled but misconfigured, or undefined if OK. */
   warning?: () => string | undefined;
   execute: (args: string, context: ToolContext) => Promise<string>;
+}
+
+/** Parse and validate tool arguments against a Zod schema. Throws with a clean message on failure. */
+export function parseToolArgs<T extends z.ZodType>(
+  schema: T,
+  args: string,
+): z.infer<T> {
+  const json = JSON.parse(args);
+  const result = schema.safeParse(json);
+  if (!result.success) {
+    const messages = result.error.issues.map((i) => i.message);
+    throw new Error(messages.join("; "));
+  }
+  return result.data;
 }
 
 /** Converts a Tool to the OpenAI tool definition format for the API request. */

--- a/src/tools/web-search.test.ts
+++ b/src/tools/web-search.test.ts
@@ -34,15 +34,12 @@ describe("web_search tool", () => {
     expect(tool?.enabled).toBe(false);
   });
 
-  it("returns error for empty query", async () => {
+  it("throws for empty query", async () => {
     process.env.TAVILY_API_KEY = "test-key";
     const tool = getTool("web_search");
-    const result = await tool?.execute(
-      JSON.stringify({ query: "" }),
-      mockContext,
-    );
-
-    expect(result).toBe("Error: no search query provided");
+    await expect(
+      tool?.execute(JSON.stringify({ query: "" }), mockContext),
+    ).rejects.toThrow("no search query provided");
   });
 
   it("returns error when TAVILY_API_KEY is not set", async () => {

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,7 +1,12 @@
+import { z } from "zod";
 import { registerTool } from "./registry";
-import type { ToolContext } from "./types";
+import { type ToolContext, parseToolArgs } from "./types";
 
 const TAVILY_API_URL = "https://api.tavily.com/search";
+
+const argsSchema = z.object({
+  query: z.string().min(1, "no search query provided"),
+});
 
 registerTool({
   name: "web_search",
@@ -24,12 +29,7 @@ registerTool({
       ? undefined
       : "TAVILY_API_KEY env var is not set",
   async execute(args: string, _context: ToolContext): Promise<string> {
-    const parsed = JSON.parse(args);
-    const query: string = parsed.query ?? "";
-
-    if (!query.trim()) {
-      return "Error: no search query provided";
-    }
+    const { query } = parseToolArgs(argsSchema, args);
 
     const apiKey = process.env.TAVILY_API_KEY;
     if (!apiKey) {

--- a/src/tools/write-file.test.ts
+++ b/src/tools/write-file.test.ts
@@ -72,14 +72,11 @@ describe("write_file tool", () => {
     expect(readFileSync(filePath, "utf-8")).toBe("deep\n");
   });
 
-  it("returns error for empty path", async () => {
+  it("throws for empty path", async () => {
     const tool = getTool("write_file");
-    const result = await tool?.execute(
-      JSON.stringify({ path: "", content: "x" }),
-      mockContext,
-    );
-
-    expect(result).toBe("Error: no file path provided");
+    await expect(
+      tool?.execute(JSON.stringify({ path: "", content: "x" }), mockContext),
+    ).rejects.toThrow("no file path provided");
     expect(mockContext.renderInteractive).not.toHaveBeenCalled();
   });
 

--- a/src/tools/write-file.ts
+++ b/src/tools/write-file.ts
@@ -1,11 +1,17 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { createElement } from "react";
+import { z } from "zod";
 import { WriteFileConfirm } from "../components/write-file-confirm";
 import { isPathWithinCwd } from "../permissions";
 import { formatDiff, formatNewFile } from "./format-diff";
 import { registerTool } from "./registry";
-import type { ToolContext } from "./types";
+import { type ToolContext, parseToolArgs } from "./types";
+
+const argsSchema = z.object({
+  path: z.string().min(1, "no file path provided"),
+  content: z.string(),
+});
 
 function performWrite(filePath: string, content: string): string {
   try {
@@ -36,15 +42,10 @@ registerTool({
     required: ["path", "content"],
   },
   async execute(args: string, context: ToolContext): Promise<string> {
-    const parsed = JSON.parse(args);
-    const rawPath: string = parsed.path ?? "";
-    const content: string = parsed.content ?? "";
+    const parsed = parseToolArgs(argsSchema, args);
+    const { content } = parsed;
 
-    if (!rawPath.trim()) {
-      return "Error: no file path provided";
-    }
-
-    const filePath = resolve(rawPath);
+    const filePath = resolve(parsed.path);
 
     // Skip confirmation if permission granted and path is within cwd
     if (context.permissions.write_file && isPathWithinCwd(filePath)) {


### PR DESCRIPTION
## Summary

Prepares the codebase for open-source distribution by adding a license, hardening tool argument
validation, and fixing a minor security concern with the PAGER env var.

## GitHub Issue

N/A

## What Changed

**MIT License** — Added a LICENSE file. The publish workflow already referenced MIT in the Homebrew
formula but the actual file was missing from the repo.

**Zod-based tool argument validation** — All 8 tools (read_file, write_file, edit_file, glob, grep,
run_command, ask, web_search) previously used raw `JSON.parse()` with manual field extraction and
ad-hoc validation. Each tool now declares a Zod schema and validates through a shared
`parseToolArgs()` helper in `types.ts`. Invalid arguments throw with clean error messages that the
existing `executeSingleToolCall` catch handler converts to tool error results. Tests updated to
expect thrown errors.

**PAGER whitelist** — The Tab-to-pager feature used `process.env.PAGER` directly in `spawnSync()`.
Now validates against a whitelist of known pagers (less, more, most, bat, cat) and silently no-ops
for unrecognised values.

**Shared `isGitRepo()` utility** — Extracted the identical function from both `glob.ts` and
`grep.ts` into a new `git.ts` module.