### PR TITLE
refactor(chat-input): extract autocomplete into reusable hook with scrolling

### DIFF
--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 import chalk from "chalk";
 import { Box, Text, useApp, useInput, useStdout } from "ink";
 import { getAllCommands } from "../commands";
+import {
+  type AutocompleteProvider,
+  useAutocomplete,
+} from "../hooks/use-autocomplete";
 
 interface ChatInputProps {
   onSubmit: (text: string) => void;
@@ -11,7 +15,16 @@ interface ChatInputProps {
   contextPercent?: number | null;
 }
 
-const MAX_SUGGESTIONS = 5;
+const commandProvider: AutocompleteProvider = {
+  prefix: "/",
+  items: () =>
+    getAllCommands().map((cmd) => ({
+      name: cmd.name,
+      description: cmd.description,
+    })),
+};
+
+const defaultProviders: AutocompleteProvider[] = [commandProvider];
 
 function findPrevWordBoundary(text: string, pos: number): number {
   let i = pos - 1;
@@ -50,21 +63,8 @@ export function ChatInput({
     };
   }, [stdout]);
 
-  const isAutocomplete = value.startsWith("/") && !value.includes(" ");
-  const partial = isAutocomplete ? value.slice(1) : "";
-  const matches = isAutocomplete
-    ? getAllCommands()
-        .filter((cmd) => cmd.name.startsWith(partial))
-        .slice(0, MAX_SUGGESTIONS)
-    : [];
-  const topMatch = matches[0];
-  const ghost =
-    topMatch && partial.length > 0
-      ? topMatch.name.slice(partial.length)
-      : topMatch
-        ? topMatch.name
-        : "";
-  const showGhost = isAutocomplete && ghost && cursor === value.length;
+  const autocomplete = useAutocomplete(defaultProviders, value, cursor);
+  const { active: isAutocomplete, ghost, showGhost } = autocomplete;
 
   useInput((input, key) => {
     const isCtrlC = input === "c" && key.ctrl;
@@ -121,8 +121,12 @@ export function ChatInput({
       return;
     }
 
-    // Vertical cursor movement across lines
+    // Vertical cursor movement — autocomplete navigation or multi-line movement
     if (key.upArrow) {
+      if (isAutocomplete && autocomplete.visibleEntries.length > 0) {
+        autocomplete.moveUp();
+        return;
+      }
       const lineStart = value.lastIndexOf("\n", cursor - 1);
       if (lineStart >= 0) {
         const col = cursor - lineStart - 1;
@@ -134,6 +138,10 @@ export function ChatInput({
       return;
     }
     if (key.downArrow) {
+      if (isAutocomplete && autocomplete.visibleEntries.length > 0) {
+        autocomplete.moveDown();
+        return;
+      }
       const lineStart = value.lastIndexOf("\n", cursor - 1) + 1;
       const col = cursor - lineStart;
       const nextLineBreak = value.indexOf("\n", cursor);
@@ -171,8 +179,8 @@ export function ChatInput({
       if (key.shift) {
         setValue((v) => `${v.slice(0, cursor)}\n${v.slice(cursor)}`);
         setCursor((c) => c + 1);
-      } else if (isAutocomplete && topMatch) {
-        onSubmit(`/${topMatch.name}`);
+      } else if (isAutocomplete && autocomplete.submitValue) {
+        onSubmit(autocomplete.submitValue);
         setValue("");
         setCursor(0);
       } else if (value.trim()) {
@@ -249,16 +257,18 @@ export function ChatInput({
         {"─".repeat(bottomLineWidth)}
         {contextLabel}
       </Text>
-      {isAutocomplete && matches.length > 0 ? (
+      {isAutocomplete && autocomplete.visibleEntries.length > 0 ? (
         <Box flexDirection="column">
-          {matches.map((cmd, i) => (
+          {autocomplete.visibleEntries.map((entry, i) => (
             <Text
-              key={cmd.name}
-              color={i === 0 ? "cyan" : undefined}
-              dimColor={i !== 0}
+              key={entry.name}
+              color={
+                i === autocomplete.visibleSelectedIndex ? "cyan" : undefined
+              }
+              dimColor={i !== autocomplete.visibleSelectedIndex}
             >
               {"  "}
-              {`/${cmd.name}`} — {cmd.description}
+              {`${autocomplete.prefix}${entry.name}`} — {entry.description}
             </Text>
           ))}
         </Box>

--- a/src/hooks/use-autocomplete.test.tsx
+++ b/src/hooks/use-autocomplete.test.tsx
@@ -1,0 +1,302 @@
+import { useState } from "react";
+import { render } from "ink-testing-library";
+import { Text } from "ink";
+import { describe, expect, it } from "vitest";
+import {
+  type AutocompleteProvider,
+  type AutocompleteState,
+  useAutocomplete,
+} from "./use-autocomplete";
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+
+const testItems = [
+  { name: "context", description: "Show context" },
+  { name: "grant", description: "Grant permissions" },
+  { name: "help", description: "Show help" },
+  { name: "history", description: "Show history" },
+  { name: "model", description: "Switch model" },
+  { name: "new", description: "New session" },
+  { name: "session", description: "Manage sessions" },
+  { name: "status", description: "Show status" },
+];
+
+const providers: AutocompleteProvider[] = [
+  { prefix: "/", items: () => testItems },
+];
+
+interface HarnessControls {
+  state: AutocompleteState | null;
+  setValue: (v: string) => void;
+}
+
+function Harness({
+  providers,
+  controls,
+}: {
+  providers: AutocompleteProvider[];
+  controls: HarnessControls;
+}) {
+  const [value, setValue] = useState("");
+  const [cursor, setCursor] = useState(0);
+  const state = useAutocomplete(providers, value, cursor);
+  controls.state = state;
+  controls.setValue = (v: string) => {
+    setValue(v);
+    setCursor(v.length);
+  };
+
+  return <Text>{JSON.stringify({ active: state.active })}</Text>;
+}
+
+function setup(providerList: AutocompleteProvider[] = providers) {
+  const controls: HarnessControls = {
+    state: null,
+    setValue: () => {},
+  };
+  render(<Harness providers={providerList} controls={controls} />);
+  return controls;
+}
+
+describe("useAutocomplete", () => {
+  it("is inactive for non-prefixed input", async () => {
+    const c = setup();
+    c.setValue("hello");
+    await flush();
+    expect(c.state?.active).toBe(false);
+    expect(c.state?.visibleEntries).toHaveLength(0);
+  });
+
+  it("activates when input starts with the prefix", async () => {
+    const c = setup();
+    c.setValue("/");
+    await flush();
+    expect(c.state?.active).toBe(true);
+    expect(c.state?.prefix).toBe("/");
+  });
+
+  it("shows matches at the top of visible entries", async () => {
+    const c = setup();
+    c.setValue("/h");
+    await flush();
+    const names = c.state?.visibleEntries.map((e) => e.name) ?? [];
+    // "help" and "history" match, then non-matches follow
+    expect(names[0]).toBe("help");
+    expect(names[1]).toBe("history");
+    // Non-matches fill the rest of the window
+    expect(c.state?.visibleEntries).toHaveLength(5);
+    expect(c.state?.visibleEntries[0].matched).toBe(true);
+    expect(c.state?.visibleEntries[1].matched).toBe(true);
+    expect(c.state?.visibleEntries[2].matched).toBe(false);
+  });
+
+  it("shows all items as matches when only prefix is typed", async () => {
+    const c = setup();
+    c.setValue("/");
+    await flush();
+    // All 8 items match, window shows first 5
+    expect(c.state?.visibleEntries).toHaveLength(5);
+    expect(c.state?.visibleEntries.every((e) => e.matched)).toBe(true);
+  });
+
+  it("shows no entries when nothing matches", async () => {
+    const c = setup();
+    c.setValue("/zzz");
+    await flush();
+    expect(c.state?.active).toBe(true);
+    expect(c.state?.visibleEntries).toHaveLength(0);
+    expect(c.state?.submitValue).toBeNull();
+  });
+
+  it("computes ghost text from the selected match", async () => {
+    const c = setup();
+    c.setValue("/he");
+    await flush();
+    expect(c.state?.ghost).toBe("lp");
+    expect(c.state?.showGhost).toBe(true);
+  });
+
+  it("shows full name as ghost when only prefix is typed", async () => {
+    const c = setup();
+    c.setValue("/");
+    await flush();
+    expect(c.state?.ghost).toBe("context");
+  });
+
+  it("clears ghost text when a non-match is selected", async () => {
+    const c = setup();
+    c.setValue("/he");
+    await flush();
+    // Navigate past the 2 matches into non-matches
+    c.state?.moveDown();
+    await flush();
+    c.state?.moveDown();
+    await flush();
+    expect(c.state?.visibleEntries[c.state.visibleSelectedIndex].matched).toBe(
+      false,
+    );
+    expect(c.state?.ghost).toBe("");
+  });
+
+  it("returns submitValue with prefix + selected name", async () => {
+    const c = setup();
+    c.setValue("/he");
+    await flush();
+    expect(c.state?.submitValue).toBe("/help");
+  });
+
+  it("deactivates when input contains a space", async () => {
+    const c = setup();
+    c.setValue("/help ");
+    await flush();
+    expect(c.state?.active).toBe(false);
+  });
+
+  it("moveDown cycles through all entries", async () => {
+    const c = setup();
+    c.setValue("/h");
+    await flush();
+    expect(c.state?.visibleSelectedIndex).toBe(0);
+    expect(c.state?.submitValue).toBe("/help");
+
+    c.state?.moveDown();
+    await flush();
+    expect(c.state?.visibleSelectedIndex).toBe(1);
+    expect(c.state?.submitValue).toBe("/history");
+
+    // Navigate into non-matches
+    c.state?.moveDown();
+    await flush();
+    expect(c.state?.submitValue).toBe("/context");
+  });
+
+  it("moveUp wraps from first to last", async () => {
+    const c = setup();
+    c.setValue("/he");
+    await flush();
+    expect(c.state?.visibleSelectedIndex).toBe(0);
+
+    c.state?.moveUp();
+    await flush();
+    // Wraps to last entry (8 total: 2 matches + 6 non-matches)
+    expect(c.state?.submitValue).toBe("/status");
+  });
+
+  it("moveDown wraps from last to first", async () => {
+    setup();
+    // Use a small set so we can reach the end easily
+    const smallProviders: AutocompleteProvider[] = [
+      {
+        prefix: "/",
+        items: () => [
+          { name: "aa", description: "A" },
+          { name: "ab", description: "B" },
+        ],
+      },
+    ];
+    const c2 = setup(smallProviders);
+    c2.setValue("/a");
+    await flush();
+    // Both match, navigate to last then wrap
+    c2.state?.moveDown();
+    await flush();
+    expect(c2.state?.visibleSelectedIndex).toBe(1);
+    c2.state?.moveDown();
+    await flush();
+    expect(c2.state?.visibleSelectedIndex).toBe(0);
+  });
+
+  it("resets selection when value changes", async () => {
+    const c = setup();
+    c.setValue("/h");
+    await flush();
+    c.state?.moveDown();
+    await flush();
+    expect(c.state?.visibleSelectedIndex).toBe(1);
+
+    c.setValue("/he");
+    await flush();
+    expect(c.state?.visibleSelectedIndex).toBe(0);
+  });
+
+  it("scrolls the window when navigating past visible entries", async () => {
+    const c = setup();
+    c.setValue("/");
+    await flush();
+    // 8 items total, window shows 5. Navigate down to item 5 (index 4 is last visible)
+    const names = () => c.state?.visibleEntries.map((e) => e.name) ?? [];
+    expect(names()[0]).toBe("context");
+
+    // Navigate to index 5 (6th item, should scroll)
+    for (let i = 0; i < 5; i++) {
+      c.state?.moveDown();
+      await flush();
+    }
+    // Window should have scrolled to keep selection visible
+    expect(c.state?.visibleSelectedIndex).toBeGreaterThanOrEqual(0);
+    expect(c.state?.visibleSelectedIndex).toBeLessThan(5);
+    expect(names()).toContain("new");
+  });
+
+  it("scrolls up when navigating above visible window", async () => {
+    const c = setup();
+    c.setValue("/");
+    await flush();
+    // Navigate down past the window
+    for (let i = 0; i < 6; i++) {
+      c.state?.moveDown();
+      await flush();
+    }
+    // Now navigate back up
+    for (let i = 0; i < 6; i++) {
+      c.state?.moveUp();
+      await flush();
+    }
+    // Should be back at the top
+    expect(c.state?.visibleSelectedIndex).toBe(0);
+    expect(c.state?.visibleEntries[0].name).toBe("context");
+  });
+
+  it("ghost text reflects the selected matched item after navigation", async () => {
+    const c = setup();
+    c.setValue("/h");
+    await flush();
+    expect(c.state?.ghost).toBe("elp");
+
+    c.state?.moveDown();
+    await flush();
+    expect(c.state?.ghost).toBe("istory");
+  });
+
+  it("matches the longest prefix first", async () => {
+    const skillItems = [{ name: "review", description: "Review code" }];
+    const multiProviders: AutocompleteProvider[] = [
+      { prefix: "/", items: () => testItems },
+      { prefix: "//", items: () => skillItems },
+    ];
+
+    const c = setup(multiProviders);
+
+    c.setValue("//r");
+    await flush();
+    expect(c.state?.active).toBe(true);
+    expect(c.state?.prefix).toBe("//");
+    expect(c.state?.visibleEntries[0].name).toBe("review");
+    expect(c.state?.submitValue).toBe("//review");
+  });
+
+  it("falls back to shorter prefix when longer does not match", async () => {
+    const skillItems = [{ name: "review", description: "Review code" }];
+    const multiProviders: AutocompleteProvider[] = [
+      { prefix: "/", items: () => testItems },
+      { prefix: "//", items: () => skillItems },
+    ];
+
+    const c = setup(multiProviders);
+
+    c.setValue("/h");
+    await flush();
+    expect(c.state?.prefix).toBe("/");
+    expect(c.state?.visibleEntries[0].name).toBe("help");
+  });
+});

--- a/src/hooks/use-autocomplete.ts
+++ b/src/hooks/use-autocomplete.ts
@@ -1,0 +1,145 @@
+import { useRef, useState } from "react";
+
+export interface AutocompleteItem {
+  name: string;
+  description: string;
+}
+
+export interface AutocompleteEntry extends AutocompleteItem {
+  matched: boolean;
+}
+
+export interface AutocompleteProvider {
+  prefix: string;
+  items: () => AutocompleteItem[];
+}
+
+export interface AutocompleteState {
+  /** Whether autocomplete mode is active. */
+  active: boolean;
+  /** The matched prefix ("/" or "//"). */
+  prefix: string;
+  /** Entries visible in the current scroll window. */
+  visibleEntries: AutocompleteEntry[];
+  /** Index of the selected entry within visibleEntries. */
+  visibleSelectedIndex: number;
+  /** Ghost text to append after the input. */
+  ghost: string;
+  /** Whether the ghost text should be displayed. */
+  showGhost: boolean;
+  /** The full string to submit (prefix + selected name), or null if no match. */
+  submitValue: string | null;
+  /** Move the selection up (wraps around). */
+  moveUp: () => void;
+  /** Move the selection down (wraps around). */
+  moveDown: () => void;
+}
+
+const MAX_VISIBLE = 5;
+
+/**
+ * Reusable autocomplete hook. Accepts multiple providers (each with a prefix
+ * and items function) and returns match state with up/down keyboard navigation.
+ *
+ * Matches are sorted to the top, non-matches below. A scrolling window of
+ * MAX_VISIBLE entries follows the selection. Providers are checked
+ * longest-prefix-first so "//" is matched before "/".
+ */
+export function useAutocomplete(
+  providers: AutocompleteProvider[],
+  value: string,
+  cursor: number,
+): AutocompleteState {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const prevValueRef = useRef(value);
+  const windowStartRef = useRef(0);
+
+  // Reset selection and scroll when input changes.
+  if (prevValueRef.current !== value) {
+    prevValueRef.current = value;
+    setSelectedIndex(0);
+    windowStartRef.current = 0;
+  }
+
+  // Match the provider whose prefix fits (longest first).
+  const sorted = [...providers].sort(
+    (a, b) => b.prefix.length - a.prefix.length,
+  );
+
+  let activeProvider: AutocompleteProvider | null = null;
+  for (const provider of sorted) {
+    if (value.startsWith(provider.prefix) && !value.includes(" ")) {
+      activeProvider = provider;
+      break;
+    }
+  }
+
+  const active = activeProvider !== null;
+  const prefix = activeProvider?.prefix ?? "";
+  const partial = active ? value.slice(prefix.length) : "";
+  const allItems = active ? (activeProvider?.items() ?? []) : [];
+
+  // Matches first, then non-matches. Only show non-matches when there are matches.
+  const matched = allItems.filter((item) => item.name.startsWith(partial));
+  const unmatched =
+    matched.length > 0
+      ? allItems.filter((item) => !item.name.startsWith(partial))
+      : [];
+  const entries: AutocompleteEntry[] = [
+    ...matched.map((item) => ({ ...item, matched: true })),
+    ...unmatched.map((item) => ({ ...item, matched: false })),
+  ];
+
+  // Clamp index so it never exceeds the entry list.
+  const clamped =
+    entries.length > 0 ? Math.min(selectedIndex, entries.length - 1) : 0;
+  const selectedEntry = entries[clamped];
+
+  // Scroll window to keep selection visible.
+  if (clamped < windowStartRef.current) {
+    windowStartRef.current = clamped;
+  } else if (clamped >= windowStartRef.current + MAX_VISIBLE) {
+    windowStartRef.current = clamped - MAX_VISIBLE + 1;
+  }
+  windowStartRef.current = Math.min(
+    windowStartRef.current,
+    Math.max(0, entries.length - MAX_VISIBLE),
+  );
+
+  const visibleStart = windowStartRef.current;
+  const visibleEntries = entries.slice(
+    visibleStart,
+    visibleStart + MAX_VISIBLE,
+  );
+  const visibleSelectedIndex = clamped - visibleStart;
+
+  // Ghost text only for matched entries.
+  const ghost =
+    selectedEntry?.matched && partial.length > 0
+      ? selectedEntry.name.slice(partial.length)
+      : selectedEntry?.matched
+        ? selectedEntry.name
+        : "";
+  const showGhost = active && !!ghost && cursor === value.length;
+  const submitValue = selectedEntry ? `${prefix}${selectedEntry.name}` : null;
+
+  const moveUp = () => {
+    setSelectedIndex((i) => (i > 0 ? i - 1 : entries.length - 1));
+  };
+
+  const moveDown = () => {
+    setSelectedIndex((i) => (i < entries.length - 1 ? i + 1 : 0));
+  };
+
+  return {
+    active,
+    prefix,
+    visibleEntries,
+    visibleSelectedIndex,
+    ghost,
+    showGhost,
+    submitValue,
+    moveUp,
+    moveDown,
+  };
+}


### PR DESCRIPTION
## Summary

Extracts the inline autocomplete logic from ChatInput into a standalone `useAutocomplete` hook.
The hook supports multiple providers (e.g. `/` for commands, `//` for skills), enabling the
upcoming skills feature to share the same autocomplete infrastructure.

## GitHub Issue

N/A

## What Changed

The autocomplete logic (prefix detection, filtering, ghost text, submit value) has been pulled
out of ChatInput into `src/hooks/use-autocomplete.ts`. The hook introduces two improvements
over the previous inline implementation:

- **Multi-provider support** — providers are matched longest-prefix-first, so `//` (skills)
  takes priority over `/` (commands). Adding a new autocomplete source is just adding a
  provider to the array.
- **Scrolling window with navigation** — matches sort to the top with non-matches below.
  A 5-item visible window scrolls as the user navigates with up/down arrows (wrapping at
  boundaries). The selected item is highlighted in cyan; ghost text only appears for matched
  entries.

ChatInput now consumes the hook and delegates arrow-key handling: up/down navigate suggestions
when autocomplete is active, falling back to multi-line cursor movement otherwise.

19 tests cover the hook directly (activation, filtering, navigation, scrolling, multi-provider
prefix priority). All 31 existing ChatInput tests continue to pass.