### PR TITLE
ci(release): improve release drafter reliability for squash merges

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,13 +13,15 @@ permissions:
 
 jobs:
   update-release-draft:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v6
+        with:
+          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Fixes release drafter not picking up squash-merged PRs in draft release notes.

## GitHub Issue

N/A

## What Changed

Release drafter was producing empty "No changes" drafts despite PRs being merged after the previous
release. Investigation showed the action found the correct commits but matched zero PRs — likely a
race condition where the push event fires seconds after merge and the action queries before GitHub
fully indexes the squash commit-to-PR association.

Two changes to improve reliability:

- **`commitish: main`** — explicitly targets the main branch for commit resolution rather than
  relying on push event context
- **`workflow_dispatch`** — allows manual re-triggering when the automatic run misses PRs, with the
  job condition updated to also run on dispatch events