### PR TITLE
feat(images): add multi-modal image support for vision-capable models

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ Instruction content loaded as context when the skill is invoked.
 
 Use `/skills` to list available skills. The model will automatically load relevant skills when appropriate, or you can ask it to use a specific skill.
 
+## Images
+
+Tomo supports sending images to vision-capable models (e.g. Qwen 2.5 VL).
+
+- **Paste a file** — copy an image file in Finder and `Cmd+V` in tomo. The file path is detected and the image is auto-attached.
+- **Paste a screenshot** — take a screenshot or copy image content, then press `Ctrl+V` to attach from clipboard (macOS).
+
+Attached images appear in the bottom bar as `[Img 1][Img 2]` etc. Press `↓` to navigate into images, `←→` to select, and `⌫` to remove.
+
 ## Sessions
 
 Conversations are saved automatically. Use `/session` to browse or `/session <id>` to resume.

--- a/docs/adr/0010-clipboard-image-paste-via-osascript.md
+++ b/docs/adr/0010-clipboard-image-paste-via-osascript.md
@@ -1,0 +1,55 @@
+# 10. Image paste: file path detection and osascript clipboard
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Tomo needs to attach images to messages for vision-capable models. There are two distinct user workflows:
+
+1. **Copy a file in Finder, paste in terminal** — the terminal receives the file path as text, not the image data. Reading the clipboard's `«class PNGf»` in this case yields the file's icon, not its content.
+2. **Take a screenshot or copy image content from an app** — the clipboard contains raw image data (no file path pasted).
+
+Node.js has no built-in API for reading binary clipboard contents. The application runs inside an Ink (React for terminal) render loop, so any clipboard access must not corrupt terminal output.
+
+Alternatives considered for clipboard image data:
+
+1. **`pbpaste`** — macOS built-in, but only outputs text clipboard contents. Cannot read image data.
+2. **`pngpaste`** — Third-party CLI that reads clipboard images to a file. Works well but requires users to install an extra dependency.
+3. **Native Node addon** — Would require a compiled native module, complicating the single-binary distribution via Node SEA (see ADR-0004).
+4. **`osascript` (AppleScript)** — macOS built-in. Can extract raw image data as PNG via `the clipboard as «class PNGf»`. No extra dependencies.
+
+## Decision
+
+Use two complementary strategies:
+
+### 1. File path detection via Cmd+V (cross-platform)
+
+When text is entered in the chat input, the character handler checks whether the accumulated value ends with an absolute path to an image file (`/path/to/image.png` or `~/path/to/image.png`). If the file exists and has a supported image extension, it is read from disk, attached as an image, and the path text is stripped from the input.
+
+This handles the "Copy as Pathname" workflow (Option+Cmd+C in Finder, then Cmd+V in terminal). The backward-scanning algorithm tries each `/` position and checks `existsSync`, handling paths with spaces and any preceding character (e.g. `question?/path/to/image.png`).
+
+A `useRef` tracks the accumulated value/cursor across React's batched state updates, since Ink fires `useInput` per character during a paste but React batches the `setValue` calls, making the closure value stale.
+
+### 2. Ctrl+V clipboard read (macOS only)
+
+`Ctrl+V` triggers two strategies in order via `readClipboardImage()`:
+
+**a) File reference detection via JXA** — uses `osascript -l JavaScript` with the ObjC bridge to access `NSPasteboard`, checking for `public.file-url` entries. If a file URL is found and points to an image, the file is read directly from disk. This handles files copied in Finder with Cmd+C, avoiding the `«class PNGf»` icon data.
+
+**b) Raw image data via AppleScript** — falls back to reading `«class PNGf»` clipboard data for screenshots and image content copied from apps. Writes to a temp file, reads, base64-encodes, and cleans up.
+
+All `execSync` calls use `stdio: ["pipe", "pipe", "pipe"]` to prevent output from corrupting Ink's terminal rendering.
+
+On non-macOS platforms, `readClipboardImage()` returns `null` immediately. Linux and Windows support can be added later using `xclip`/`xsel` and PowerShell respectively.
+
+## Consequences
+
+- **File path detection is cross-platform** — works on any OS where the terminal pastes file paths as text.
+- **Ctrl+V clipboard access is macOS only** for now. Silently does nothing on other platforms.
+- **Blocking I/O** — `existsSync`/`readFileSync` run per character when the value ends with an image extension (fast, < 1ms). `execSync` runs on Ctrl+V (< 100ms). Both are acceptable for user-initiated actions.
+- **No extra dependencies** — works out of the box on macOS.
+- **Handles paths with spaces** — the backward-scanning path detection correctly handles macOS file names with spaces by trying each `/` position against `existsSync`.

--- a/src/components/chat-input.test.tsx
+++ b/src/components/chat-input.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "ink-testing-library";
 import { describe, it, expect, vi } from "vitest";
 import "../commands";
