### PR TITLE
refactor(ui): extract shared ConfirmPrompt component

### DIFF
--- a/src/components/command-confirm.tsx
+++ b/src/components/command-confirm.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
 import chalk from "chalk";
-import { Box, Text, useInput } from "ink";
+import { Text } from "ink";
+import { ConfirmPrompt } from "./confirm-prompt";
 
 interface CommandConfirmProps {
   command: string;
@@ -16,64 +16,30 @@ export function CommandConfirm({
   onApproveAlways,
   onDeny,
 }: CommandConfirmProps) {
-  const [cursor, setCursor] = useState(0);
-
-  useInput((input, key) => {
-    if (key.escape || input === "n" || input === "N") {
-      onDeny();
-      return;
-    }
-
-    if (input === "y" || input === "Y") {
-      onApprove();
-      return;
-    }
-
-    if (input === "a" || input === "A") {
-      onApproveAlways();
-      return;
-    }
-
-    if (key.return) {
-      if (cursor === 0) onApprove();
-      else if (cursor === 1) onApproveAlways();
-      else onDeny();
-      return;
-    }
-
-    if (key.upArrow) {
-      setCursor((c) => (c > 0 ? c - 1 : 2));
-      return;
-    }
-
-    if (key.downArrow) {
-      setCursor((c) => (c < 2 ? c + 1 : 0));
-    }
-  });
-
   return (
-    <Box flexDirection="column">
-      <Text bold color="yellow">
-        {"  Run this command?"}
-      </Text>
+    <ConfirmPrompt
+      title="Run this command?"
+      options={[
+        {
+          label: "Approve",
+          shortcut: "y",
+          color: "green",
+          onSelect: onApprove,
+        },
+        {
+          label: "Approve Always",
+          shortcut: "a",
+          color: "cyan",
+          onSelect: onApproveAlways,
+        },
+        { label: "Deny", shortcut: "n", color: "red", onSelect: onDeny },
+      ]}
+    >
       <Text>{""}</Text>
       <Text>
         {"  "}
         {chalk.bold(`> ${command}`)}
       </Text>
-      <Text>{""}</Text>
-      <Text color={cursor === 0 ? "green" : undefined}>
-        {"  "}
-        {cursor === 0 ? "❯" : " "} Approve (y)
-      </Text>
-      <Text color={cursor === 1 ? "cyan" : undefined}>
-        {"  "}
-        {cursor === 1 ? "❯" : " "} Approve Always (a)
-      </Text>
-      <Text color={cursor === 2 ? "red" : undefined}>
-        {"  "}
-        {cursor === 2 ? "❯" : " "} Deny (n)
-      </Text>
-    </Box>
+    </ConfirmPrompt>
   );
 }

--- a/src/components/confirm-prompt.test.tsx
+++ b/src/components/confirm-prompt.test.tsx
@@ -1,0 +1,173 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { ConfirmPrompt } from "./confirm-prompt";
+import { Text } from "ink";
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+
+describe("ConfirmPrompt", () => {
+  it("renders title, children, and options", () => {
+    const { lastFrame } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: vi.fn() },
+          { label: "No", shortcut: "n", color: "red", onSelect: vi.fn() },
+        ]}
+      >
+        <Text>{"  detail line"}</Text>
+      </ConfirmPrompt>,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain("Test?");
+    expect(output).toContain("detail line");
+    expect(output).toContain("Yes (y)");
+    expect(output).toContain("No (n)");
+  });
+
+  it("calls matching option on shortcut key", async () => {
+    const onApprove = vi.fn();
+    const { stdin } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: onApprove },
+          { label: "No", shortcut: "n", color: "red", onSelect: vi.fn() },
+        ]}
+      />,
+    );
+
+    stdin.write("y");
+    await flush();
+    expect(onApprove).toHaveBeenCalled();
+  });
+
+  it("shortcut is case-insensitive", async () => {
+    const onApprove = vi.fn();
+    const { stdin } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: onApprove },
+          { label: "No", shortcut: "n", color: "red", onSelect: vi.fn() },
+        ]}
+      />,
+    );
+
+    stdin.write("Y");
+    await flush();
+    expect(onApprove).toHaveBeenCalled();
+  });
+
+  it("escape triggers the last option", async () => {
+    const onDeny = vi.fn();
+    const { stdin } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: vi.fn() },
+          { label: "No", shortcut: "n", color: "red", onSelect: onDeny },
+        ]}
+      />,
+    );
+
+    stdin.write("\x1B");
+    await flush();
+    expect(onDeny).toHaveBeenCalled();
+  });
+
+  it("enter selects the option at cursor (default first)", async () => {
+    const onApprove = vi.fn();
+    const { stdin } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: onApprove },
+          { label: "No", shortcut: "n", color: "red", onSelect: vi.fn() },
+        ]}
+      />,
+    );
+
+    stdin.write("\r");
+    await flush();
+    expect(onApprove).toHaveBeenCalled();
+  });
+
+  it("arrow keys move cursor and enter selects", async () => {
+    const onDeny = vi.fn();
+    const { stdin } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: vi.fn() },
+          { label: "No", shortcut: "n", color: "red", onSelect: onDeny },
+        ]}
+      />,
+    );
+
+    stdin.write("\x1B[B"); // down to No
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onDeny).toHaveBeenCalled();
+  });
+
+  it("cursor wraps around downward", async () => {
+    const onApprove = vi.fn();
+    const { stdin } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: onApprove },
+          { label: "No", shortcut: "n", color: "red", onSelect: vi.fn() },
+        ]}
+      />,
+    );
+
+    stdin.write("\x1B[B"); // down to No
+    await flush();
+    stdin.write("\x1B[B"); // wrap to Yes
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onApprove).toHaveBeenCalled();
+  });
+
+  it("cursor wraps around upward", async () => {
+    const onDeny = vi.fn();
+    const { stdin } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: vi.fn() },
+          { label: "No", shortcut: "n", color: "red", onSelect: onDeny },
+        ]}
+      />,
+    );
+
+    stdin.write("\x1B[A"); // up wraps to No
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onDeny).toHaveBeenCalled();
+  });
+
+  it("works with three options", async () => {
+    const onAlways = vi.fn();
+    const { stdin } = render(
+      <ConfirmPrompt
+        title="Test?"
+        options={[
+          { label: "Yes", shortcut: "y", color: "green", onSelect: vi.fn() },
+          { label: "Always", shortcut: "a", color: "cyan", onSelect: onAlways },
+          { label: "No", shortcut: "n", color: "red", onSelect: vi.fn() },
+        ]}
+      />,
+    );
+
+    stdin.write("a");
+    await flush();
+    expect(onAlways).toHaveBeenCalled();
+  });
+});

