### PR TITLE
chore(test): create shared makeMockContext test helper

### DIFF
--- a/src/tools/edit-file.test.ts
+++ b/src/tools/edit-file.test.ts
@@ -2,32 +2,18 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTool } from "./registry";
+import { makeMockContext } from "./test-helpers";
 
 // Import to trigger registration
 import "./edit-file";
 
 const tmpDir = resolve(import.meta.dirname, "../../.test-edit-file-tmp");
-const mockContext = {
-  renderInteractive: vi.fn().mockResolvedValue("approved"),
-  reportProgress: vi.fn(),
-  permissions: {},
-  signal: new AbortController().signal,
-  depth: 0,
-  providerConfig: {
-    baseUrl: "http://localhost",
-    model: "test-model",
-    apiKey: undefined,
-    maxTokens: 1024,
-    contextWindow: 8192,
-  },
-
-  allowedCommands: [],
-};
+let mockContext = makeMockContext({ permissions: {} });
 
 beforeEach(() => {
   mkdirSync(tmpDir, { recursive: true });
   vi.clearAllMocks();
-  mockContext.renderInteractive.mockResolvedValue("approved");
+  mockContext = makeMockContext({ permissions: {} });
 });
 
 afterEach(() => {

--- a/src/tools/glob.test.ts
+++ b/src/tools/glob.test.ts
@@ -3,27 +3,13 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTool } from "./registry";
+import { makeMockContext } from "./test-helpers";
 
 // Import to trigger registration
 import "./glob";
 
 const tmpDir = resolve(import.meta.dirname, "../../.test-glob-tmp");
-const mockContext = {
-  renderInteractive: vi.fn().mockResolvedValue("approved"),
-  reportProgress: vi.fn(),
-  permissions: { read_file: true },
-  signal: new AbortController().signal,
-  depth: 0,
-  providerConfig: {
-    baseUrl: "http://localhost",
-    model: "test-model",
-    apiKey: undefined,
-    maxTokens: 1024,
-    contextWindow: 8192,
-  },
-
-  allowedCommands: [],
-};
+let mockContext = makeMockContext();
 
 /** Initialise a git repo inside tmpDir with a .gitignore and committed + ignored files. */
 function setupGitRepo() {
@@ -46,7 +32,7 @@ beforeEach(() => {
   writeFileSync(resolve(tmpDir, "src/app.tsx"), "<App />");
   writeFileSync(resolve(tmpDir, "src/utils.test.ts"), "test()");
   vi.clearAllMocks();
-  mockContext.renderInteractive.mockResolvedValue("approved");
+  mockContext = makeMockContext();
 });
 
 afterEach(() => {

--- a/src/tools/grep.test.ts
+++ b/src/tools/grep.test.ts
@@ -3,27 +3,13 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTool } from "./registry";
+import { makeMockContext } from "./test-helpers";
 
 // Import to trigger registration
 import "./grep";
 
 const tmpDir = resolve(import.meta.dirname, "../../.test-grep-tmp");
-const mockContext = {
-  renderInteractive: vi.fn().mockResolvedValue("approved"),
-  reportProgress: vi.fn(),
-  permissions: { read_file: true },
-  signal: new AbortController().signal,
-  depth: 0,
-  providerConfig: {
-    baseUrl: "http://localhost",
-    model: "test-model",
-    apiKey: undefined,
-    maxTokens: 1024,
-    contextWindow: 8192,
-  },
-
-  allowedCommands: [],
-};
+let mockContext = makeMockContext();
 
 /** Initialise a git repo inside tmpDir with committed files. */
 function setupGitRepo() {
@@ -55,7 +41,7 @@ beforeEach(() => {
     "function App() {\n  return <div>Hello</div>;\n}\n",
   );
   vi.clearAllMocks();
-  mockContext.renderInteractive.mockResolvedValue("approved");
+  mockContext = makeMockContext();
 });
 
 afterEach(() => {

--- a/src/tools/read-file.test.ts
+++ b/src/tools/read-file.test.ts
@@ -2,32 +2,18 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTool } from "./registry";
+import { makeMockContext } from "./test-helpers";
 
 // Import to trigger registration
 import "./read-file";
 
 const tmpDir = resolve(import.meta.dirname, "../../.test-read-file-tmp");
-const mockContext = {
-  renderInteractive: vi.fn().mockResolvedValue("approved"),
-  reportProgress: vi.fn(),
-  permissions: { read_file: true },
-  signal: new AbortController().signal,
-  depth: 0,
-  providerConfig: {
-    baseUrl: "http://localhost",
-    model: "test-model",
-    apiKey: undefined,
-    maxTokens: 1024,
-    contextWindow: 8192,
-  },
-
-  allowedCommands: [],
-};
+let mockContext = makeMockContext();
 
 beforeEach(() => {
   mkdirSync(tmpDir, { recursive: true });
   vi.clearAllMocks();
-  mockContext.renderInteractive.mockResolvedValue("approved");
+  mockContext = makeMockContext();
 });
 
 afterEach(() => {

--- a/src/tools/skill.test.ts
+++ b/src/tools/skill.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Skill } from "../skills";
+import { makeMockContext } from "./test-helpers";
 
 const testSkills: Skill[] = [
   {
@@ -25,22 +26,7 @@ vi.mock("../skills", () => ({
 await import("./skill");
 const { getTool } = await import("./registry");
 
-const mockContext = {
-  renderInteractive: vi.fn(),
-  reportProgress: vi.fn(),
-  permissions: {},
-  signal: new AbortController().signal,
-  depth: 0,
-  providerConfig: {
-    baseUrl: "http://localhost",
-    model: "test-model",
-    apiKey: undefined,
-    maxTokens: 1024,
-    contextWindow: 8192,
-  },
-
-  allowedCommands: [],
-};
+const mockContext = makeMockContext({ permissions: {} });
 
 describe("skill tool", () => {
   it("is registered as non-interactive", () => {

--- a/src/tools/test-helpers.ts
+++ b/src/tools/test-helpers.ts
@@ -1,0 +1,36 @@
+import type { Mock } from "vitest";
+import { vi } from "vitest";
+import type { ToolContext } from "./types";
+
+/** ToolContext with mock functions exposed for test assertions. */
+export type MockToolContext = Omit<
+  ToolContext,
+  "renderInteractive" | "reportProgress"
+> & {
+  renderInteractive: Mock;
+  reportProgress: Mock;
+};
+
+/** Create a mock ToolContext with sensible defaults. Pass overrides for specific tests. */
+export function makeMockContext(
+  overrides?: Partial<
+    Omit<ToolContext, "renderInteractive" | "reportProgress">
+  >,
+): MockToolContext {
+  return {
+    permissions: { read_file: true, write_file: false },
+    signal: new AbortController().signal,
+    depth: 0,
+    providerConfig: {
+      baseUrl: "http://localhost",
+      model: "test-model",
+      apiKey: undefined,
+      maxTokens: 1024,
+      contextWindow: 8192,
+    },
+    allowedCommands: [],
+    ...overrides,
+    renderInteractive: vi.fn().mockResolvedValue("approved"),
+    reportProgress: vi.fn(),
+  };
+}

--- a/src/tools/web-search.test.ts
+++ b/src/tools/web-search.test.ts
@@ -1,25 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTool } from "./registry";
+import { makeMockContext } from "./test-helpers";
 
 // Import to trigger registration
 import "./web-search";
 
-const mockContext = {
-  renderInteractive: vi.fn().mockResolvedValue("approved"),
-  reportProgress: vi.fn(),
-  permissions: {},
-  signal: new AbortController().signal,
-  depth: 0,
-  providerConfig: {
-    baseUrl: "http://localhost",
-    model: "test-model",
-    apiKey: undefined,
-    maxTokens: 1024,
-    contextWindow: 8192,
-  },
-
-  allowedCommands: [],
-};
+const mockContext = makeMockContext({ permissions: {} });
 
 const originalEnv = process.env.TAVILY_API_KEY;
 

--- a/src/tools/write-file.test.ts
+++ b/src/tools/write-file.test.ts
@@ -2,32 +2,18 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTool } from "./registry";
+import { makeMockContext } from "./test-helpers";
 
 // Import to trigger registration
 import "./write-file";
 
 const tmpDir = resolve(import.meta.dirname, "../../.test-write-file-tmp");
-const mockContext = {
-  renderInteractive: vi.fn().mockResolvedValue("approved"),
-  reportProgress: vi.fn(),
-  permissions: {},
-  signal: new AbortController().signal,
-  depth: 0,
-  providerConfig: {
-    baseUrl: "http://localhost",
-    model: "test-model",
-    apiKey: undefined,
-    maxTokens: 1024,
-    contextWindow: 8192,
-  },
-
-  allowedCommands: [],
-};
+let mockContext = makeMockContext({ permissions: {} });
 
 beforeEach(() => {
   mkdirSync(tmpDir, { recursive: true });
   vi.clearAllMocks();
-  mockContext.renderInteractive.mockResolvedValue("approved");
+  mockContext = makeMockContext({ permissions: {} });
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Extract a shared `makeMockContext` factory from 7 tool test files that all duplicated an identical mock `ToolContext` object. Net reduction of 62 lines of test boilerplate.

## GitHub Issue

Closes #172

## What Changed

Added `src/tools/test-helpers.ts` with a `makeMockContext(overrides?)` factory that returns a `MockToolContext` — a `ToolContext` with `renderInteractive` and `reportProgress` typed as vitest `Mock` for test assertions. All 7 tool test files now use the factory instead of inline object literals. The factory accepts partial overrides for non-function fields (e.g. `permissions`, `depth`).