+import * as images from "../images";
 import { ChatInput } from "./chat-input";
 
 const flush = () => new Promise((r) => setTimeout(r, 50));
@@ -447,5 +448,173 @@ describe("ChatInput", () => {
     await flush();
     expect(onEscape).not.toHaveBeenCalled();
     expect(lastFrame()).toContain("Ctrl+C again to close Tomo");
+  });
+
+  it("Ctrl+V pastes clipboard image and shows tag", async () => {
+    const mockImage = {
+      name: "clipboard.png",
+      dataUri: "data:image/png;base64,abc",
+    };
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(mockImage);
+
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    // Ctrl+V
+    stdin.write("\x16");
+    await flush();
+    const output = lastFrame() ?? "";
+    expect(output).toContain("[Img 1]");
+
+    vi.restoreAllMocks();
+  });
+
+  it("Ctrl+V with no clipboard image does nothing", async () => {
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(null);
+
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x16");
+    await flush();
+    const output = lastFrame() ?? "";
+    expect(output).not.toContain("[Img");
+
+    vi.restoreAllMocks();
+  });
+
+  it("Ctrl+C clears clipboard images", async () => {
+    const mockImage = {
+      name: "clipboard.png",
+      dataUri: "data:image/png;base64,abc",
+    };
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(mockImage);
+
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x16");
+    await flush();
+    expect(lastFrame()).toContain("[Img 1]");
+    // Ctrl+C to clear
+    stdin.write("\x03");
+    await flush();
+    expect(lastFrame()).not.toContain("[Img");
+
+    vi.restoreAllMocks();
+  });
+
+  it("passes clipboard images through onSubmit", async () => {
+    const mockImage = {
+      name: "clipboard.png",
+      dataUri: "data:image/png;base64,abc",
+    };
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(mockImage);
+
+    const onSubmit = vi.fn();
+    const { stdin } = render(<ChatInput onSubmit={onSubmit} />);
+    // Paste image then type and submit
+    stdin.write("\x16");
+    await flush();
+    stdin.write("describe this");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("describe this", [mockImage]);
+
+    vi.restoreAllMocks();
+  });
+
+  it("shows down arrow hint when clipboard images are present", async () => {
+    const mockImage = {
+      name: "clipboard.png",
+      dataUri: "data:image/png;base64,abc",
+    };
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(mockImage);
+
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x16");
+    await flush();
+    expect(lastFrame()).toContain("↓ images");
+
+    vi.restoreAllMocks();
+  });
+
+  it("enters image nav on down arrow and shows nav hints", async () => {
+    const mockImage = {
+      name: "clipboard.png",
+      dataUri: "data:image/png;base64,abc",
+    };
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(mockImage);
+
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x16");
+    await flush();
+    // Down arrow to enter image nav
+    stdin.write("\x1B[B");
+    await flush();
+    const output = lastFrame() ?? "";
+    expect(output).toContain("←→ select");
+    expect(output).toContain("⌫ remove");
+
+    vi.restoreAllMocks();
+  });
+
+  it("exits image nav on up arrow", async () => {
+    const mockImage = {
+      name: "clipboard.png",
+      dataUri: "data:image/png;base64,abc",
+    };
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(mockImage);
+
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x16");
+    await flush();
+    // Enter nav
+    stdin.write("\x1B[B");
+    await flush();
+    expect(lastFrame()).toContain("←→ select");
+    // Exit nav
+    stdin.write("\x1B[A");
+    await flush();
+    expect(lastFrame()).toContain("↓ images");
+
+    vi.restoreAllMocks();
+  });
+
+  it("removes clipboard image with backspace in image nav", async () => {
+    const mockImage = {
+      name: "clipboard.png",
+      dataUri: "data:image/png;base64,abc",
+    };
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(mockImage);
+
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x16");
+    await flush();
+    expect(lastFrame()).toContain("[Img 1]");
+    // Enter nav then backspace to remove
+    stdin.write("\x1B[B");
+    await flush();
+    stdin.write("\x7f");
+    await flush();
+    expect(lastFrame()).not.toContain("[Img");
+    // Should exit nav since no images left
+    expect(lastFrame()).not.toContain("←→ select");
+
+    vi.restoreAllMocks();
+  });
+
+  it("shows multiple image tags for multiple clipboard pastes", async () => {
+    const mockImage = {
+      name: "clipboard.png",
+      dataUri: "data:image/png;base64,abc",
+    };
+    vi.spyOn(images, "readClipboardImage").mockReturnValue(mockImage);
+
+    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
+    stdin.write("\x16");
+    await flush();
+    stdin.write("\x16");
+    await flush();
+    const output = lastFrame() ?? "";
+    expect(output).toContain("[Img 1]");
+    expect(output).toContain("[Img 2]");
+
+    vi.restoreAllMocks();
   });
 });

--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -1,15 +1,20 @@
-import { useEffect, useState } from "react";
 import chalk from "chalk";
 import { Box, Text, useApp, useInput, useStdout } from "ink";
