### PR TITLE
feat(chat-input): add delete previous word keybindings

### DIFF
--- a/src/components/chat-input.test.tsx
+++ b/src/components/chat-input.test.tsx
@@ -385,6 +385,59 @@ describe("ChatInput", () => {
     expect(onSubmit).toHaveBeenCalledWith("helloX world");
   });
 
+  it("Ctrl+W deletes previous word", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("hello world foo");
+    await flush();
+    stdin.write("\x17"); // Ctrl+W
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("hello world ");
+  });
+
+  it("Ctrl+W deletes previous word from middle of text", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("hello world foo");
+    await flush();
+    // Move cursor back to end of "world" (skip " foo" = 4 chars)
+    stdin.write("\x1B[D\x1B[D\x1B[D\x1B[D");
+    await flush();
+    stdin.write("\x17"); // Ctrl+W
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("hello  foo");
+  });
+
+  it("Option+Backspace deletes previous word", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("hello world foo");
+    await flush();
+    stdin.write("\x1b\x7f"); // Option+Backspace
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("hello world ");
+  });
+
+  it("Ctrl+W does nothing at start of input", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    stdin.write("hello");
+    await flush();
+    stdin.write("\x01"); // Ctrl+A — go to start
+    await flush();
+    stdin.write("\x17"); // Ctrl+W
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("hello");
+  });
+
   it("Ctrl+C shows exit warning when disabled", async () => {
     const onEscape = vi.fn();
     const { lastFrame, stdin } = render(

--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -210,7 +210,23 @@ export function ChatInput({
       return;
     }
 
-    if (key.backspace || key.delete) {
+    // Delete previous word: Ctrl+Backspace, Option+Backspace, Ctrl+W
+    // Ink maps \x08 (Ctrl+Backspace) to key.backspace, \x7f (regular Backspace)
+    // to key.delete, and \x1b\x7f (Option+Backspace) to key.delete + key.meta.
+    if (
+      key.backspace ||
+      (key.delete && (key.ctrl || key.meta)) ||
+      (input === "w" && key.ctrl)
+    ) {
+      if (cursor > 0) {
+        const boundary = findPrevWordBoundary(value, cursor);
+        setValue((v) => v.slice(0, boundary) + v.slice(cursor));
+        setCursor(boundary);
+      }
+      return;
+    }
+
+    if (key.delete) {
       if (cursor > 0) {
         setValue((v) => v.slice(0, cursor - 1) + v.slice(cursor));
         setCursor((c) => c - 1);


### PR DESCRIPTION
## Summary

Adds delete-previous-word support to the chat input via Ctrl+Backspace, Option+Backspace, and Ctrl+W. Reuses the existing `findPrevWordBoundary` helper.

## GitHub Issue

N/A

## What Changed

Ink has a quirk where `\x7f` (regular Backspace) maps to `key.delete` and `\x08` (Ctrl+Backspace) maps to `key.backspace`. The previous code handled both under a single `key.backspace || key.delete` branch for single-character deletion.

This PR splits them apart: `key.backspace`, `key.delete + key.meta` (Option+Backspace), `key.delete + key.ctrl` (kitty protocol), and Ctrl+W now trigger word deletion via `findPrevWordBoundary`. Plain `key.delete` remains single-character deletion.

Four tests cover: word delete at end, word delete from middle, Option+Backspace, and no-op at cursor position 0.