### PR TITLE
feat(config): auto-launch /configure on first run

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -40,7 +40,7 @@ vi.mock("./config", () => ({
       { name: "test", type: "ollama", baseUrl: "http://localhost:11434" },
     ],
   }),
-  getActiveProvider: () => ({
+  getProviderByName: () => ({
     name: "test",
     type: "ollama",
     baseUrl: "http://localhost:11434",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { spawnSync } from "node:child_process";
 import chalk from "chalk";
 import { Box, Static, Text } from "ink";
@@ -10,7 +10,7 @@ import { completePartialMarkdown, renderMarkdown } from "./components/markdown";
 import type { DisplayMessage } from "./components/message-list";
 import { Message } from "./components/message-list";
 import { ThinkingIndicator } from "./components/thinking-indicator";
-import { getActiveProvider, loadConfig } from "./config";
+import { getProviderByName, loadConfig } from "./config";
 import { useChat } from "./hooks/use-chat";
 import { loadInstructions } from "./instructions";
 import { createSession } from "./session";
@@ -32,11 +32,10 @@ function getToolWarnings(): string[] {
 
 function initApp() {
   const config = loadConfig();
-  const initialProvider = getActiveProvider(config);
-  const initialSession = createSession(
-    initialProvider.name,
-    config.activeModel,
-  );
+  const initialProvider = getProviderByName(config, config.activeProvider);
+  const initialSession = initialProvider
+    ? createSession(initialProvider.name, config.activeModel)
+    : createSession("none", "none");
   const instructions = loadInstructions();
   const startupWarnings = getToolWarnings();
   return {
@@ -45,6 +44,7 @@ function initApp() {
     initialSession,
     instructions,
     startupWarnings,
+    needsSetup: !initialProvider,
   };
 }
 
@@ -65,16 +65,31 @@ export function App({ onRestart }: AppProps) {
     initialSession,
     instructions,
     startupWarnings,
+    needsSetup,
   } = useMemo(() => initApp(), []);
+
+  const placeholderProvider = {
+    name: "none",
+    type: "ollama" as const,
+    baseUrl: "http://localhost:11434",
+  };
 
   const chat = useChat(
     config,
-    initialProvider,
-    config.activeModel,
+    initialProvider ?? placeholderProvider,
+    initialProvider ? config.activeModel : "none",
     initialSession,
     instructions,
     onRestart,
   );
+
+  // Auto-launch /configure when no providers are configured.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only run once on mount
+  useEffect(() => {
+    if (needsSetup) {
+      chat.submit("/configure");
+    }
+  }, []);
 
   const headerItem = useMemo(
     (): StaticItem => ({ type: "header", id: "__header__" }),

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -39,10 +39,9 @@ afterEach(() => {
 describe("loadConfig", () => {
   it("creates default config when none exists", () => {
     const config = loadConfig();
-    expect(config.activeProvider).toBe("ollama");
-    expect(config.activeModel).toBe("qwen3:8b");
-    expect(config.providers).toHaveLength(1);
-    expect(config.providers[0].name).toBe("ollama");
+    expect(config.activeProvider).toBe("");
+    expect(config.activeModel).toBe("");
+    expect(config.providers).toHaveLength(0);
     expect(existsSync(globalPath)).toBe(true);
   });
 
@@ -92,7 +91,7 @@ providers:
     expect(config.activeModel).toBe("mistral");
   });
 
-  it("throws on empty providers", () => {
+  it("accepts empty providers array", () => {
     writeYaml(
       globalPath,
       `
@@ -101,7 +100,8 @@ activeModel: qwen3:8b
 providers: []
 `,
     );
-    expect(() => loadConfig()).toThrow("non-empty");
+    const config = loadConfig();
+    expect(config.providers).toHaveLength(0);
   });
 
   it("throws on missing provider name", () => {
@@ -147,7 +147,7 @@ providers:
     expect(() => loadConfig()).toThrow("validation failed");
   });
 
-  it("throws when activeProvider does not match any provider", () => {
+  it("loads when activeProvider does not match any provider", () => {
     writeYaml(
       globalPath,
       `
@@ -159,9 +159,9 @@ providers:
     baseUrl: http://localhost:11434
 `,
     );
-    expect(() => loadConfig()).toThrow(
-      'activeProvider "nonexistent" does not match any provider',
-    );
+    const config = loadConfig();
+    expect(config.activeProvider).toBe("nonexistent");
+    expect(config.providers).toHaveLength(1);
   });
 });
 
@@ -248,9 +248,9 @@ describe("addProvider", () => {
       apiKey: "sk-test",
     });
     const config = loadConfig();
-    expect(config.providers).toHaveLength(2);
-    expect(config.providers[1].name).toBe("openrouter");
-    expect(config.providers[1].apiKey).toBe("sk-test");
+    expect(config.providers).toHaveLength(1);
+    expect(config.providers[0].name).toBe("openrouter");
+    expect(config.providers[0].apiKey).toBe("sk-test");
   });
 });
 
@@ -280,7 +280,7 @@ providers:
     loadConfig(); // create default
     removeProvider("nonexistent");
     const config = loadConfig();
-    expect(config.providers).toHaveLength(1);
+    expect(config.providers).toHaveLength(0);
   });
 });
 
@@ -292,7 +292,7 @@ describe("updateActiveModel", () => {
     expect(config.activeModel).toBe("llama3:70b");
   });
 
-  it("updates activeModel in local config when present", () => {
+  it("does not modify local config", () => {
     writeYaml(
       globalPath,
       `
@@ -307,16 +307,13 @@ providers:
     writeYaml(
       localPath,
       `
-activeProvider: ollama
-activeModel: qwen3:8b
-providers:
-  - name: ollama
-    type: ollama
-    baseUrl: http://localhost:11434
+activeModel: original-model
 `,
     );
     updateActiveModel("mistral");
+    // Local config should still override to original-model since we
+    // only wrote to global. loadConfig merges local on top.
     const config = loadConfig();
-    expect(config.activeModel).toBe("mistral");
+    expect(config.activeModel).toBe("original-model");
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,53 +30,29 @@ const permissionsSchema = z
 
 const toolsSchema = z.record(z.string(), z.boolean()).optional();
 
-const configSchema = z
-  .object({
-    activeProvider: z.string().min(1, "activeProvider is required"),
-    activeModel: z.string().min(1, "activeModel is required"),
-    maxTokens: z.number().int().positive().default(8192),
-    providers: z
-      .array(providerSchema)
-      .min(1, "providers must be a non-empty array"),
-    permissions: permissionsSchema,
-    tools: toolsSchema,
-  })
-  .check((ctx) => {
-    const names = ctx.value.providers.map((p) => p.name);
-    if (!names.includes(ctx.value.activeProvider)) {
-      ctx.issues.push({
-        code: "custom",
-        message: `activeProvider "${ctx.value.activeProvider}" does not match any provider. Available: ${names.join(", ")}`,
-        input: ctx.value,
-        path: ["activeProvider"],
-      });
-    }
-  });
+const configSchema = z.object({
+  activeProvider: z.string().default(""),
+  activeModel: z.string().default(""),
+  maxTokens: z.number().int().positive().default(8192),
+  providers: z.array(providerSchema),
+  permissions: permissionsSchema,
+  tools: toolsSchema,
+});
 
 export type ProviderConfig = z.infer<typeof providerSchema>;
 export type Config = z.infer<typeof configSchema>;
 
 const DEFAULT_CONFIG: Config = {
-  activeProvider: "ollama",
-  activeModel: "qwen3:8b",
+  activeProvider: "",
+  activeModel: "",
   maxTokens: 8192,
-  providers: [
-    {
-      name: "ollama",
-      type: "ollama",
-      baseUrl: "http://localhost:11434",
-    },
-  ],
+  providers: [],
 };
 
-const DEFAULT_CONFIG_YAML = `activeProvider: ollama
-activeModel: qwen3:8b
+const DEFAULT_CONFIG_YAML = `activeProvider: ""
+activeModel: ""
 maxTokens: 8192
-
-providers:
-  - name: ollama
-    type: ollama
-    baseUrl: http://localhost:11434
+providers: []
 `;
 
 /** Returns the path to the global config file (~/.tomo/config.yaml). */
@@ -136,28 +112,23 @@ export function loadConfig(): Config {
   return result.data;
 }
 
-/** Updates fields in config files on disk. Updates local if present, always updates global. */
-function updateConfigFiles(updates: Record<string, unknown>): void {
-  const paths = [globalConfigPath()];
-  const local = localConfigPath();
-  if (existsSync(local)) paths.push(local);
-
-  for (const path of paths) {
-    const raw = loadYaml(path);
-    if (!raw) continue;
-    Object.assign(raw, updates);
-    writeFileSync(path, stringify(raw), "utf-8");
-  }
+/** Updates fields in the global config file on disk. */
+function updateGlobalConfig(updates: Record<string, unknown>): void {
+  const path = globalConfigPath();
+  const raw = loadYaml(path);
+  if (!raw) return;
+  Object.assign(raw, updates);
+  writeFileSync(path, stringify(raw), "utf-8");
 }
 
-/** Updates activeModel in config files on disk. */
+/** Updates activeModel in the global config. */
 export function updateActiveModel(model: string): void {
-  updateConfigFiles({ activeModel: model });
+  updateGlobalConfig({ activeModel: model });
 }
 
-/** Updates activeProvider in config files on disk. */
+/** Updates activeProvider in the global config. */
 export function updateActiveProvider(provider: string): void {
-  updateConfigFiles({ activeProvider: provider });
+  updateGlobalConfig({ activeProvider: provider });
 }
 
 /** Updates permissions in the local project config (.tomo/config.yaml). Creates the file if absent. */


### PR DESCRIPTION
## Summary

On first run or when no providers are configured, the app now auto-launches `/configure` instead of silently bootstrapping a hardcoded ollama provider. Also scopes `activeModel`/`activeProvider` config writes to global only, preventing local project configs from getting stale provider references.

## GitHub Issue

Closes #146

## What Changed

**Empty default config:** The default config created on first run now has an empty providers list and empty `activeProvider`/`activeModel`. The Zod schema was relaxed to accept these empty states without throwing validation errors.

**Auto-setup flow:** `initApp` uses `getProviderByName` (returns undefined) instead of `getActiveProvider` (throws). When the provider isn't found — whether because it's a fresh install, providers were manually cleared, or `activeProvider` references a removed provider — the app auto-submits `/configure` via a `useEffect` on mount.

**Global-only config writes:** `updateActiveModel` and `updateActiveProvider` now only write to `~/.tomo/config.yaml`. Previously they also wrote to local `.tomo/config.yaml` when present, which caused validation failures when a provider existed in global but not local config.