+import { useEffect, useRef, useState } from "react";
 import { getAllCommands } from "../commands";
 import {
   type AutocompleteProvider,
   useAutocomplete,
 } from "../hooks/use-autocomplete";
+import {
+  detectImagePath,
+  type ImageAttachment,
+  readClipboardImage,
+} from "../images";
 import { getAllSkills } from "../skills";
 
 interface ChatInputProps {
-  onSubmit: (text: string) => void;
+  onSubmit: (text: string, clipboardImages?: ImageAttachment[]) => void;
   disabled?: boolean;
   hidden?: boolean;
   onEscape?: () => void;
@@ -69,6 +74,15 @@ export function ChatInput({
   const [value, setValue] = useState("");
   const [cursor, setCursor] = useState(0);
   const [exitWarning, setExitWarning] = useState(false);
+  const [clipboardImages, setClipboardImages] = useState<ImageAttachment[]>([]);
+  const [imageNavActive, setImageNavActive] = useState(false);
+  const [selectedImageIdx, setSelectedImageIdx] = useState(0);
+
+  // Refs track the real value/cursor across React batched updates (paste bursts).
+  const valueRef = useRef(value);
+  const cursorRef = useRef(cursor);
+  valueRef.current = value;
+  cursorRef.current = cursor;
 
   useEffect(() => {
     const onResize = () => setColumns(stdout.columns || 80);
@@ -77,6 +91,8 @@ export function ChatInput({
       stdout.off("resize", onResize);
     };
   }, [stdout]);
+
+  const totalImages = clipboardImages.length;
 
   const autocomplete = useAutocomplete(defaultProviders, value, cursor);
   const { active: isAutocomplete, ghost, showGhost } = autocomplete;
@@ -94,9 +110,12 @@ export function ChatInput({
           setExitWarning(true);
           return;
         }
-        if (value) {
+        if (value || clipboardImages.length > 0) {
           setValue("");
           setCursor(0);
+          setClipboardImages([]);
+          setImageNavActive(false);
+          setSelectedImageIdx(0);
           return;
         }
         setExitWarning(true);
@@ -105,6 +124,37 @@ export function ChatInput({
 
       if (exitWarning) {
         setExitWarning(false);
+      }
+
+      // Image navigation mode — intercept keys before normal handling
+      if (imageNavActive) {
+        if (key.upArrow || key.escape) {
+          setImageNavActive(false);
+          return;
+        }
+        if (key.leftArrow) {
+          setSelectedImageIdx((i) => Math.max(0, i - 1));
+          return;
+        }
+        if (key.rightArrow) {
+          setSelectedImageIdx((i) => Math.min(totalImages - 1, i + 1));
+          return;
+        }
+        if (key.delete || key.backspace) {
+          setClipboardImages((prev) =>
+            prev.filter((_, i) => i !== selectedImageIdx),
+          );
+          const newTotal = totalImages - 1;
+          if (newTotal === 0) {
+            setImageNavActive(false);
+            setSelectedImageIdx(0);
+          } else {
+            setSelectedImageIdx((i) => Math.min(i, newTotal - 1));
+          }
+          return;
+        }
+        // Ignore all other keys in image nav mode
+        return;
       }
 
       if (key.escape) {
@@ -118,6 +168,15 @@ export function ChatInput({
       }
 
       if (disabled) return;
+
+      // Ctrl+V: paste image from system clipboard
+      if (input === "v" && key.ctrl) {
+        const img = readClipboardImage();
+        if (img) {
+          setClipboardImages((prev) => [...prev, img]);
+        }
+        return;
+      }
 
       // Word-skip: Option/Alt+Arrow or Alt+B/F
       if (key.leftArrow && key.meta) {
@@ -169,6 +228,12 @@ export function ChatInput({
               ? nextNextLineBreak - nextLineStart
               : value.length - nextLineStart;
           setCursor(nextLineStart + Math.min(col, nextLineLength));
+          return;
+        }
+        // On last line — enter image navigation if images exist
+        if (totalImages > 0) {
+          setImageNavActive(true);
+          setSelectedImageIdx(0);
         }
         return;
       }
@@ -202,13 +267,23 @@ export function ChatInput({
           setValue((v) => `${v.slice(0, cursor)}\n${v.slice(cursor)}`);
           setCursor((c) => c + 1);
         } else if (isAutocomplete && autocomplete.submitValue) {
-          onSubmit(autocomplete.submitValue);
+          if (clipboardImages.length > 0) {
+            onSubmit(autocomplete.submitValue, clipboardImages);
+          } else {
+            onSubmit(autocomplete.submitValue);
+          }
           setValue("");
           setCursor(0);
-        } else if (value.trim()) {
-          onSubmit(value);
+          setClipboardImages([]);
+        } else if (value.trim() || clipboardImages.length > 0) {
+          if (clipboardImages.length > 0) {
+            onSubmit(value, clipboardImages);
+          } else {
+            onSubmit(value);
+          }
           setValue("");
           setCursor(0);
+          setClipboardImages([]);
         }
         return;
       }
@@ -238,8 +313,28 @@ export function ChatInput({
       }
 
       if (input && !key.ctrl && !key.meta) {
-        setValue((v) => v.slice(0, cursor) + input + v.slice(cursor));
-        setCursor((c) => c + input.length);
+        // Use refs to get the real accumulated value during paste bursts
+        // (React batches setValue calls, so the closure `value` may be stale).
+        const prev = valueRef.current;
+        const cur = cursorRef.current;
+        const newValue = prev.slice(0, cur) + input + prev.slice(cur);
+        const newCursor = cur + input.length;
+
+        // Auto-detect pasted image file paths (e.g. Cmd+V of a file from Finder)
+        const detected = detectImagePath(newValue);
+        if (detected) {
+          const prefix = newValue.slice(0, detected.pathStart).trimEnd();
+          setValue(prefix);
+          setCursor(prefix.length);
+          setClipboardImages((prev) => [...prev, detected.attachment]);
+          valueRef.current = prefix;
+          cursorRef.current = prefix.length;
+        } else {
+          setValue(newValue);
+          setCursor(newCursor);
+          valueRef.current = newValue;
+          cursorRef.current = newCursor;
+        }
       }
     },
     {
@@ -256,6 +351,9 @@ export function ChatInput({
 
   let inputDisplay: string;
   if (disabled) {
+    inputDisplay = value;
+  } else if (imageNavActive) {
+    // No cursor highlight when navigating images
     inputDisplay = value;
   } else {
     const charAtCursor = cursor < value.length ? value[cursor] : null;
@@ -286,7 +384,63 @@ export function ChatInput({
     ? ` ${Math.round(contextPercent)}% context `
     : "";
   const topLineWidth = columns - 2;
-  const bottomLineWidth = Math.max(0, columns - 2 - contextLabel.length);
+
+  // Build image tags for the bottom bar
+  const maxVisible = 5;
+  let imageDisplayStr = "";
+  let imagePlainWidth = 0;
+
+  if (totalImages > 0) {
+    // Determine visible window
+    let start = 0;
+    let end = Math.min(totalImages, maxVisible);
+
+    if (imageNavActive && selectedImageIdx >= end) {
+      end = Math.min(totalImages, selectedImageIdx + 1);
+      start = Math.max(0, end - maxVisible);
+    }
+
+    const showLeading = start > 0;
+    const showTrailing = end < totalImages;
+
+    const parts: string[] = [];
+    imagePlainWidth = 2; // leading ──
+
+    if (showLeading) {
+      parts.push("...");
+      imagePlainWidth += 3;
+    }
+
+    for (let i = start; i < end; i++) {
+      const label = `[Img ${i + 1}]`;
+      imagePlainWidth += label.length;
+      parts.push(
+        imageNavActive && i === selectedImageIdx
+          ? chalk.bgWhite.black(label)
+          : label,
+      );
+    }
+
+    if (showTrailing) {
+      parts.push("...");
+      imagePlainWidth += 3;
+    }
+
+    imageDisplayStr = `──${parts.join("")}`;
+  }
+
+  const bottomLineWidth = Math.max(
+    0,
+    columns - 2 - imagePlainWidth - contextLabel.length,
+  );
+
+  // Hint text below the bottom bar
+  let hintText: string | null = null;
+  if (imageNavActive) {
+    hintText = "  ↑ input  ←→ select  ⌫ remove";
+  } else if (totalImages > 0 && !disabled) {
+    hintText = "  ↓ images";
+  }
 
   return (
     <Box flexDirection="column">
@@ -298,6 +452,7 @@ export function ChatInput({
         {inputDisplay}
       </Text>
       <Text dimColor={dividerDim} color={dividerColor}>
+        {imageDisplayStr}
         {"─".repeat(bottomLineWidth)}
         {contextLabel}
       </Text>
@@ -329,6 +484,7 @@ export function ChatInput({
           })()}
         </Box>
       ) : null}
+      {hintText ? <Text dimColor>{hintText}</Text> : null}
       {exitWarning ? (
         <Text dimColor>{"  Ctrl+C again to close Tomo"}</Text>
       ) : null}

--- a/src/components/message-list.tsx
+++ b/src/components/message-list.tsx
@@ -1,4 +1,5 @@
 import { Box } from "ink";
+import type { ImageAttachment } from "../images";
 import type { ToolCall } from "../provider/client";
 import { AssistantMessage } from "./assistant-message";
 import { SystemMessage } from "./system-message";
@@ -6,14 +7,17 @@ import { ToolMessage } from "./tool-message";
 import { UserMessage } from "./user-message";
 
 export type DisplayMessage =
-  | { id: string; role: "user"; content: string }
+  | { id: string; role: "user"; content: string; images?: ImageAttachment[] }
   | { id: string; role: "system"; content: string }
   | { id: string; role: "assistant"; content: string; tool_calls?: ToolCall[] }
   | { id: string; role: "tool"; content: string; tool_call_id: string };
 
 /** Renders a single message, dispatching to the appropriate component by role. */
 export function Message({ msg }: { msg: DisplayMessage }) {
-  if (msg.role === "user") return <UserMessage>{msg.content}</UserMessage>;
+  if (msg.role === "user")
+    return (
+      <UserMessage imageCount={msg.images?.length}>{msg.content}</UserMessage>
+    );
   if (msg.role === "system")
     return <SystemMessage>{msg.content}</SystemMessage>;
   if (msg.role === "tool") return <ToolMessage>{msg.content}</ToolMessage>;

--- a/src/components/user-message.test.tsx
+++ b/src/components/user-message.test.tsx
@@ -10,4 +10,28 @@ describe("UserMessage", () => {
     const output = lastFrame() ?? "";
     expect(output).toContain("How does this work?");
   });
+
+  it("shows image count when images are attached", () => {
+    const { lastFrame } = render(
+      <UserMessage imageCount={2}>{"describe these"}</UserMessage>,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("describe these");
+    expect(output).toContain("2 images");
+  });
+
+  it("shows singular image label for one image", () => {
+    const { lastFrame } = render(
+      <UserMessage imageCount={1}>{"what is this?"}</UserMessage>,
+    );
+    const output = lastFrame() ?? "";
+    expect(output).toContain("1 image");
+    expect(output).not.toContain("images");
+  });
+
+  it("shows no image label when imageCount is undefined", () => {
+    const { lastFrame } = render(<UserMessage>{"just text"}</UserMessage>);
+    const output = lastFrame() ?? "";
+    expect(output).not.toContain("image");
+  });
 });

--- a/src/components/user-message.tsx
+++ b/src/components/user-message.tsx
@@ -1,14 +1,21 @@
+import chalk from "chalk";
 import { Text } from "ink";
 
 interface UserMessageProps {
   children: string;
+  imageCount?: number;
 }
 
 /** Renders a user message with a gray background for visual distinction. */
-export function UserMessage({ children }: UserMessageProps) {
+export function UserMessage({ children, imageCount }: UserMessageProps) {
+  const imageLabel =
+    imageCount && imageCount > 0
+      ? chalk.dim(` [${imageCount} image${imageCount > 1 ? "s" : ""}]`)
+      : "";
   return (
     <Text backgroundColor="gray" color="white">
       {children}
+      {imageLabel}
     </Text>
   );
 }

--- a/src/hooks/use-chat.test.tsx
+++ b/src/hooks/use-chat.test.tsx
@@ -709,7 +709,7 @@ describe("useChat", () => {
       const lastCallMessages =
         vi.mocked(streamChatCompletion).mock.calls[2][0].messages;
       const nudge = lastCallMessages.find(
-        (m: { content: string }) =>
+        (m: { content: string | unknown }) =>
           typeof m.content === "string" &&
           m.content.includes("previous response was empty"),
       );

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -1,38 +1,39 @@
+import chalk from "chalk";
 import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
 import { getCommand, parse } from "../commands";
 import type { DisplayMessage } from "../components/message-list";
 import {
   type Config,
-  type ProviderConfig,
   getMaxTokens,
   getProviderByName,
   loadConfig,
+  type ProviderConfig,
   updateActiveModel,
   updateActiveProvider,
 } from "../config";
 import { truncateMessages } from "../context/truncate";
-import type { ChatMessage, TokenUsage } from "../provider/client";
+import type { ImageAttachment } from "../images";
+import { resolvePermissions } from "../permissions";
+import type { ChatMessage, ContentPart, TokenUsage } from "../provider/client";
 import {
   fetchContextWindow,
   getDefaultContextWindow,
   streamChatCompletion,
 } from "../provider/client";
 import {
-  type Session,
   appendMessage,
   createSession,
   loadSession,
+  type Session,
 } from "../session";
-import chalk from "chalk";
-import { resolvePermissions } from "../permissions";
 import { getSkill } from "../skills";
 import {
-  type ToolContext,
   getToolDefinitions,
   resolveToolAvailability,
+  type ToolContext,
 } from "../tools";
-import { ToolDismissedError, executeToolCalls } from "./tool-execution";
+import { executeToolCalls, ToolDismissedError } from "./tool-execution";
 
 export interface ChatState {
   messages: DisplayMessage[];
@@ -46,7 +47,7 @@ export interface ChatState {
   contextWindow: number;
   pendingMessage: string | null;
   toolActive: boolean;
-  submit: (text: string) => void;
+  submit: (text: string, clipboardImages?: ImageAttachment[]) => void;
   cancel: () => void;
   clearMessages: () => void;
 }
@@ -76,6 +77,18 @@ function toChatMessages(
             content: m.content,
             tool_calls: m.tool_calls,
           };
+        }
+        if (m.role === "user" && m.images && m.images.length > 0) {
+          const parts: ContentPart[] = [
+            { type: "text", text: m.content },
+            ...m.images.map(
+              (img): ContentPart => ({
+                type: "image_url",
+                image_url: { url: img.dataUri },
+              }),
+            ),
+          ];
+          return { role: "user", content: parts };
         }
         return { role: m.role as "user" | "assistant", content: m.content };
       }),
@@ -161,7 +174,7 @@ export function useChat(
     setTokenUsage(null);
   };
 
-  const submit = async (text: string) => {
+  const submit = async (text: string, clipboardImages?: ImageAttachment[]) => {
     if (streamingRef.current) {
       pendingMessageRef.current = text;
       setPendingMessage(text);
@@ -287,6 +300,8 @@ export function useChat(
       id: crypto.randomUUID(),
       role: "user",
       content: chatText,
+      ...(clipboardImages &&
+        clipboardImages.length > 0 && { images: clipboardImages }),
     };
 
     if (skillDisplay) {

--- a/src/images.test.ts
+++ b/src/images.test.ts
@@ -1,0 +1,145 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { detectImagePath, readImageFile } from "./images";
+
+const tmpDir = resolve(import.meta.dirname, "../.test-images-tmp");
+
+beforeEach(() => {
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("readImageFile", () => {
+  it("reads a PNG file as a data URI", () => {
+    const filePath = resolve(tmpDir, "test.png");
+    const content = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    writeFileSync(filePath, content);
+
+    const result = readImageFile(filePath);
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe("test.png");
+    expect(result?.dataUri).toBe(
+      `data:image/png;base64,${content.toString("base64")}`,
+    );
+  });
+
+  it("reads a JPEG file as a data URI", () => {
+    const filePath = resolve(tmpDir, "test.jpg");
+    writeFileSync(filePath, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
+
+    const result = readImageFile(filePath);
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe("test.jpg");
+    expect(result?.dataUri).toMatch(/^data:image\/jpeg;base64,/);
+  });
+
+  it("returns null for non-existent file", () => {
+    expect(readImageFile("/nonexistent/file.png")).toBeNull();
+  });
+
+  it("returns null for unsupported format", () => {
+    const filePath = resolve(tmpDir, "test.tiff");
+    writeFileSync(filePath, "data");
+    expect(readImageFile(filePath)).toBeNull();
+  });
+
+  it("returns null for non-image extension", () => {
+    expect(readImageFile("/tmp/file.txt")).toBeNull();
+  });
+});
+
+describe("detectImagePath", () => {
+  it("detects an absolute path at the end of text", () => {
+    const filePath = resolve(tmpDir, "photo.png");
+    writeFileSync(filePath, Buffer.from([0x89, 0x50]));
+
+    const result = detectImagePath(`look at ${filePath}`);
+    expect(result).not.toBeNull();
+    expect(result?.attachment.name).toBe("photo.png");
+    expect(result?.pathStart).toBe(8);
+  });
+
+  it("detects a standalone absolute path", () => {
+    const filePath = resolve(tmpDir, "photo.png");
+    writeFileSync(filePath, Buffer.from([0x89, 0x50]));
+
+    const result = detectImagePath(filePath);
+    expect(result).not.toBeNull();
+    expect(result?.pathStart).toBe(0);
+  });
+
+  it("handles paths with spaces", () => {
+    const filePath = resolve(tmpDir, "my screenshot.png");
+    writeFileSync(filePath, Buffer.from([0x89, 0x50]));
+
+    const result = detectImagePath(filePath);
+    expect(result).not.toBeNull();
+    expect(result?.attachment.name).toBe("my screenshot.png");
+  });
+
+  it("returns null for non-existent path", () => {
+    expect(detectImagePath("/nonexistent/file.png")).toBeNull();
+  });
+
+  it("returns null for text without image paths", () => {
+    expect(detectImagePath("hello world")).toBeNull();
+  });
+
+  it("returns null for non-image extensions", () => {
+    expect(detectImagePath("/tmp/file.txt")).toBeNull();
+  });
+
+  it("handles trailing whitespace", () => {
+    const filePath = resolve(tmpDir, "photo.png");
+    writeFileSync(filePath, Buffer.from([0x89, 0x50]));
+
+    const result = detectImagePath(`${filePath}  `);
+    expect(result).not.toBeNull();
+  });
+
+  it("is case-insensitive for extensions", () => {
+    const filePath = resolve(tmpDir, "photo.PNG");
+    writeFileSync(filePath, Buffer.from([0x89, 0x50]));
+
+    const result = detectImagePath(filePath);
+    expect(result).not.toBeNull();
+  });
+
+  it("detects path preceded by non-whitespace character", () => {
+    const filePath = resolve(tmpDir, "photo.png");
+    writeFileSync(filePath, Buffer.from([0x89, 0x50]));
+
+    const result = detectImagePath(`whats this?${filePath}`);
+    expect(result).not.toBeNull();
+    expect(result?.attachment.name).toBe("photo.png");
+  });
+
+  it("strips preceding text and returns correct pathStart", () => {
+    const filePath = resolve(tmpDir, "img.jpg");
+    writeFileSync(filePath, Buffer.from([0xff, 0xd8]));
+
+    const prefix = "describe this image";
+    const result = detectImagePath(`${prefix}${filePath}`);
+    expect(result).not.toBeNull();
+    expect(result?.pathStart).toBe(prefix.length);
+  });
+});
+
+describe("readClipboardImage", () => {
+  it("returns null on non-darwin platforms", async () => {
+    vi.resetModules();
+    vi.doMock("node:os", () => ({
+      platform: () => "linux",
+      tmpdir: () => "/tmp",
+      homedir: () => "/home/test",
+    }));
+    const { readClipboardImage } = await import("./images");
+    expect(readClipboardImage()).toBeNull();
+    vi.doUnmock("node:os");
+    vi.resetModules();
+  });
+});

--- a/src/images.ts
+++ b/src/images.ts
@@ -1,0 +1,163 @@
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { homedir, platform, tmpdir } from "node:os";
+import { basename, extname, resolve } from "node:path";
+
+export interface ImageAttachment {
+  name: string;
+  dataUri: string;
+}
+
+const IMAGE_EXTENSIONS: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+};
+
+/**
+ * Reads an image file from disk and returns it as a base64 data URI.
+ * Returns null if the file doesn't exist, isn't a supported format, or can't be read.
+ */
+export function readImageFile(filePath: string): ImageAttachment | null {
+  const ext = extname(filePath).toLowerCase();
+  const mime = IMAGE_EXTENSIONS[ext];
+  if (!mime) return null;
+
+  const resolved = filePath.startsWith("~/")
+    ? resolve(homedir(), filePath.slice(2))
+    : resolve(filePath);
+
+  if (!existsSync(resolved)) return null;
+
+  try {
+    const data = readFileSync(resolved);
+    return {
+      name: basename(resolved),
+      dataUri: `data:${mime};base64,${data.toString("base64")}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks if text ends with an absolute path to an image file.
+ * Returns the path start index and the resolved ImageAttachment, or null.
+ *
+ * Scans backward through each `/` in the text, trying progressively
+ * longer paths until one resolves to an existing image file. This handles
+ * paths with spaces and any preceding character (e.g. `question?/path.png`).
+ */
+export function detectImagePath(
+  text: string,
+): { pathStart: number; attachment: ImageAttachment } | null {
+  const trimmed = text.trimEnd();
+  if (!/\.(?:png|jpe?g|gif|webp|bmp)$/i.test(trimmed)) return null;
+
+  for (let i = trimmed.length - 1; i >= 0; i--) {
+    if (trimmed[i] !== "/") continue;
+
+    // Check for ~/ prefix
+    const start = i > 0 && trimmed[i - 1] === "~" ? i - 1 : i;
+    const candidatePath = trimmed.slice(start);
+    const attachment = readImageFile(candidatePath);
+    if (attachment) {
+      return { pathStart: start, attachment };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Checks if the clipboard contains a file reference (e.g. file copied in
+ * Finder) and reads the actual file from disk. Uses JXA with NSPasteboard
+ * to read the `public.file-url` pasteboard type and extract the POSIX path.
+ */
+function readClipboardFileAsImage(): ImageAttachment | null {
+  try {
+    const filePath = execSync(
+      `osascript -l JavaScript -e '
+ObjC.import("AppKit");
+var pb = $.NSPasteboard.generalPasteboard;
+var fileType = "public.file-url";
+var available = pb.availableTypeFromArray([fileType]);
+if (available && available.js) {
+  var urlStr = pb.stringForType(fileType);
+  if (urlStr) {
+    var url = $.NSURL.URLWithString(urlStr);
+    if (url && url.isFileURL) { url.path.js; } else { ""; }
+  } else { ""; }
+} else { ""; }'`,
+      { encoding: "utf-8", timeout: 3000, stdio: ["pipe", "pipe", "pipe"] },
+    ).trim();
+
+    if (!filePath) return null;
+    return readImageFile(filePath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads raw image data from the clipboard (screenshots, copied image content).
+ */
+function readClipboardRawImage(): ImageAttachment | null {
+  const tmpFile = resolve(
+    tmpdir(),
+    `tomo-clipboard-${Date.now()}-${Math.random().toString(36).slice(2)}.png`,
+  );
+
+  try {
+    const info = execSync('osascript -e "clipboard info"', {
+      encoding: "utf-8",
+      timeout: 3000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    if (
+      !info.includes("«class PNGf»") &&
+      !info.includes("«class TIFF»") &&
+      !info.includes("«class jp2 »")
+    ) {
+      return null;
+    }
+
+    execSync(
+      `osascript -e 'set png to (the clipboard as «class PNGf»)' -e 'set f to open for access POSIX file "${tmpFile}" with write permission' -e 'write png to f' -e 'close access f'`,
+      { timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    const data = readFileSync(tmpFile);
+    unlinkSync(tmpFile);
+
+    return {
+      name: "clipboard.png",
+      dataUri: `data:image/png;base64,${data.toString("base64")}`,
+    };
+  } catch {
+    try {
+      unlinkSync(tmpFile);
+    } catch {
+      // temp file may not exist
+    }
+    return null;
+  }
+}
+
+/**
+ * Reads an image from the system clipboard (macOS only).
+ *
+ * Tries two strategies in order:
+ * 1. File reference — if a file was copied in Finder, reads the actual file from disk
+ * 2. Raw image data — if image content was copied (screenshot, editor), extracts PNG data
+ *
+ * Returns null if no image is on the clipboard or on non-macOS platforms.
+ */
+export function readClipboardImage(): ImageAttachment | null {
+  if (platform() !== "darwin") return null;
+  return readClipboardFileAsImage() ?? readClipboardRawImage();
+}

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -111,8 +111,12 @@ export interface ToolCall {
   function: ToolCallFunction;
 }
 
+export type ContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
 export type ChatMessage =
-  | { role: "user"; content: string }
+  | { role: "user"; content: string | ContentPart[] }
   | { role: "system"; content: string }
   | { role: "assistant"; content: string; tool_calls?: ToolCall[] }
   | { role: "tool"; content: string; tool_call_id: string };

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -101,6 +101,26 @@ describe("appendMessage / loadSession", () => {
     expect(loaded?.messages[2].content).toBe("third");
   });
 
+  it("round-trips user messages with images", () => {
+    const session = createSession("ollama", "qwen3:8b");
+    const msg = {
+      id: "msg-1",
+      role: "user" as const,
+      content: "what is this?",
+      images: [
+        {
+          name: "photo.png",
+          dataUri: "data:image/png;base64,iVBORw0KGgo=",
+        },
+      ],
+    };
+
+    appendMessage(session, msg);
+
+    const loaded = loadSession(session.id);
+    expect(loaded?.messages).toEqual([msg]);
+  });
+
   it("round-trips assistant messages with tool_calls", () => {
     const session = createSession("ollama", "qwen3:8b");
     const msg = {

--- a/src/session.ts
+++ b/src/session.ts
@@ -4,15 +4,16 @@ import {
   existsSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   readSync,
-  readdirSync,
   statSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import type { DisplayMessage } from "./components/message-list";
+import type { ImageAttachment } from "./images";
 import type { ToolCall } from "./provider/client";
 
 export interface Session {
@@ -33,7 +34,14 @@ interface MetaEntry {
 }
 
 type MessageEntry =
-  | { type: "message"; id: string; role: "user" | "system"; content: string }
+  | {
+      type: "message";
+      id: string;
+      role: "user";
+      content: string;
+      images?: ImageAttachment[];
+    }
+  | { type: "message"; id: string; role: "system"; content: string }
   | {
       type: "message";
       id: string;


### PR DESCRIPTION
## Summary

Add support for attaching images to messages for vision-capable models (e.g. Qwen 2.5 VL). Images are sent as OpenAI vision content arrays via the `/v1/chat/completions` endpoint.

## GitHub Issue

Closes #142

## What Changed

Two complementary image input methods:

**Cmd+V file path detection** — when a file path ending in an image extension is pasted into the input (e.g. from Finder's "Copy as Pathname"), the file is detected, read from disk, base64-encoded, and auto-attached. The path text is stripped from the input. A backward-scanning algorithm tries each `/` position against `existsSync`, handling macOS filenames with spaces naturally.

**Ctrl+V clipboard paste (macOS)** — reads image data from the system clipboard. Uses JXA with `NSPasteboard` to detect file references (Cmd+C on a file in Finder) and reads the actual file from disk. Falls back to AppleScript `«class PNGf»` extraction for screenshots and copied image content. All `execSync` calls pipe stdio to avoid corrupting Ink's terminal rendering.

**Image navigation UI** — attached images display as `[Img N]` tags in the input bottom bar. `↓` enters image navigation, `←→` moves between images, `⌫` removes the selected image, `↑` returns to text input. Truncates to 5 visible tags with `...` overflow. Contextual hints shown below the bar.

**API and persistence** — `ChatMessage` user content now supports `string | ContentPart[]` (OpenAI vision format). `DisplayMessage` carries an optional `images` array. Images are persisted in session JSONL and restored on session load.

## Notes for Reviewers

- A `useRef` tracks the accumulated value/cursor across React batched state updates — Ink fires `useInput` per character during a paste burst, but React batches `setValue` calls, making the closure value stale without the ref.
- ADR 0010 documents the clipboard approach, the file path detection algorithm, and the trade-offs considered.