### PR TITLE
fix(glob): use :(glob) pathspec for recursive pattern matching

### DIFF
--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -75,14 +75,16 @@ registerTool({
  * matching the pattern. Falls back to `fs.globSync` if not in a git repo.
  */
 function gitGlob(pattern: string, cwd: string): string[] {
+  // Use :(glob) pathspec prefix so git interprets ** as recursive match
+  const pathspec = `:(glob)${pattern}`;
   // tracked files matching the pattern
-  const tracked = execSync(`git ls-files -- ${JSON.stringify(pattern)}`, {
+  const tracked = execSync(`git ls-files -- ${JSON.stringify(pathspec)}`, {
     cwd,
     encoding: "utf-8",
   });
   // untracked files that aren't ignored
   const untracked = execSync(
-    `git ls-files --others --exclude-standard -- ${JSON.stringify(pattern)}`,
+    `git ls-files --others --exclude-standard -- ${JSON.stringify(pathspec)}`,
     { cwd, encoding: "utf-8" },
   );
 


### PR DESCRIPTION
## Summary

Glob patterns using `**` (e.g. `terraform/base/**/*.tf`) silently returned no results because `git ls-files` doesn't treat `**` as a recursive glob by default.

## GitHub Issue

N/A

## What Changed

Prepended the `:(glob)` pathspec prefix to patterns passed to `git ls-files`. This tells git to use full glob semantics, including `**` for recursive directory matching, instead of its default pathspec interpretation which ignores `**`.