### PR TITLE
docs: add MCP server documentation and ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,38 +33,87 @@ Context window size is auto-detected for all provider types.
 
 Type `/` to see available commands with autocomplete suggestions.
 
-| Command         | Description                                     |
-| --------------- | ----------------------------------------------- |
-| `/new`          | Start a new conversation                        |
-| `/session`      | Browse and load previous sessions               |
-| `/session <id>` | Load a session by ID                            |
-| `/model`        | Switch the active model                         |
-| `/provider`     | Manage providers (add/remove)                   |
-| `/settings`     | Manage tools, permissions, and allowed commands |
-| `/context`      | Show context window usage stats                 |
-| `/skills`       | List available skills                           |
-| `/help`         | List available commands                         |
+| Command         | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `/new`          | Start a new conversation                             |
+| `/session`      | Browse and load previous sessions                    |
+| `/session <id>` | Load a session by ID                                 |
+| `/model`        | Switch the active model                              |
+| `/provider`     | Manage providers (add/remove)                        |
+| `/settings`     | Manage tools, permissions, commands, and MCP servers |
+| `/context`      | Show context window usage stats                      |
+| `/skills`       | List available skills                                |
+| `/help`         | List available commands                              |
 
 ## Tools
 
 Tomo can read, write, and search files, run commands, and more. Tools are enabled by default and the model calls them as needed.
 
