### PR TITLE
refactor(ui): extract useListNavigation hook from selector components

### DIFF
--- a/src/components/configure-selector.tsx
+++ b/src/components/configure-selector.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import { fetchModels, type ModelInfo } from "../provider/client";
+import { useListNavigation } from "../hooks/use-list-navigation";
 
 interface ProviderEntry {
   name: string;
@@ -52,7 +53,6 @@ export function ConfigureSelector({
   onCancel,
 }: ConfigureSelectorProps) {
   const [step, setStep] = useState<Step>("menu");
-  const [cursor, setCursor] = useState(0);
   const [newProvider, setNewProvider] = useState<NewProvider>({
     type: "",
     baseUrl: "",
@@ -63,7 +63,6 @@ export function ConfigureSelector({
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [nameError, setNameError] = useState<string | null>(null);
   const [modelFilter, setModelFilter] = useState("");
-  const modelWindowRef = useRef(0);
 
   const MAX_VISIBLE = 5;
   const menuOptions = ["Add provider", "Remove provider"];
@@ -76,11 +75,31 @@ export function ConfigureSelector({
       )
     : models;
 
-  // Reset cursor and scroll window when step changes
+  // Compute item count based on current step
+  const itemCount = (() => {
+    switch (step) {
+      case "menu":
+        return menuOptions.length;
+      case "selectType":
+        return PROVIDER_TYPES.length;
+      case "selectModel":
+        return filteredModels.length;
+      case "removeProvider":
+        return removableProviders.length;
+      default:
+        return 0;
+    }
+  })();
+
+  const { cursor, setCursor, windowStart, handleUp, handleDown } =
+    useListNavigation(itemCount, {
+      maxVisible: step === "selectModel" ? MAX_VISIBLE : undefined,
+    });
+
+  // Reset cursor and filter when step changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset cursor on step change
   useEffect(() => {
     setCursor(0);
-    modelWindowRef.current = 0;
     setModelFilter("");
   }, [step]);
 
@@ -91,7 +110,6 @@ export function ConfigureSelector({
       } else if (step === "selectModel" && modelFilter) {
         setModelFilter("");
         setCursor(0);
-        modelWindowRef.current = 0;
       } else {
         setStep("menu");
         setNewProvider({ type: "", baseUrl: "" });
@@ -105,9 +123,9 @@ export function ConfigureSelector({
     switch (step) {
       case "menu": {
         if (key.upArrow) {
-          setCursor((c) => (c > 0 ? c - 1 : menuOptions.length - 1));
+          handleUp();
         } else if (key.downArrow) {
-          setCursor((c) => (c < menuOptions.length - 1 ? c + 1 : 0));
+          handleDown();
         } else if (key.return) {
           if (cursor === 0) {
             setStep("selectType");
@@ -121,9 +139,9 @@ export function ConfigureSelector({
 
       case "selectType": {
         if (key.upArrow) {
-          setCursor((c) => (c > 0 ? c - 1 : PROVIDER_TYPES.length - 1));
+          handleUp();
         } else if (key.downArrow) {
-          setCursor((c) => (c < PROVIDER_TYPES.length - 1 ? c + 1 : 0));
+          handleDown();
         } else if (key.return) {
           const type = PROVIDER_TYPES[cursor];
           setNewProvider({ type, baseUrl: "" });
@@ -172,9 +190,9 @@ export function ConfigureSelector({
 
       case "selectModel": {
         if (key.upArrow) {
-          setCursor((c) => (c > 0 ? c - 1 : filteredModels.length - 1));
+          handleUp();
         } else if (key.downArrow) {
-          setCursor((c) => (c < filteredModels.length - 1 ? c + 1 : 0));
+          handleDown();
         } else if (key.return && filteredModels.length > 0) {
           const model = filteredModels[cursor];
           if (!model) return;
@@ -185,13 +203,11 @@ export function ConfigureSelector({
         } else if (key.backspace || key.delete) {
           setModelFilter((f) => {
             setCursor(0);
-            modelWindowRef.current = 0;
             return f.slice(0, -1);
           });
         } else if (input && !key.ctrl && !key.meta) {
           setModelFilter((f) => {
             setCursor(0);
-            modelWindowRef.current = 0;
             return f + input;
           });
         }
@@ -229,9 +245,9 @@ export function ConfigureSelector({
 
       case "removeProvider": {
         if (key.upArrow) {
-          setCursor((c) => (c > 0 ? c - 1 : removableProviders.length - 1));
+          handleUp();
         } else if (key.downArrow) {
-          setCursor((c) => (c < removableProviders.length - 1 ? c + 1 : 0));
+          handleDown();
         } else if (key.return && removableProviders.length > 0) {
           const provider = removableProviders[cursor];
           if (!provider) return;
@@ -359,19 +375,9 @@ export function ConfigureSelector({
       return <Text dimColor>{"  Fetching models..."}</Text>;
 
     case "selectModel": {
-      // Keep scroll window around cursor
-      if (cursor < modelWindowRef.current) {
-        modelWindowRef.current = cursor;
-      } else if (cursor >= modelWindowRef.current + MAX_VISIBLE) {
-        modelWindowRef.current = cursor - MAX_VISIBLE + 1;
-      }
-      modelWindowRef.current = Math.min(
-        modelWindowRef.current,
-        Math.max(0, filteredModels.length - MAX_VISIBLE),
-      );
       const visibleModels = filteredModels.slice(
-        modelWindowRef.current,
-        modelWindowRef.current + MAX_VISIBLE,
+        windowStart,
+        windowStart + MAX_VISIBLE,
       );
       const remaining = filteredModels.length - MAX_VISIBLE;
       return (
@@ -397,7 +403,7 @@ export function ConfigureSelector({
             <Text dimColor>{"    No models match your search."}</Text>
           )}
           {visibleModels.map((model, i) => {
-            const actualIdx = modelWindowRef.current + i;
+            const actualIdx = windowStart + i;
             const isCursor = actualIdx === cursor;
             const prefix = isCursor ? "❯" : " ";
             return (

--- a/src/components/model-selector.tsx
+++ b/src/components/model-selector.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { ModelInfo } from "../provider/client";
 import { fetchModels, resolveApiKey } from "../provider/client";
+import { useListNavigation } from "../hooks/use-list-navigation";
 
 interface ProviderEntry {
   name: string;
@@ -75,10 +76,8 @@ export function ModelSelector({
     .filter((i) => i >= 0);
 
   const MAX_VISIBLE = 5;
-  const [cursor, setCursor] = useState(0);
   const [initialised, setInitialised] = useState(false);
   const [filter, setFilter] = useState("");
-  const windowStartRef = useRef(0);
 
   // Filter selectable indices by search term
   const filteredIndices = filter
@@ -90,6 +89,9 @@ export function ModelSelector({
         );
       })
     : selectableIndices;
+
+  const { cursor, setCursor, windowStart, handleUp, handleDown } =
+    useListNavigation(filteredIndices.length, { maxVisible: MAX_VISIBLE });
 
   // Set cursor to active model once results arrive
   // biome-ignore lint/correctness/useExhaustiveDependencies: only trigger on load completion
@@ -103,15 +105,7 @@ export function ModelSelector({
           row.model === activeModel
         );
       });
-      const pos = initial >= 0 ? initial : 0;
-      setCursor(pos);
-      windowStartRef.current = Math.max(
-        0,
-        Math.min(
-          pos - Math.floor(MAX_VISIBLE / 2),
-          filteredIndices.length - MAX_VISIBLE,
-        ),
-      );
+      setCursor(initial >= 0 ? initial : 0);
       setInitialised(true);
     }
   }, [loading, initialised, filteredIndices.length]);
@@ -121,7 +115,6 @@ export function ModelSelector({
       if (filter) {
         setFilter("");
         setCursor(0);
-        windowStartRef.current = 0;
         return;
       }
       onCancel();
@@ -139,20 +132,18 @@ export function ModelSelector({
     }
 
     if (key.upArrow) {
-      setCursor((c) => (c > 0 ? c - 1 : filteredIndices.length - 1));
+      handleUp();
       return;
     }
     if (key.downArrow) {
-      setCursor((c) => (c < filteredIndices.length - 1 ? c + 1 : 0));
+      handleDown();
       return;
     }
 
     if (key.backspace || key.delete) {
       setFilter((f) => {
-        const next = f.slice(0, -1);
         setCursor(0);
-        windowStartRef.current = 0;
-        return next;
+        return f.slice(0, -1);
       });
       return;
     }
@@ -160,22 +151,10 @@ export function ModelSelector({
     if (input && !key.ctrl && !key.meta) {
       setFilter((f) => {
         setCursor(0);
-        windowStartRef.current = 0;
         return f + input;
       });
     }
   });
-
-  // Keep the scroll window around the cursor
-  if (cursor < windowStartRef.current) {
-    windowStartRef.current = cursor;
-  } else if (cursor >= windowStartRef.current + MAX_VISIBLE) {
-    windowStartRef.current = cursor - MAX_VISIBLE + 1;
-  }
-  windowStartRef.current = Math.min(
-    windowStartRef.current,
-    Math.max(0, filteredIndices.length - MAX_VISIBLE),
-  );
 
   if (loading) {
     return <Text dimColor>{"  Fetching models..."}</Text>;
@@ -187,8 +166,8 @@ export function ModelSelector({
 
   // Visible window of filtered model rows
   const visibleSelectables = filteredIndices.slice(
-    windowStartRef.current,
-    windowStartRef.current + MAX_VISIBLE,
+    windowStart,
+    windowStart + MAX_VISIBLE,
   );
   const remaining = filteredIndices.length - MAX_VISIBLE;
 

--- a/src/components/session-selector.tsx
+++ b/src/components/session-selector.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { Session } from "../session";
 import { listSessions } from "../session";
+import { useListNavigation } from "../hooks/use-list-navigation";
 
 const WINDOW_SIZE = 5;
 const MAX_PREVIEW_LENGTH = 50;
@@ -50,8 +51,10 @@ interface SessionSelectorProps {
 /** Interactive session picker with arrow key navigation and a sliding window. */
 export function SessionSelector({ onSelect, onCancel }: SessionSelectorProps) {
   const [sessions] = useState<Session[]>(() => listSessions(50));
-  const [cursor, setCursor] = useState(0);
-  const [windowStart, setWindowStart] = useState(0);
+  const { cursor, windowStart, handleUp, handleDown } = useListNavigation(
+    sessions.length,
+    { maxVisible: WINDOW_SIZE, wrap: false },
+  );
 
   useInput((_, key) => {
     if (key.escape) {
@@ -64,17 +67,8 @@ export function SessionSelector({ onSelect, onCancel }: SessionSelectorProps) {
       return;
     }
 
-    if (key.upArrow && cursor > 0) {
-      const next = cursor - 1;
-      setCursor(next);
-      if (next < windowStart) setWindowStart(next);
-    }
-
-    if (key.downArrow && cursor < sessions.length - 1) {
-      const next = cursor + 1;
-      setCursor(next);
-      if (next >= windowStart + WINDOW_SIZE) setWindowStart(windowStart + 1);
-    }
+    if (key.upArrow) handleUp();
+    if (key.downArrow) handleDown();
   });
 
   if (sessions.length === 0) {

--- a/src/components/settings-selector.tsx
+++ b/src/components/settings-selector.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import { CheckboxList, type CheckboxItem } from "./checkbox-list";
+import { useListNavigation } from "../hooks/use-list-navigation";
 
 interface PermissionRow {
   key: string;
@@ -63,7 +64,6 @@ export function SettingsSelector({
   onCancel,
 }: SettingsSelectorProps) {
   const [step, setStep] = useState<Step>("menu");
-  const [cursor, setCursor] = useState(0);
   const [toolAvailability, setToolAvailability] = useState({
     ...currentToolAvailability,
   });
@@ -73,6 +73,23 @@ export function SettingsSelector({
   ]);
   const [adding, setAdding] = useState(false);
   const [newEntry, setNewEntry] = useState("");
+
+  // Compute item count based on current step
+  const itemCount = (() => {
+    switch (step) {
+      case "menu":
+        return MENU_OPTIONS.length;
+      case "tools":
+        return tools.length;
+      case "permissions":
+        return PERMISSION_ROWS.length;
+      case "allowed":
+        return allowedCommands.length + 1; // +1 for "Add..." row
+    }
+  })();
+
+  const { cursor, setCursor, handleUp, handleDown } =
+    useListNavigation(itemCount);
 
   // Reset cursor when step changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset cursor on step change
@@ -132,9 +149,9 @@ export function SettingsSelector({
     switch (step) {
       case "menu": {
         if (key.upArrow) {
-          setCursor((c) => (c > 0 ? c - 1 : MENU_OPTIONS.length - 1));
+          handleUp();
         } else if (key.downArrow) {
-          setCursor((c) => (c < MENU_OPTIONS.length - 1 ? c + 1 : 0));
+          handleDown();
         } else if (key.return) {
           const steps: Step[] = ["tools", "permissions", "allowed"];
           setStep(steps[cursor]);
@@ -144,9 +161,9 @@ export function SettingsSelector({
 
       case "tools": {
         if (key.upArrow) {
-          setCursor((c) => (c > 0 ? c - 1 : tools.length - 1));
+          handleUp();
         } else if (key.downArrow) {
-          setCursor((c) => (c < tools.length - 1 ? c + 1 : 0));
+          handleDown();
         } else if (input === " " || key.return) {
           const name = tools[cursor];
           setToolAvailability((prev) => ({
@@ -159,9 +176,9 @@ export function SettingsSelector({
 
       case "permissions": {
         if (key.upArrow) {
-          setCursor((c) => (c > 0 ? c - 1 : PERMISSION_ROWS.length - 1));
+          handleUp();
         } else if (key.downArrow) {
-          setCursor((c) => (c < PERMISSION_ROWS.length - 1 ? c + 1 : 0));
+          handleDown();
         } else if (input === " " || key.return) {
           const row = PERMISSION_ROWS[cursor];
           setPermissions((prev) => ({
@@ -173,17 +190,15 @@ export function SettingsSelector({
       }
 
       case "allowed": {
-        // rows: allowed commands + add row
-        const totalRows = allowedCommands.length + 1;
         const isOnAdd = cursor === allowedCommands.length;
 
         if (key.upArrow) {
-          setCursor((c) => (c > 0 ? c - 1 : totalRows - 1));
+          handleUp();
         } else if (key.downArrow) {
-          setCursor((c) => (c < totalRows - 1 ? c + 1 : 0));
+          handleDown();
         } else if ((input === "d" || input === "D") && !isOnAdd) {
           setAllowedCommands((prev) => prev.filter((_, i) => i !== cursor));
-          if (cursor >= totalRows - 1) {
+          if (cursor >= itemCount - 1) {
             setCursor((c) => Math.max(0, c - 1));
           }
         } else if (input === "a" || input === "A") {

--- a/src/hooks/use-list-navigation.test.tsx
+++ b/src/hooks/use-list-navigation.test.tsx
@@ -1,0 +1,281 @@
+import { render } from "ink-testing-library";
+import { Text } from "ink";
+import { describe, expect, it } from "vitest";
+import { useListNavigation } from "./use-list-navigation";
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+
+interface HarnessProps {
+  itemCount: number;
+  maxVisible?: number;
+  wrap?: boolean;
+}
+
+let controls: {
+  cursor: number;
+  windowStart: number;
+  handleUp: () => void;
+  handleDown: () => void;
+  setCursor: (n: number) => void;
+};
+
+function Harness({ itemCount, maxVisible, wrap }: HarnessProps) {
+  const nav = useListNavigation(itemCount, { maxVisible, wrap });
+  controls = {
+    ...nav,
+    setCursor: (n: number) => nav.setCursor(n),
+  };
+  return (
+    <Text>
+      {nav.cursor}/{nav.windowStart}
+    </Text>
+  );
+}
+
+describe("useListNavigation", () => {
+  describe("cursor wrapping (default)", () => {
+    it("wraps cursor down past last item to first", async () => {
+      render(<Harness itemCount={3} />);
+      await flush();
+      controls.setCursor(2);
+      await flush();
+      controls.handleDown();
+      await flush();
+      expect(controls.cursor).toBe(0);
+    });
+
+    it("wraps cursor up past first item to last", async () => {
+      render(<Harness itemCount={3} />);
+      await flush();
+      controls.handleUp();
+      await flush();
+      expect(controls.cursor).toBe(2);
+    });
+
+    it("moves cursor down normally", async () => {
+      render(<Harness itemCount={3} />);
+      await flush();
+      controls.handleDown();
+      await flush();
+      expect(controls.cursor).toBe(1);
+    });
+
+    it("moves cursor up normally", async () => {
+      render(<Harness itemCount={3} />);
+      await flush();
+      controls.setCursor(2);
+      await flush();
+      controls.handleUp();
+      await flush();
+      expect(controls.cursor).toBe(1);
+    });
+
+    it("traverses full list with sequential down presses", async () => {
+      render(<Harness itemCount={4} />);
+      await flush();
+      for (let i = 0; i < 4; i++) {
+        expect(controls.cursor).toBe(i);
+        controls.handleDown();
+        await flush();
+      }
+      // Should have wrapped back to 0
+      expect(controls.cursor).toBe(0);
+    });
+  });
+
+  describe("non-wrapping mode", () => {
+    it("stops at first item going up", async () => {
+      render(<Harness itemCount={3} wrap={false} />);
+      await flush();
+      controls.handleUp();
+      await flush();
+      expect(controls.cursor).toBe(0);
+    });
+
+    it("stops at last item going down", async () => {
+      render(<Harness itemCount={3} wrap={false} />);
+      await flush();
+      controls.setCursor(2);
+      await flush();
+      controls.handleDown();
+      await flush();
+      expect(controls.cursor).toBe(2);
+    });
+
+    it("moves normally within range", async () => {
+      render(<Harness itemCount={5} wrap={false} />);
+      await flush();
+      controls.handleDown();
+      await flush();
+      controls.handleDown();
+      await flush();
+      expect(controls.cursor).toBe(2);
+      controls.handleUp();
+      await flush();
+      expect(controls.cursor).toBe(1);
+    });
+  });
+
+  describe("sliding window", () => {
+    it("keeps windowStart at 0 initially", async () => {
+      render(<Harness itemCount={10} maxVisible={3} />);
+      await flush();
+      expect(controls.windowStart).toBe(0);
+    });
+
+    it("slides window down when cursor passes bottom edge", async () => {
+      render(<Harness itemCount={10} maxVisible={3} />);
+      await flush();
+      controls.setCursor(3);
+      await flush();
+      expect(controls.windowStart).toBe(1);
+    });
+
+    it("slides window up when cursor passes top edge", async () => {
+      render(<Harness itemCount={10} maxVisible={3} />);
+      await flush();
+      controls.setCursor(5);
+      await flush();
+      controls.setCursor(2);
+      await flush();
+      expect(controls.windowStart).toBe(2);
+    });
+
+    it("does not shift window when cursor moves within visible range", async () => {
+      render(<Harness itemCount={10} maxVisible={5} />);
+      await flush();
+      controls.handleDown(); // cursor 1, window [0..4]
+      await flush();
+      expect(controls.windowStart).toBe(0);
+      controls.handleDown(); // cursor 2, still in window
+      await flush();
+      expect(controls.windowStart).toBe(0);
+      controls.handleDown(); // cursor 3, still in window
+      await flush();
+      expect(controls.windowStart).toBe(0);
+    });
+
+    it("clamps window when cursor is near end of list", async () => {
+      render(<Harness itemCount={5} maxVisible={3} />);
+      await flush();
+      controls.setCursor(4); // last item
+      await flush();
+      // windowStart should be at most 5 - 3 = 2
+      expect(controls.windowStart).toBe(2);
+    });
+
+    it("window follows cursor wrapping back to top", async () => {
+      render(<Harness itemCount={10} maxVisible={3} />);
+      await flush();
+      controls.setCursor(9); // last item, windowStart = 7
+      await flush();
+      expect(controls.windowStart).toBe(7);
+      controls.handleDown(); // wraps to 0
+      await flush();
+      expect(controls.cursor).toBe(0);
+      expect(controls.windowStart).toBe(0);
+    });
+
+    it("does nothing when maxVisible >= itemCount", async () => {
+      render(<Harness itemCount={3} maxVisible={5} />);
+      await flush();
+      controls.setCursor(2);
+      await flush();
+      // Window should stay at 0 since all items fit
+      expect(controls.windowStart).toBe(0);
+    });
+
+    it("works with non-wrapping mode", async () => {
+      render(<Harness itemCount={10} maxVisible={3} wrap={false} />);
+      await flush();
+      controls.setCursor(5);
+      await flush();
+      expect(controls.windowStart).toBe(3);
+      // Going down to boundary then trying to go past
+      controls.setCursor(9);
+      await flush();
+      controls.handleDown(); // should stay at 9
+      await flush();
+      expect(controls.cursor).toBe(9);
+      expect(controls.windowStart).toBe(7);
+    });
+  });
+
+  describe("dynamic item count", () => {
+    it("clamps cursor when item count shrinks below cursor", async () => {
+      const { rerender } = render(<Harness itemCount={5} />);
+      await flush();
+      controls.setCursor(4);
+      await flush();
+      expect(controls.cursor).toBe(4);
+      rerender(<Harness itemCount={3} />);
+      await flush();
+      expect(controls.cursor).toBe(2);
+    });
+
+    it("keeps cursor at 0 when item count grows", async () => {
+      const { rerender } = render(<Harness itemCount={3} />);
+      await flush();
+      expect(controls.cursor).toBe(0);
+      rerender(<Harness itemCount={10} />);
+      await flush();
+      expect(controls.cursor).toBe(0);
+    });
+
+    it("cursor reset to 0 also resets window", async () => {
+      render(<Harness itemCount={10} maxVisible={3} />);
+      await flush();
+      controls.setCursor(7);
+      await flush();
+      expect(controls.windowStart).toBe(5);
+      controls.setCursor(0);
+      await flush();
+      expect(controls.windowStart).toBe(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles zero items", async () => {
+      render(<Harness itemCount={0} />);
+      await flush();
+      controls.handleUp();
+      await flush();
+      expect(controls.cursor).toBe(0);
+      controls.handleDown();
+      await flush();
+      expect(controls.cursor).toBe(0);
+    });
+
+    it("handles single item with wrapping", async () => {
+      render(<Harness itemCount={1} />);
+      await flush();
+      controls.handleDown();
+      await flush();
+      expect(controls.cursor).toBe(0);
+      controls.handleUp();
+      await flush();
+      expect(controls.cursor).toBe(0);
+    });
+
+    it("handles single item without wrapping", async () => {
+      render(<Harness itemCount={1} wrap={false} />);
+      await flush();
+      controls.handleDown();
+      await flush();
+      expect(controls.cursor).toBe(0);
+      controls.handleUp();
+      await flush();
+      expect(controls.cursor).toBe(0);
+    });
+
+    it("handles zero items with sliding window", async () => {
+      render(<Harness itemCount={0} maxVisible={3} />);
+      await flush();
+      expect(controls.windowStart).toBe(0);
+      controls.handleDown();
+      await flush();
+      expect(controls.cursor).toBe(0);
+      expect(controls.windowStart).toBe(0);
+    });
+  });
+});

--- a/src/hooks/use-list-navigation.ts
+++ b/src/hooks/use-list-navigation.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseListNavigationOptions {
+  maxVisible?: number;
+  wrap?: boolean;
+}
+
+/**
+ * Shared hook for cursor navigation and sliding window in list selectors.
+ *
+ * @param itemCount - Number of items in the list (may change dynamically)
+ * @param options.maxVisible - If set, computes a sliding windowStart for virtualised rendering
+ * @param options.wrap - Whether cursor wraps around at boundaries (default true)
+ */
+export function useListNavigation(
+  itemCount: number,
+  options?: UseListNavigationOptions,
+) {
+  const { maxVisible, wrap = true } = options ?? {};
+  const [cursor, setCursor] = useState(0);
+  const windowStartRef = useRef(0);
+
+  // Clamp cursor when item count shrinks
+  useEffect(() => {
+    if (itemCount > 0 && cursor >= itemCount) {
+      setCursor(itemCount - 1);
+    }
+  }, [itemCount, cursor]);
+
+  const handleUp = useCallback(() => {
+    setCursor((c) => {
+      if (itemCount === 0) return 0;
+      return wrap ? (c > 0 ? c - 1 : itemCount - 1) : Math.max(0, c - 1);
+    });
+  }, [itemCount, wrap]);
+
+  const handleDown = useCallback(() => {
+    setCursor((c) => {
+      if (itemCount === 0) return 0;
+      return wrap
+        ? c < itemCount - 1
+          ? c + 1
+          : 0
+        : Math.min(itemCount - 1, c + 1);
+    });
+  }, [itemCount, wrap]);
+
+  // Sliding window calculation
+  let windowStart = windowStartRef.current;
+  if (maxVisible && itemCount > 0) {
+    if (cursor < windowStart) {
+      windowStart = cursor;
+    } else if (cursor >= windowStart + maxVisible) {
+      windowStart = cursor - maxVisible + 1;
+    }
+    windowStart = Math.min(windowStart, Math.max(0, itemCount - maxVisible));
+    windowStartRef.current = windowStart;
+  }
+
+  return { cursor, setCursor, windowStart, handleUp, handleDown };
+}


### PR DESCRIPTION
## Summary

Extract a shared `useListNavigation` hook from four selector components that all duplicated cursor wrapping and sliding window logic. Reduces ~86 lines of duplication and ensures consistent keyboard navigation behaviour.

## GitHub Issue

Closes #169

## What Changed

Added a `useListNavigation(itemCount, options?)` hook that manages cursor position with wrapping (or clamped) movement and an optional sliding window for virtualised rendering. Supports dynamic item counts with automatic cursor clamping.

All four selector components (`model-selector`, `configure-selector`, `settings-selector`, `session-selector`) now use the hook instead of inline cursor/window logic. The multi-step selectors pass a dynamic `itemCount` computed from the current step.

## Notes for Reviewers

`SessionSelector` uses `wrap: false` to preserve its existing non-wrapping behaviour. The other three selectors wrap by default. The hook is tested with 23 tests covering wrapping, non-wrapping, sliding window, dynamic item counts, and edge cases.