### PR TITLE
feat(chat): add input history and fix cancelled message handling

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -22,6 +22,7 @@ const mockChatState: ChatState = {
   contextWindow: 8192,
   pendingMessage: null,
   toolActive: false,
+  inputHistory: [],
   submit: vi.fn(),
   cancel: vi.fn(),
   cancelPending: vi.fn(),

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -196,7 +196,7 @@ export function App({ onRestart }: AppProps) {
               {chat.pendingMessage}
             </Text>
           </Text>
-          <Text dimColor>{"q cancel  ↑ edit"}</Text>
+          <Text dimColor>{"↑ edit"}</Text>
         </Box>
       ) : null}
 
@@ -220,6 +220,7 @@ export function App({ onRestart }: AppProps) {
         }
         pendingMessage={chat.pendingMessage}
         onCancelPending={chat.cancelPending}
+        inputHistory={chat.inputHistory}
       />
     </Box>
   );

--- a/src/components/chat-input.test.tsx
+++ b/src/components/chat-input.test.tsx
@@ -617,4 +617,124 @@ describe("ChatInput", () => {
 
     vi.restoreAllMocks();
   });
+
+  describe("input history", () => {
+    it("up arrow recalls last history entry", async () => {
+      const { lastFrame, stdin } = render(
+        <ChatInput onSubmit={vi.fn()} inputHistory={["first message"]} />,
+      );
+      stdin.write("\x1B[A");
+      await flush();
+      expect(lastFrame()).toContain("first message");
+    });
+
+    it("up arrow cycles through history oldest-first", async () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <ChatInput onSubmit={onSubmit} inputHistory={["one", "two"]} />,
+      );
+      stdin.write("\x1B[A");
+      await flush();
+      stdin.write("\x1B[A");
+      await flush();
+      stdin.write("\r");
+      await flush();
+      expect(onSubmit).toHaveBeenLastCalledWith("one");
+    });
+
+    it("down arrow navigates forward through history", async () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <ChatInput onSubmit={onSubmit} inputHistory={["one", "two"]} />,
+      );
+      stdin.write("\x1B[A");
+      await flush();
+      stdin.write("\x1B[A");
+      await flush();
+      stdin.write("\x1B[B");
+      await flush();
+      stdin.write("\r");
+      await flush();
+      expect(onSubmit).toHaveBeenLastCalledWith("two");
+    });
+
+    it("down arrow past end of history clears the input", async () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <ChatInput onSubmit={onSubmit} inputHistory={["hello"]} />,
+      );
+      stdin.write("\x1B[A");
+      await flush();
+      stdin.write("\x1B[B");
+      await flush();
+      stdin.write("\r");
+      await flush();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("does nothing with empty history", async () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <ChatInput onSubmit={onSubmit} inputHistory={[]} />,
+      );
+      stdin.write("\x1B[A");
+      await flush();
+      stdin.write("\r");
+      await flush();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pending message shortcuts", () => {
+    it("up arrow with pending message loads it into input", async () => {
+      const onCancelPending = vi.fn();
+      const { lastFrame, stdin } = render(
+        <ChatInput
+          onSubmit={vi.fn()}
+          pendingMessage="edit me"
+          onCancelPending={onCancelPending}
+        />,
+      );
+      stdin.write("\x1B[A");
+      await flush();
+      expect(onCancelPending).toHaveBeenCalled();
+      expect(lastFrame()).toContain("edit me");
+    });
+
+    it("up arrow after pending recall goes to previous history entry", async () => {
+      const onSubmit = vi.fn();
+      const onCancelPending = vi.fn();
+      const { stdin, rerender } = render(
+        <ChatInput
+          onSubmit={onSubmit}
+          inputHistory={["first", "second"]}
+          pendingMessage="second"
+          onCancelPending={onCancelPending}
+        />,
+      );
+
+      // Up arrow loads pending "second" into input
+      stdin.write("\x1B[A");
+      await flush();
+      expect(onCancelPending).toHaveBeenCalled();
+
+      // Clear pending prop to simulate cancelPending effect
+      rerender(
+        <ChatInput
+          onSubmit={onSubmit}
+          inputHistory={["first", "second"]}
+          pendingMessage={null}
+          onCancelPending={onCancelPending}
+        />,
+      );
+      await flush();
+
+      // Next up arrow should go straight to "first"
+      stdin.write("\x1B[A");
+      await flush();
+      stdin.write("\r");
+      await flush();
+      expect(onSubmit).toHaveBeenLastCalledWith("first");
+    });
+  });
 });