-| Tool         | Description                                           | Default  |
-| ------------ | ----------------------------------------------------- | -------- |
-| Read File    | Read file contents with line numbers                  | Enabled  |
-| Write File   | Create or overwrite a file                            | Enabled  |
-| Edit File    | Apply string replacements to a file                   | Enabled  |
-| Glob         | Find files by glob pattern (respects `.gitignore`)    | Enabled  |
-| Grep         | Search file contents by regex (respects `.gitignore`) | Enabled  |
-| Run Command  | Run a shell command                                   | Enabled  |
-| Ask          | Ask the user a question                               | Enabled  |
-| Skill        | Load specialized task instructions                    | Enabled  |
-| Agent        | Spawn sub-agents for parallel research/exploration    | Enabled  |
-| Web Search   | Search the web via Tavily API                         | Disabled |
+| Tool        | Description                                           | Default  |
+| ----------- | ----------------------------------------------------- | -------- |
+| Read File   | Read file contents with line numbers                  | Enabled  |
+| Write File  | Create or overwrite a file                            | Enabled  |
+| Edit File   | Apply string replacements to a file                   | Enabled  |
+| Glob        | Find files by glob pattern (respects `.gitignore`)    | Enabled  |
+| Grep        | Search file contents by regex (respects `.gitignore`) | Enabled  |
+| Run Command | Run a shell command                                   | Enabled  |
+| Ask         | Ask the user a question                               | Enabled  |
+| Skill       | Load specialized task instructions                    | Enabled  |
+| Agent       | Spawn sub-agents for parallel research/exploration    | Enabled  |
+| Web Search  | Search the web via Tavily API                         | Disabled |
 
 Web Search requires a [Tavily](https://tavily.com) API key. Set `TAVILY_API_KEY` in your environment and enable the tool with `/settings`.
 
 Agent spawns headless sub-agents that can read files, search code, and explore the codebase in parallel. The model decides when to spawn agents and how many. Active agents show color-coded progress indicators with tool call counts.
+
+## MCP Servers
+
+Tomo supports the [Model Context Protocol](https://modelcontextprotocol.io) (MCP) for connecting to external tool servers. MCP servers expose tools that the model can call alongside tomo's built-in tools.
+
+Two transport types are supported:
+
+| Transport | Description                    | Example                   |
+| --------- | ------------------------------ | ------------------------- |
+| `http`    | Remote server via HTTP POST    | `https://mcp.example.com` |
+| `stdio`   | Local process via stdin/stdout | `node my-server.js`       |
+
+### Adding a Server
+
+Use `/settings` → **MCP Servers** → **Add**:
+
+1. Select transport type (HTTP or stdio)
+2. Enter the server URL or command (with args)
+3. Tomo connects, discovers the server name and tools
+4. Tools appear in **Tool Availability**, disabled by default
+5. Enable the tools you want the model to use
+
+### Config
+
+MCP servers are stored in the global config (`~/.tomo/config.yaml`):
+
+```yaml
+mcpServers:
+  my-server:
+    transport: http
+    url: https://mcp.example.com
+    # headers:              # optional HTTP headers
+    #   Authorization: "Bearer ${MCP_TOKEN}"
+  local-tools:
+    transport: stdio
+    command: node
+    args: ["my-mcp-server.js"]
+    # env:                  # optional environment variables
+    #   DB_URL: postgresql://localhost:5432/mydb
+    # enabled: false        # disable without removing
+```
+
+Environment variable substitution (`${VAR}`) is supported in all string values.
+
+Tool availability is controlled per-tool in the local config (`./.tomo/config.yaml`) under the `tools` key, using namespaced names like `mcp__server-name__tool-name`.
+
+### Connection Failures
+
+If an MCP server fails to connect at startup, a warning is displayed and other servers continue normally. Use `/settings` → **MCP Servers** and press `r` on a failed server to retry.
 
 ## Permissions
 

--- a/docs/adr/0011-mcp-server-support.md
+++ b/docs/adr/0011-mcp-server-support.md
@@ -1,0 +1,78 @@
+# 11. MCP server support
+
+Date: 2026-03-28
+
+## Status
+
+Accepted
+
+## Context
+
+Tomo's built-in tools (read_file, run_command, etc.) cover common development tasks, but users need access to external tools — databases, APIs, cloud services, custom workflows — without modifying tomo's source code. The Model Context Protocol (MCP) is an open standard that defines how AI clients discover and invoke tools from external servers, and a growing ecosystem of MCP servers already exists.
+
+Key constraints:
+
+- Tomo is a terminal-first CLI tool — UX must work within `/settings` interactive menus
+- Multiple MCP servers may be configured simultaneously, some local (stdio) and some remote (HTTP)
+- Tool naming must not collide with built-in tools or across servers
+- Users need fine-grained control: enable/disable individual tools, not just entire servers
+- Connection failures should not block the app or other servers
+
+## Decision
+
+### Custom JSON-RPC client over the official SDK
+
+We implemented the MCP protocol directly rather than using `@modelcontextprotocol/sdk`. The protocol is JSON-RPC 2.0 with a small surface area — `initialize`, `tools/list`, and `tools/call` are the only methods needed. A custom implementation avoids a dependency, keeps the bundle small, and gives full control over error handling and transport behaviour.
+
+The client is split into three layers:
+
+- **Transport** (`McpTransport` interface) — handles the wire protocol. `StdioTransport` spawns a child process and communicates via newline-delimited JSON over stdin/stdout. `HttpTransport` sends POST requests and parses SSE responses.
+- **Client** (`McpClient`) — manages the MCP lifecycle: initialize handshake, tool discovery, tool invocation. Accepts any `McpTransport` via constructor injection.
+- **Manager** (`McpManager`) — starts multiple servers from config, namespaces tool definitions, routes tool calls, and handles graceful shutdown.
+
+### Tool namespacing with double-underscore separator
+
+MCP tools are namespaced as `mcp__<server-name>__<tool-name>` to avoid collisions. The server name comes from the MCP `initialize` handshake (`serverInfo.name`), not user input — this avoids naming issues (spaces, special characters) and removes a manual step from the setup flow. Duplicate server names are auto-suffixed (`server-2`, `server-3`).
+
+The `__` separator was chosen because it's unlikely to appear in tool names naturally, can be used as a JavaScript object key without quoting, and is easy to split programmatically.
+
+### Enable/disable over approval prompts
+
+We initially implemented an `autoApprove` model where MCP tool calls would show a confirmation prompt before executing (similar to file write confirmations). This was replaced with a simpler enable/disable model:
+
+- Servers can be enabled/disabled entirely
+- Individual tools are toggled in Tool Availability (disabled by default when a server is first added)
+- Only enabled tools are sent in the tool definitions array to the LLM
+- Disabled tools are also blocked at execution time as a safety net (the model may call tools it saw in previous turns before they were disabled)
+
+The enable/disable model is simpler to understand, requires fewer interactions per session, and is consistent with how built-in tools already work in `/settings`.
+
+### Independent server startup
+
+`McpManager.startAll()` starts each server independently using `Promise.all` with per-server try/catch. A failing server does not block others. Failed servers are tracked and surfaced as startup warnings. The settings UI shows a warning indicator on failed servers and offers a reconnect shortcut (`r`).
+
+### Server name auto-discovery
+
+When adding a server via `/settings`, tomo connects immediately, performs the MCP initialize handshake, and uses `serverInfo.name` from the response as the config key. This eliminates a manual naming step and ensures the name matches what the server identifies itself as.
+
+### Lazy manager restart on config change
+
+The MCP manager is started at app mount time. On each message submit, the desired server set (from config) is compared against the manager's connected servers. If they differ — a server was added, removed, or failed to connect previously — the manager is shut down and recreated. This handles mid-session config changes from `/settings` without requiring an app restart.
+
+### Resources and notifications deprioritized
+
+MCP defines two additional primitives — resources (`resources/list`, `resources/read`) and server notifications (`notifications/tools/list_changed`). Neither is implemented:
+
+- **Resources**: No major MCP client (Claude Desktop, Cursor, Windsurf, Claude Code) has shipped meaningful resources support as of mid-2025. Most MCP server authors expose data access as tools instead.
+- **Notifications**: Restarting tomo is sufficient to pick up tool list changes. The complexity of live notification handling is not justified.
+
+Both can be added later if the ecosystem adoption changes.
+
+## Consequences
+
+- MCP servers are a first-class feature alongside built-in tools, managed through the same `/settings` UI
+- No external dependencies added — the protocol implementation is ~500 lines across transport, client, and manager
+- Tool namespacing means MCP tool names are longer in the LLM context (`mcp__server__tool` vs `tool`), consuming slightly more tokens
+- Environment variable substitution in server config supports secrets without storing them in YAML
+- The `tools` config record is shared between built-in and MCP tools — MCP tool entries use namespaced keys and follow the same boolean toggle pattern
+- Adding a new transport type (e.g. WebSocket) requires implementing the `McpTransport` interface — no changes to the client or manager


### PR DESCRIPTION
## Summary

Adds user-facing documentation and an architecture decision record for the MCP server support feature.

## What Changed

**README** — New "MCP Servers" section covering transport types (HTTP/stdio), the /settings add flow, config format with env var substitution, tool availability controls, and connection failure handling. Updated /settings command description.

**ADR-0011** — Documents the key decisions: custom JSON-RPC client over the official SDK, tool namespacing strategy, enable/disable over approval prompts, independent server startup, server name auto-discovery, lazy manager restart, and why resources/notifications were deprioritized.