### PR TITLE
refactor: extract getErrorMessage utility function

### DIFF
--- a/src/components/configure-selector.tsx
+++ b/src/components/configure-selector.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
+import { getErrorMessage } from "../errors";
 import { fetchModels, type ModelInfo } from "../provider/client";
 import { useListNavigation } from "../hooks/use-list-navigation";
 
@@ -275,7 +276,7 @@ export function ConfigureSelector({
       })
       .catch((err) => {
         if (cancelled) return;
-        setFetchError(err instanceof Error ? err.message : String(err));
+        setFetchError(getErrorMessage(err));
       });
 
     return () => {

--- a/src/components/model-selector.tsx
+++ b/src/components/model-selector.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { ModelInfo } from "../provider/client";
+import { getErrorMessage } from "../errors";
 import { fetchModels, resolveApiKey } from "../provider/client";
 import { useListNavigation } from "../hooks/use-list-navigation";
 
@@ -51,7 +52,7 @@ export function ModelSelector({
           return {
             provider: p.name,
             models: [],
-            error: err instanceof Error ? err.message : String(err),
+            error: getErrorMessage(err),
           };
         }
       }),

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getErrorMessage } from "./errors";
+
+describe("getErrorMessage", () => {
+  it("extracts message from Error instances", () => {
+    expect(getErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("extracts message from Error subclasses", () => {
+    expect(getErrorMessage(new TypeError("bad type"))).toBe("bad type");
+  });
+
+  it("converts strings to themselves", () => {
+    expect(getErrorMessage("something broke")).toBe("something broke");
+  });
+
+  it("converts numbers to string", () => {
+    expect(getErrorMessage(42)).toBe("42");
+  });
+
+  it("converts null to string", () => {
+    expect(getErrorMessage(null)).toBe("null");
+  });
+
+  it("converts undefined to string", () => {
+    expect(getErrorMessage(undefined)).toBe("undefined");
+  });
+
+  it("converts objects to string", () => {
+    expect(getErrorMessage({ code: 500 })).toBe("[object Object]");
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,4 @@
+/** Extract a human-readable message from an unknown caught value. */
+export function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/hooks/tool-execution.ts
+++ b/src/hooks/tool-execution.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import type { DisplayMessage } from "../components/message-list";
 import type { ToolCall } from "../provider/client";
+import { getErrorMessage } from "../errors";
 import { type ToolContext, getTool, getToolDisplayName } from "../tools";
 
 export class ToolDismissedError extends Error {
@@ -58,7 +59,7 @@ async function executeSingleToolCall(
       result = await tool.execute(tc.function.arguments, toolContext);
     } catch (err) {
       if (err instanceof ToolDismissedError) throw err;
-      result = `Error: ${err instanceof Error ? err.message : String(err)}`;
+      result = `Error: ${getErrorMessage(err)}`;
     }
   }
 

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -14,6 +14,7 @@ import {
   updateActiveModel,
   updateActiveProvider,
 } from "../config";
+import { getErrorMessage } from "../errors";
 import type { ImageAttachment } from "../images";
 import { resolvePermissions } from "../permissions";
 import type { ChatMessage, ContentPart, TokenUsage } from "../provider/client";
@@ -423,7 +424,7 @@ export function useChat(
         setMessages(currentMessages);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     }
 
     streamingRef.current = false;

--- a/src/tools/agent.ts
+++ b/src/tools/agent.ts
@@ -5,6 +5,7 @@ import { loadInstructions } from "../instructions";
 import type { ChatMessage } from "../provider/client";
 import { addAgent, incrementToolCalls, removeAgent } from "./agent-tracker";
 import { getTool, registerTool } from "./registry";
+import { getErrorMessage } from "../errors";
 import { type ToolContext, parseToolArgs, toToolDefinition } from "./types";
 
 const argsSchema = z.object({
@@ -147,7 +148,7 @@ registerTool({
         }
         throw err;
       }
-      return `Sub-agent error: ${err instanceof Error ? err.message : String(err)}`;
+      return `Sub-agent error: ${getErrorMessage(err)}`;
     } finally {
       clearTimeout(timeoutId);
       removeAgent(agentId);

--- a/src/tools/edit-file.ts
+++ b/src/tools/edit-file.ts
@@ -6,6 +6,7 @@ import { WriteFileConfirm } from "../components/write-file-confirm";
 import { isPathWithinCwd } from "../permissions";
 import { formatDiff } from "./format-diff";
 import { registerTool } from "./registry";
+import { getErrorMessage } from "../errors";
 import { type ToolContext, parseToolArgs } from "./types";
 
 const argsSchema = z.object({
@@ -19,7 +20,7 @@ function performEdit(filePath: string, content: string): string {
     writeFileSync(filePath, content, "utf-8");
     return `Successfully edited ${filePath}`;
   } catch (err) {
-    return `Error writing file: ${err instanceof Error ? err.message : String(err)}`;
+    return `Error writing file: ${getErrorMessage(err)}`;
   }
 }
 
@@ -65,7 +66,7 @@ registerTool({
     try {
       content = readFileSync(filePath, "utf-8");
     } catch (err) {
-      return `Error reading file: ${err instanceof Error ? err.message : String(err)}`;
+      return `Error reading file: ${getErrorMessage(err)}`;
     }
 
     // Count occurrences

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -7,6 +7,7 @@ import { FileAccessConfirm } from "../components/file-access-confirm";
 import { isPathWithinCwd } from "../permissions";
 import { isGitRepo } from "../git";
 import { registerTool } from "./registry";
+import { getErrorMessage } from "../errors";
 import { type ToolContext, parseToolArgs } from "./types";
 
 const argsSchema = z.object({
@@ -105,6 +106,6 @@ function runGlob(pattern: string, cwd: string, gitignore: boolean): string {
     }
     return matches.join("\n");
   } catch (err) {
-    return `Error: ${err instanceof Error ? err.message : String(err)}`;
+    return `Error: ${getErrorMessage(err)}`;
   }
 }

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -6,6 +6,7 @@ import { FileAccessConfirm } from "../components/file-access-confirm";
 import { isPathWithinCwd } from "../permissions";
 import { isGitRepo } from "../git";
 import { registerTool } from "./registry";
+import { getErrorMessage } from "../errors";
 import { type ToolContext, parseToolArgs } from "./types";
 
 const argsSchema = z.object({
@@ -120,6 +121,6 @@ function runGrep(
     ) {
       return "No matches found.";
     }
-    return `Error: ${err instanceof Error ? err.message : String(err)}`;
+    return `Error: ${getErrorMessage(err)}`;
   }
 }

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { FileAccessConfirm } from "../components/file-access-confirm";
 import { isPathWithinCwd } from "../permissions";
 import { registerTool } from "./registry";
+import { getErrorMessage } from "../errors";
 import { type ToolContext, parseToolArgs } from "./types";
 
 const argsSchema = z.object({
@@ -59,7 +60,7 @@ function readFile(
     );
     return `${filePath} (${totalLines} lines)\n${numbered.join("\n")}`;
   } catch (err) {
-    return `Error reading file: ${err instanceof Error ? err.message : String(err)}`;
+    return `Error reading file: ${getErrorMessage(err)}`;
   }
 }
 

--- a/src/tools/write-file.ts
+++ b/src/tools/write-file.ts
@@ -6,6 +6,7 @@ import { WriteFileConfirm } from "../components/write-file-confirm";
 import { isPathWithinCwd } from "../permissions";
 import { formatDiff, formatNewFile } from "./format-diff";
 import { registerTool } from "./registry";
+import { getErrorMessage } from "../errors";
 import { type ToolContext, parseToolArgs } from "./types";
 
 const argsSchema = z.object({
@@ -19,7 +20,7 @@ function performWrite(filePath: string, content: string): string {
     writeFileSync(filePath, content, "utf-8");
     return `Successfully wrote to ${filePath}`;
   } catch (err) {
-    return `Error writing file: ${err instanceof Error ? err.message : String(err)}`;
+    return `Error writing file: ${getErrorMessage(err)}`;
   }
 }
 


### PR DESCRIPTION
## Summary

Extract a shared `getErrorMessage(err: unknown): string` utility to replace 11 inline `err instanceof Error ? err.message : String(err)` occurrences scattered across tools, hooks, and components.

## GitHub Issue

Closes #170

## What Changed

Added `src/errors.ts` with a single `getErrorMessage` function and updated all 10 consuming files (6 tools, 2 hooks, 2 components) to import and use it. The utility is tested with 7 cases covering Error instances, subclasses, primitives, null, undefined, and objects.