### PR TITLE
feat(context): replace stat dump with visual progress bar

### DIFF
--- a/src/commands/context.test.ts
+++ b/src/commands/context.test.ts
@@ -32,39 +32,54 @@ describe("/context", () => {
   const cmd = getCommand("context");
   if (!cmd) throw new Error("context command not registered");
 
-  it("shows no-data message when token usage is null", () => {
+  it("shows 0% usage when no token data yet", () => {
     const result = cmd.execute("", makeCallbacks());
-    expect("output" in result).toBe(true);
-
     const output = (result as { output: string }).output;
-    expect(output).toContain("No token usage data yet");
+
+    expect(output).toContain("0% used");
+    expect(output).toContain("░".repeat(30));
+    expect(output).toContain("0 / 32.8k tokens");
+    expect(output).toContain("Context window     32.8k tokens");
+    expect(output).toContain("Response reserve   8.2k tokens");
+    expect(output).toContain("Input budget       24.6k tokens");
   });
 
-  it("shows formatted stats when token usage is present", () => {
+  it("shows progress bar and config with token usage", () => {
     const result = cmd.execute(
       "",
       makeCallbacks({
         tokenUsage: { promptTokens: 1500, completionTokens: 500 },
         contextWindow: 32768,
         maxTokens: 8192,
-        messageCount: 4,
       }),
     );
 
     const output = (result as { output: string }).output;
-    expect(output).toContain("Context window:");
-    expect(output).toContain("32.8k");
-    expect(output).toContain("Prompt tokens:");
-    expect(output).toContain("1.5k");
-    expect(output).toContain("Response tokens:");
-    expect(output).toContain("500");
-    expect(output).toContain("Total used:");
-    expect(output).toContain("2.0k");
-    expect(output).toContain("6%");
-    expect(output).toContain("Input budget:");
-    expect(output).toContain("24.6k");
-    expect(output).toContain("Messages:");
-    expect(output).toContain("4");
+    expect(output).toContain("6% used");
+    expect(output).toContain("2.0k / 32.8k tokens");
+    expect(output).toContain("Context window     32.8k tokens");
+    expect(output).toContain("Response reserve   8.2k tokens");
+    expect(output).toContain("Input budget       24.6k tokens");
+    expect(output).toContain(
+      "input budget = context window - response reserve",
+    );
+  });
+
+  it("shows filled progress bar at high usage", () => {
+    const result = cmd.execute(
+      "",
+      makeCallbacks({
+        tokenUsage: { promptTokens: 30000, completionTokens: 1000 },
+        contextWindow: 32768,
+        maxTokens: 8192,
+      }),
+    );
+
+    const output = (result as { output: string }).output;
+    expect(output).toContain("95% used");
+    const bar = output.split("\n")[0] ?? "";
+    const filledCount = (bar.match(/█/g) || []).length;
+    expect(filledCount).toBeGreaterThanOrEqual(28);
   });
 
   it("formats small token counts without k suffix", () => {
@@ -74,15 +89,12 @@ describe("/context", () => {
         tokenUsage: { promptTokens: 50, completionTokens: 20 },
         contextWindow: 4096,
         maxTokens: 512,
-        messageCount: 2,
       }),
     );
 
     const output = (result as { output: string }).output;
-    expect(output).toContain("4.1k");
-    expect(output).toContain("50");
-    expect(output).toContain("20");
-    expect(output).toContain("70");
-    expect(output).toContain("2%");
+    expect(output).toContain("2% used");
+    expect(output).toContain("70 / 4.1k tokens");
+    expect(output).toContain("Input budget       3.6k tokens");
   });
 });

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import { register } from "./registry";
 import type { Command } from "./types";
 
@@ -6,28 +7,37 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
+const BAR_WIDTH = 30;
+const FILLED = "█";
+const EMPTY = "░";
+
+function progressBar(percent: number): string {
+  const clamped = Math.max(0, Math.min(100, percent));
+  const filled = Math.round((clamped / 100) * BAR_WIDTH);
+  return FILLED.repeat(filled) + EMPTY.repeat(BAR_WIDTH - filled);
+}
+
 const context: Command = {
   name: "context",
   description: "Show context window usage stats",
   execute: (_args, callbacks) => {
-    const { tokenUsage, contextWindow, maxTokens, messageCount } = callbacks;
+    const { tokenUsage, contextWindow, maxTokens } = callbacks;
 
-    if (!tokenUsage) {
-      return { output: "No token usage data yet — send a message first." };
-    }
-
-    const total = tokenUsage.promptTokens + tokenUsage.completionTokens;
+    const total = tokenUsage
+      ? tokenUsage.promptTokens + tokenUsage.completionTokens
+      : 0;
     const percent = Math.round((total / contextWindow) * 100);
     const inputBudget = contextWindow - maxTokens;
 
     const lines = [
-      `  Context window:    ${formatTokens(contextWindow)} tokens`,
-      `  Prompt tokens:     ${formatTokens(tokenUsage.promptTokens)}`,
-      `  Response tokens:   ${formatTokens(tokenUsage.completionTokens)}`,
-      `  Total used:        ${formatTokens(total)} (${percent}%)`,
-      `  Input budget:      ${formatTokens(inputBudget)} (window - ${formatTokens(maxTokens)} reserved)`,
-      `  Max tokens:        ${formatTokens(maxTokens)}`,
-      `  Messages:          ${messageCount}`,
+      `  ${progressBar(percent)}  ${percent}% used`,
+      `  ${formatTokens(total)} / ${formatTokens(contextWindow)} tokens`,
+      ``,
+      `  Context window     ${formatTokens(contextWindow)} tokens`,
+      `  Response reserve   ${formatTokens(maxTokens)} tokens`,
+      `  Input budget       ${formatTokens(inputBudget)} tokens`,
+      ``,
+      chalk.dim(`  (input budget = context window - response reserve)`),
     ];
 
     return { output: lines.join("\n") };


### PR DESCRIPTION
## Summary

Replaces the `/context` command's raw stat dump with a visual progress bar showing context usage percentage, a token summary, and a clean config section with a dimmed explainer.

## GitHub Issue

N/A

## What Changed

The `/context` command output now shows a Unicode progress bar (`█`/`░`) with percentage used, a `used / total` token summary, and three config lines: context window, response reserve, and input budget. A dimmed explainer line clarifies how input budget is derived. The previous "no data yet" state now shows 0% with the config rather than refusing to display. Message count was removed as unnecessary noise.