--- a/src/components/confirm-prompt.tsx
+++ b/src/components/confirm-prompt.tsx
@@ -1,0 +1,72 @@
+import { type ReactNode, useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface ConfirmOption {
+  label: string;
+  shortcut: string;
+  color: string;
+  onSelect: () => void;
+}
+
+interface ConfirmPromptProps {
+  title: string;
+  children?: ReactNode;
+  options: ConfirmOption[];
+}
+
+/** Generic confirmation prompt with keyboard-driven option selection. */
+export function ConfirmPrompt({
+  title,
+  children,
+  options,
+}: ConfirmPromptProps) {
+  const [cursor, setCursor] = useState(0);
+  const lastIndex = options.length - 1;
+
+  useInput((input, key) => {
+    if (key.escape) {
+      options[lastIndex].onSelect();
+      return;
+    }
+
+    const lower = input.toLowerCase();
+    const match = options.find((o) => o.shortcut.toLowerCase() === lower);
+    if (match) {
+      match.onSelect();
+      return;
+    }
+
+    if (key.return) {
+      options[cursor].onSelect();
+      return;
+    }
+
+    if (key.upArrow) {
+      setCursor((c) => (c > 0 ? c - 1 : lastIndex));
+      return;
+    }
+
+    if (key.downArrow) {
+      setCursor((c) => (c < lastIndex ? c + 1 : 0));
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color="yellow">
+        {`  ${title}`}
+      </Text>
+      {children}
+      <Text>{""}</Text>
+      {options.map((option, i) => (
+        <Text
+          key={option.shortcut}
+          color={cursor === i ? option.color : undefined}
+        >
+          {"  "}
+          {cursor === i ? "❯" : " "} {option.label} ({option.shortcut})
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/components/file-access-confirm.tsx
+++ b/src/components/file-access-confirm.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
 import chalk from "chalk";
-import { Box, Text, useInput } from "ink";
+import { Text } from "ink";
+import { ConfirmPrompt } from "./confirm-prompt";
 
 interface FileAccessConfirmProps {
   filePath: string;
@@ -16,53 +16,25 @@ export function FileAccessConfirm({
   onApprove,
   onDeny,
 }: FileAccessConfirmProps) {
-  const [cursor, setCursor] = useState(0);
-
-  useInput((input, key) => {
-    if (key.escape || input === "n" || input === "N") {
-      onDeny();
-      return;
-    }
-
-    if (input === "y" || input === "Y") {
-      onApprove();
-      return;
-    }
-
-    if (key.return) {
-      if (cursor === 0) {
-        onApprove();
-      } else {
-        onDeny();
-      }
-      return;
-    }
-
-    if (key.upArrow || key.downArrow) {
-      setCursor((c) => (c === 0 ? 1 : 0));
-    }
-  });
-
   return (
-    <Box flexDirection="column">
-      <Text bold color="yellow">
-        {`  ${action}`}
-      </Text>
-      <Text> </Text>
+    <ConfirmPrompt
+      title={action}
+      options={[
+        {
+          label: "Approve",
+          shortcut: "y",
+          color: "green",
+          onSelect: onApprove,
+        },
+        { label: "Deny", shortcut: "n", color: "red", onSelect: onDeny },
+      ]}
+    >
+      <Text>{""}</Text>
       <Text>
         {"  "}
         {chalk.bold(filePath)}
       </Text>
-      <Text> </Text>
-      <Text> </Text>
-      <Text color={cursor === 0 ? "green" : undefined}>
-        {"  "}
-        {cursor === 0 ? "❯" : " "} Approve (y)
-      </Text>
-      <Text color={cursor === 1 ? "red" : undefined}>
-        {"  "}
-        {cursor === 1 ? "❯" : " "} Deny (n)
-      </Text>
-    </Box>
+      <Text>{""}</Text>
+    </ConfirmPrompt>
   );
 }

--- a/src/components/write-file-confirm.tsx
+++ b/src/components/write-file-confirm.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
 import chalk from "chalk";
-import { Box, Text, useInput } from "ink";
+import { Text } from "ink";
+import { ConfirmPrompt } from "./confirm-prompt";
 
 interface WriteFileConfirmProps {
   filePath: string;
@@ -18,56 +18,28 @@ export function WriteFileConfirm({
   onApprove,
   onDeny,
 }: WriteFileConfirmProps) {
-  const [cursor, setCursor] = useState(0);
-
-  useInput((input, key) => {
-    if (key.escape || input === "n" || input === "N") {
-      onDeny();
-      return;
-    }
-
-    if (input === "y" || input === "Y") {
-      onApprove();
-      return;
-    }
-
-    if (key.return) {
-      if (cursor === 0) {
-        onApprove();
-      } else {
-        onDeny();
-      }
-      return;
-    }
-
-    if (key.upArrow || key.downArrow) {
-      setCursor((c) => (c === 0 ? 1 : 0));
-    }
-  });
-
   const status = isNewFile ? chalk.green("new file") : chalk.yellow("modified");
 
   return (
-    <Box flexDirection="column">
-      <Text bold color="yellow">
-        {"  Write to file?"}
-      </Text>
-      <Text> </Text>
+    <ConfirmPrompt
+      title="Write to file?"
+      options={[
+        {
+          label: "Approve",
+          shortcut: "y",
+          color: "green",
+          onSelect: onApprove,
+        },
+        { label: "Deny", shortcut: "n", color: "red", onSelect: onDeny },
+      ]}
+    >
+      <Text>{""}</Text>
       <Text>
         {"  "}
         {chalk.bold(filePath)} ({status})
       </Text>
-      <Text> </Text>
+      <Text>{""}</Text>
       <Text>{diffPreview}</Text>
-      <Text> </Text>
-      <Text color={cursor === 0 ? "green" : undefined}>
-        {"  "}
-        {cursor === 0 ? "❯" : " "} Approve (y)
-      </Text>
-      <Text color={cursor === 1 ? "red" : undefined}>
-        {"  "}
-        {cursor === 1 ? "❯" : " "} Deny (n)
-      </Text>
-    </Box>
+    </ConfirmPrompt>
   );
 }


### PR DESCRIPTION
## Summary

Extract a generic `ConfirmPrompt` component from three near-identical confirmation dialogs (`WriteFileConfirm`, `FileAccessConfirm`, `CommandConfirm`), eliminating ~145 lines of duplicated cursor state, keyboard handling, and option rendering logic.

## GitHub Issue

Closes #168

## What Changed

Added a new `ConfirmPrompt` component that accepts a title, children (for custom content between the title and options), and an array of configurable options — each with a label, keyboard shortcut, color, and callback. The three existing confirmation components now delegate all interaction logic to `ConfirmPrompt` and only define their layout and option configuration.

The shared component supports any number of options, cursor wrapping with arrow keys, case-insensitive shortcut keys, and escape always triggering the last option (deny). All existing keyboard behaviour is preserved.