### PR TITLE
feat(providers): use /v1/models/user for openrouter

### DIFF
--- a/src/components/configure-selector.tsx
+++ b/src/components/configure-selector.tsx
@@ -247,7 +247,7 @@ export function ConfigureSelector({
     if (step !== "fetchingModels") return;
     let cancelled = false;
 
-    fetchModels(newProvider.baseUrl, newProvider.apiKey)
+    fetchModels(newProvider.baseUrl, newProvider.apiKey, newProvider.type)
       .then((result) => {
         if (cancelled) return;
         setModels(result);
@@ -265,7 +265,7 @@ export function ConfigureSelector({
     return () => {
       cancelled = true;
     };
-  }, [step, newProvider.baseUrl, newProvider.apiKey]);
+  }, [step, newProvider.baseUrl, newProvider.apiKey, newProvider.type]);
 
   switch (step) {
     case "menu":

--- a/src/components/model-selector.test.tsx
+++ b/src/components/model-selector.test.tsx
@@ -23,7 +23,7 @@ describe("ModelSelector", () => {
 
   it("shows loading state initially", () => {
     vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}));
-    const { lastFrame } = render(
+    const { lastFrame, unmount } = render(
       <ModelSelector
         providers={singleProvider}
         activeProvider="ollama"
@@ -33,6 +33,7 @@ describe("ModelSelector", () => {
       />,
     );
     expect(lastFrame()).toContain("Fetching models...");
+    unmount();
   });
 
   it("renders models grouped by provider", async () => {

--- a/src/components/model-selector.tsx
+++ b/src/components/model-selector.tsx
@@ -44,7 +44,7 @@ export function ModelSelector({
       providers.map(async (p) => {
         try {
           const key = resolveApiKey(p.type, p.apiKey);
-          const models = await fetchModels(p.baseUrl, key);
+          const models = await fetchModels(p.baseUrl, key, p.type);
           return { provider: p.name, models, error: null };
         } catch (err) {
           return {

--- a/src/provider/client.test.ts
+++ b/src/provider/client.test.ts
@@ -472,6 +472,51 @@ describe("fetchModels", () => {
     const headers = call[1]?.headers as Record<string, string>;
     expect(headers.Authorization).toBeUndefined();
   });
+
+  it("uses /v1/models/user for openrouter with apiKey", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ id: "anthropic/claude-sonnet-4" }] }),
+        {
+          status: 200,
+        },
+      ),
+    );
+
+    await fetchModels("https://openrouter.ai/api", "or-key", "openrouter");
+
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(call[0]).toBe("https://openrouter.ai/api/v1/models/user");
+  });
+
+  it("uses /v1/models for openrouter without apiKey", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ id: "anthropic/claude-sonnet-4" }] }),
+        {
+          status: 200,
+        },
+      ),
+    );
+
+    await fetchModels("https://openrouter.ai/api", undefined, "openrouter");
+
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(call[0]).toBe("https://openrouter.ai/api/v1/models");
+  });
+
+  it("uses /v1/models for non-openrouter providers", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: "llama3" }] }), {
+        status: 200,
+      }),
+    );
+
+    await fetchModels("http://localhost:11434", undefined, "ollama");
+
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(call[0]).toBe("http://localhost:11434/v1/models");
+  });
 });
 
 describe("streamChatCompletion auth", () => {

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -35,12 +35,17 @@ function buildHeaders(apiKey?: string): Record<string, string> {
 /**
  * Fetches the raw JSON from an OpenAI-compatible /v1/models endpoint.
  * Handles both `{ data: [...] }` (OpenRouter, Ollama) and bare array (Zen) responses.
+ * For OpenRouter with an API key, uses /v1/models/user to return only user-enabled models.
  */
 async function fetchModelsRaw(
   baseUrl: string,
   apiKey?: string,
+  providerType?: string,
 ): Promise<Array<Record<string, unknown>>> {
-  const url = `${baseUrl.replace(/\/+$/, "")}/v1/models`;
+  const base = baseUrl.replace(/\/+$/, "");
+  const modelsPath =
+    providerType === "openrouter" && apiKey ? "/v1/models/user" : "/v1/models";
+  const url = `${base}${modelsPath}`;
 
   let response: Response;
   try {
@@ -73,8 +78,9 @@ async function fetchModelsRaw(
 export async function fetchModels(
   baseUrl: string,
   apiKey?: string,
+  providerType?: string,
 ): Promise<ModelInfo[]> {
-  const models = await fetchModelsRaw(baseUrl, apiKey);
+  const models = await fetchModelsRaw(baseUrl, apiKey, providerType);
   return models.map((m) => ({ id: String(m.id) }));
 }
 
@@ -126,8 +132,9 @@ async function fetchModelsContextWindow(
   baseUrl: string,
   model: string,
   apiKey?: string,
+  providerType?: string,
 ): Promise<number | null> {
-  const models = await fetchModelsRaw(baseUrl, apiKey);
+  const models = await fetchModelsRaw(baseUrl, apiKey, providerType);
   const entry = models.find((m) => m.id === model);
   if (!entry) return null;
   // Both Zen and OpenRouter use context_length
@@ -161,7 +168,12 @@ export async function fetchContextWindow(
       providerType === "opencode-zen" ||
       providerType === "openrouter"
     ) {
-      contextLength = await fetchModelsContextWindow(baseUrl, model, apiKey);
+      contextLength = await fetchModelsContextWindow(
+        baseUrl,
+        model,
+        apiKey,
+        providerType,
+      );
     }
 
     const result = contextLength ?? DEFAULT_CONTEXT_WINDOW;

--- a/src/tools/grep.test.ts
+++ b/src/tools/grep.test.ts
@@ -220,12 +220,22 @@ describe("grep tool", () => {
   });
 
   it("prompts for paths outside cwd even with permission granted", async () => {
+    setupGitRepo();
     const tool = getTool("grep");
-    await tool?.execute(
-      JSON.stringify({ pattern: "test", path: "/tmp" }),
-      mockContext,
-    );
+    await tool?.execute(JSON.stringify({ pattern: "hello", path: tmpDir }), {
+      ...mockContext,
+      permissions: { read_file: true },
+    });
 
-    expect(mockContext.renderInteractive).toHaveBeenCalledTimes(1);
+    // tmpDir is within cwd so this won't prompt — use an outside path instead
+    // but mock renderInteractive to avoid running a real grep on a huge directory
+    const ctx = {
+      ...mockContext,
+      renderInteractive: vi.fn().mockResolvedValue("denied"),
+      permissions: { read_file: true },
+    };
+    await tool?.execute(JSON.stringify({ pattern: "test", path: "/tmp" }), ctx);
+
+    expect(ctx.renderInteractive).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Uses OpenRouter's `/v1/models/user` endpoint when an API key is available, so model lists only show user-enabled models instead of the full catalogue of hundreds.

## GitHub Issue

N/A

## What Changed

`fetchModelsRaw` now accepts an optional `providerType` parameter. When the provider is `openrouter` and an API key is present, it hits `/v1/models/user` instead of `/v1/models` — same response shape, just filtered server-side by the user's account preferences. Both `ModelSelector` and `ConfigureSelector` pass provider type through to `fetchModels`.

Also fixes a pre-existing issue where the grep tool test "prompts for paths outside cwd" ran `grep -rn` against `/tmp`, which could take forever. The test now denies the prompt so the actual grep never executes — it only needs to verify the prompt fires.