### PR TITLE
refactor: load config once per submit instead of twice

### DIFF
--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -375,11 +375,13 @@ export function useChat(
     // re-call to the provider includes prior tool results.
     let currentMessages: DisplayMessage[] = [...messages, userMsg];
 
+    // Reload config from disk so we pick up changes from /grant and /tools.
+    const freshConfig = loadConfig();
     const maxTokens = getMaxTokens(config, activeProvider, activeModel);
-    const toolAvailability = resolveToolAvailability(loadConfig().tools);
+    const toolAvailability = resolveToolAvailability(freshConfig.tools);
     const toolDefs = getToolDefinitions(toolAvailability);
 
-    const permissions = resolvePermissions(loadConfig().permissions);
+    const permissions = resolvePermissions(freshConfig.permissions);
 
     const toolContext: ToolContext = {
       renderInteractive: (factory) =>


### PR DESCRIPTION
## Summary

Eliminates a redundant disk read by loading config once per submit instead of twice.

## GitHub Issue

N/A

## What Changed

The submit flow in `useChat` called `loadConfig()` separately for tool availability (line 379) and
permissions (line 382), reading and parsing config from disk twice per turn. Now loads once into
`freshConfig` and reuses the result for both.

Config is intentionally reloaded from disk each submit (rather than using the `config` prop) because
`/grant` and `/tools` commands write updated config to disk mid-session.