--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -22,6 +22,7 @@ interface ChatInputProps {
   contextPercent?: number | null;
   pendingMessage?: string | null;
   onCancelPending?: () => void;
+  inputHistory?: string[];
 }
 
 const commandProvider: AutocompleteProvider = {
@@ -71,12 +72,14 @@ export function ChatInput({
   contextPercent,
   pendingMessage,
   onCancelPending,
+  inputHistory = [],
 }: ChatInputProps) {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [columns, setColumns] = useState(stdout.columns || 80);
   const [value, setValue] = useState("");
   const [cursor, setCursor] = useState(0);
+  const historyIndexRef = useRef(-1);
   const [exitWarning, setExitWarning] = useState(false);
   const [clipboardImages, setClipboardImages] = useState<ImageAttachment[]>([]);
   const [imageNavActive, setImageNavActive] = useState(false);
@@ -161,18 +164,15 @@ export function ChatInput({
         return;
       }
 
-      // Pending message shortcuts — only when input is empty
-      if (pendingMessage && !value) {
-        if (input === "q") {
-          onCancelPending?.();
-          return;
-        }
-        if (key.upArrow) {
-          onCancelPending?.();
-          setValue(pendingMessage);
-          setCursor(pendingMessage.length);
-          return;
-        }
+      // Pending message shortcut — up arrow loads queued message into input
+      if (pendingMessage && !value && key.upArrow) {
+        onCancelPending?.();
+        setValue(pendingMessage);
+        setCursor(pendingMessage.length);
+        // Set history index so the next up arrow skips past this entry.
+        const lastIdx = inputHistory.lastIndexOf(pendingMessage);
+        historyIndexRef.current = lastIdx >= 0 ? lastIdx : inputHistory.length;
+        return;
       }
 
       if (key.escape) {
@@ -214,7 +214,7 @@ export function ChatInput({
         return;
       }
 
-      // Vertical cursor movement — autocomplete navigation or multi-line movement
+      // Vertical cursor movement — autocomplete, multi-line, or input history
       if (key.upArrow) {
         if (isAutocomplete && autocomplete.visibleEntries.length > 0) {
           autocomplete.moveUp();
@@ -227,6 +227,17 @@ export function ChatInput({
             lineStart === 0 ? 0 : value.lastIndexOf("\n", lineStart - 1) + 1;
           const prevLineLength = lineStart - prevLineStart;
           setCursor(prevLineStart + Math.min(col, prevLineLength));
+          return;
+        }
+        // On first line — recall from input history
+        if (inputHistory.length > 0) {
+          const nextIdx =
+            historyIndexRef.current === -1
+              ? inputHistory.length - 1
+              : Math.max(0, historyIndexRef.current - 1);
+          historyIndexRef.current = nextIdx;
+          setValue(inputHistory[nextIdx]);
+          setCursor(inputHistory[nextIdx].length);
         }
         return;
       }
@@ -248,7 +259,20 @@ export function ChatInput({
           setCursor(nextLineStart + Math.min(col, nextLineLength));
           return;
         }
-        // On last line — enter image navigation if images exist
+        // On last line — navigate history forward or enter image nav
+        if (historyIndexRef.current >= 0) {
+          const nextIdx = historyIndexRef.current + 1;
+          if (nextIdx >= inputHistory.length) {
+            historyIndexRef.current = -1;
+            setValue("");
+            setCursor(0);
+          } else {
+            historyIndexRef.current = nextIdx;
+            setValue(inputHistory[nextIdx]);
+            setCursor(inputHistory[nextIdx].length);
+          }
+          return;
+        }
         if (totalImages > 0) {
           setImageNavActive(true);
           setSelectedImageIdx(0);
@@ -285,6 +309,7 @@ export function ChatInput({
           setValue((v) => `${v.slice(0, cursor)}\n${v.slice(cursor)}`);
           setCursor((c) => c + 1);
         } else if (isAutocomplete && autocomplete.submitValue) {
+          historyIndexRef.current = -1;
           if (clipboardImages.length > 0) {
             onSubmit(autocomplete.submitValue, clipboardImages);
           } else {
@@ -294,6 +319,7 @@ export function ChatInput({
           setCursor(0);
           setClipboardImages([]);
         } else if (value.trim() || clipboardImages.length > 0) {
+          historyIndexRef.current = -1;
           if (clipboardImages.length > 0) {
             onSubmit(value, clipboardImages);
           } else {

--- a/src/components/thinking-indicator.tsx
+++ b/src/components/thinking-indicator.tsx
@@ -52,6 +52,7 @@ export function ThinkingIndicator() {
     <Box>
       <Text color="cyan">{spinnerFrame} </Text>
       <Text>{styledChars.join("")}</Text>
+      <Text dimColor>{"  esc cancel"}</Text>
     </Box>
   );
 }

--- a/src/hooks/use-chat.test.tsx
+++ b/src/hooks/use-chat.test.tsx
@@ -70,6 +70,7 @@ vi.mock("../session", () => ({
     messages: [],
   }),
   appendMessage: vi.fn(),
+  removeLastMessage: vi.fn(),
   loadSession: vi.fn(),
 }));
 
@@ -442,6 +443,127 @@ describe("useChat", () => {
 
       expect(chat.pendingMessage).toBeNull();
       expect(chat.streaming).toBe(true);
+    });
+  });
+
+  describe("cancelled message handling", () => {
+    it("removes user message from LLM context when cancelled with no response", async () => {
+      // Use a stream that blocks before yielding any content
+      vi.mocked(streamChatCompletion).mockImplementationOnce(
+        ({ signal }: { signal?: AbortSignal }) => {
+          return Promise.resolve({
+            content: (async function* () {
+              await new Promise<never>((_, reject) => {
+                if (signal?.aborted) {
+                  reject(new DOMException("aborted", "AbortError"));
+                  return;
+                }
+                signal?.addEventListener("abort", () =>
+                  reject(new DOMException("aborted", "AbortError")),
+                );
+              });
+            })(),
+            getUsage: () => null,
+            getToolCalls: () => [],
+          });
+        },
+      );
+
+      render(<TestApp />);
+      await flush();
+
+      chat.submit("message to cancel");
+      await flush();
+
+      expect(chat.messages.some((m) => m.content === "message to cancel")).toBe(
+        true,
+      );
+
+      chat.cancel();
+      await flush();
+      await flush();
+
+      expect(chat.messages.some((m) => m.content === "message to cancel")).toBe(
+        false,
+      );
+    });
+
+    it("cancelled message remains in input history for recall", async () => {
+      vi.mocked(streamChatCompletion).mockImplementationOnce(
+        ({ signal }: { signal?: AbortSignal }) => {
+          return Promise.resolve({
+            content: (async function* () {
+              await new Promise<never>((_, reject) => {
+                if (signal?.aborted) {
+                  reject(new DOMException("aborted", "AbortError"));
+                  return;
+                }
+                signal?.addEventListener("abort", () =>
+                  reject(new DOMException("aborted", "AbortError")),
+                );
+              });
+            })(),
+            getUsage: () => null,
+            getToolCalls: () => [],
+          });
+        },
+      );
+
+      render(<TestApp />);
+      await flush();
+
+      chat.submit("recall me later");
+      await flush();
+
+      chat.cancel();
+      await flush();
+      await flush();
+
+      // Gone from LLM messages
+      expect(chat.messages.some((m) => m.content === "recall me later")).toBe(
+        false,
+      );
+      // Still in input history
+      expect(chat.inputHistory).toContain("recall me later");
+    });
+  });
+
+  describe("input history", () => {
+    it("records submitted messages in input history", async () => {
+      render(<TestApp />);
+      await flush();
+
+      chat.submit("hello");
+      await flush();
+
+      expect(chat.inputHistory).toContain("hello");
+    });
+
+    it("records queued messages in input history", async () => {
+      render(<TestApp />);
+      await flush();
+
+      chat.submit("first");
+      await flush();
+
+      // Submit while streaming — gets queued
+      chat.submit("queued");
+      await flush();
+
+      expect(chat.inputHistory).toContain("queued");
+    });
+
+    it("deduplicates consecutive identical entries", async () => {
+      render(<TestApp />);
+      await flush();
+
+      chat.submit("same");
+      await flush();
+      // Queued "same" again — should not duplicate
+      chat.submit("same");
+      await flush();
+
+      expect(chat.inputHistory.filter((m) => m === "same")).toHaveLength(1);
     });
   });
 

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -26,6 +26,7 @@ import {
   appendMessage,
   createSession,
   loadSession,
+  removeLastMessage,
   type Session,
 } from "../session";
 import { getSkill } from "../skills";
@@ -48,6 +49,7 @@ export interface ChatState {
   contextWindow: number;
   pendingMessage: string | null;
   toolActive: boolean;
+  inputHistory: string[];
   submit: (text: string, clipboardImages?: ImageAttachment[]) => void;
   cancel: () => void;
   cancelPending: () => void;
@@ -127,6 +129,7 @@ export function useChat(
   const streamingRef = useRef(false);
   const pendingMessageRef = useRef<string | null>(null);
   const [pendingMessage, setPendingMessage] = useState<string | null>(null);
+  const inputHistoryRef = useRef<string[]>([]);
 
   // Detect context window from provider when model or provider changes.
   // Config override takes precedence — only fetch if no override is set.
@@ -170,6 +173,7 @@ export function useChat(
 
     pendingMessageRef.current = null;
     setPendingMessage(null);
+    inputHistoryRef.current = [];
     abortRef.current?.abort();
     setMessages([]);
     setStreaming(false);
@@ -181,6 +185,13 @@ export function useChat(
   };
 
   const submit = async (text: string, clipboardImages?: ImageAttachment[]) => {
+    // Record in input history for up/down recall. Deduplicate consecutive
+    // entries so re-submitting a queued message doesn't create a duplicate.
+    const history = inputHistoryRef.current;
+    if (text.trim() && history[history.length - 1] !== text) {
+      history.push(text);
+    }
+
     if (streamingRef.current) {
       pendingMessageRef.current = text;
       setPendingMessage(text);
@@ -505,8 +516,8 @@ export function useChat(
       }
     }
 
-    // On abort, preserve partial content and sync accumulated messages.
     if (aborted && content) {
+      // Partial response — preserve it.
       const partialMsg: DisplayMessage = {
         id: crypto.randomUUID(),
         role: "assistant",
@@ -514,6 +525,12 @@ export function useChat(
       };
       currentMessages = [...currentMessages, partialMsg];
       appendMessage(sessionRef.current, partialMsg);
+    }
+    if (aborted && !content) {
+      // No response at all — remove the orphaned user message from
+      // LLM context and session so it doesn't pollute the next turn.
+      currentMessages = currentMessages.filter((m) => m.id !== userMsg.id);
+      removeLastMessage(sessionRef.current);
     }
     if (aborted) {
       setMessages(currentMessages);
@@ -564,6 +581,7 @@ export function useChat(
     contextWindow,
     pendingMessage,
     toolActive,
+    inputHistory: inputHistoryRef.current,
     submit,
     cancel,
     cancelPending,

--- a/src/session.ts
+++ b/src/session.ts
@@ -128,6 +128,16 @@ export function appendMessage(session: Session, message: DisplayMessage): void {
   _lastSavedSessionId = session.id;
 }
 
+/** Removes the last message from a session's JSONL file. */
+export function removeLastMessage(session: Session): void {
+  const path = sessionPath(session.id);
+  if (!existsSync(path)) return;
+  const content = readFileSync(path, "utf-8");
+  const lines = content.trimEnd().split("\n");
+  if (lines.length <= 1) return;
+  writeFileSync(path, `${lines.slice(0, -1).join("\n")}\n`, "utf-8");
+}
+
 /** Loads a session by ID. Returns null if not found. */
 export function loadSession(id: string): Session | null {
   const path = sessionPath(id);


### PR DESCRIPTION
## Summary

Fixes cancelled messages polluting LLM context and adds shell-style input history with up/down arrow recall.

## GitHub Issue

Closes #159

## What Changed

When a user cancels a request before any response is produced, the orphaned user message is now removed from the message history and session file so it doesn't influence the next turn.

Input history is tracked in-memory in `useChat` — every `submit()` call records the text regardless of whether the message is sent, queued, or cancelled. This history is passed to `ChatInput` as a prop and navigated with up/down arrows when on the first/last line. It is not persisted to session files; loading a session only includes messages that were part of the conversation.

The pending message "↑ edit" hint and thinking indicator "esc cancel" hint are also included.

## Notes for Reviewers

Input history is deliberately separate from `messages` — they serve different purposes. `messages` is LLM context (what the model sees). `inputHistory` is user recall (what the user typed). Cancelled messages are removed from the former but kept in the latter.