### PR TITLE
test(mcp): fill MCP integration test gaps

### DIFF
--- a/src/components/mcp-server-selector.test.tsx
+++ b/src/components/mcp-server-selector.test.tsx
@@ -1,8 +1,19 @@
 import { render } from "ink-testing-library";
 import { describe, expect, it, vi } from "vitest";
 import type { McpServerConfig } from "../config";
+import { McpClient } from "../mcp/client";
 import { McpServerSelector } from "./mcp-server-selector";
 import type { SettingsState } from "./settings-selector";
+
+vi.mock("../mcp/client", () => ({
+  McpClient: vi.fn(),
+}));
+vi.mock("../mcp/http-transport", () => ({
+  HttpTransport: vi.fn(),
+}));
+vi.mock("../mcp/stdio-transport", () => ({
+  StdioTransport: vi.fn(),
+}));
 
 const flush = () => new Promise((r) => setTimeout(r, 50));
 
@@ -341,6 +352,163 @@ describe("McpServerSelector", () => {
 
       output = lastFrame() ?? "";
       expect(output).toContain("server-b");
+    });
+  });
+
+  describe("connect flow", () => {
+    function setupMockClient(
+      serverName: string,
+      tools: { name: string; description?: string }[],
+    ) {
+      // biome-ignore lint/complexity/useArrowFunction: mockImplementation needs function for new
+      vi.mocked(McpClient).mockImplementation(function () {
+        return {
+          initialize: vi.fn().mockResolvedValue({
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            serverInfo: { name: serverName, version: "1.0.0" },
+          }),
+          listTools: vi.fn().mockResolvedValue(
+            tools.map((t) => ({
+              name: t.name,
+              description: t.description,
+              inputSchema: {},
+            })),
+          ),
+          close: vi.fn(),
+        } as unknown as McpClient;
+      });
+    }
+
+    it("connects to HTTP server and saves discovered tools", async () => {
+      setupMockClient("weather-server", [
+        { name: "get_weather", description: "Get weather data" },
+      ]);
+      const onUpdate = vi.fn();
+      const { stdin } = renderMcp({ onUpdate });
+
+      // Navigate: Add → http → enter URL (pre-filled with "https://") → submit
+      stdin.write("\r"); // select "Add..."
+      await flush();
+      stdin.write("\r"); // select "http"
+      await flush();
+      stdin.write("mcp.example.com"); // "https://" is pre-filled
+      await flush();
+      stdin.write("\r"); // submit URL
+      await flush();
+      await flush(); // extra flush for async connect
+      await flush();
+
+      expect(onUpdate).toHaveBeenCalledWith({
+        mcpServers: {
+          "weather-server": expect.objectContaining({
+            transport: "http",
+            url: "https://mcp.example.com",
+            tools: [
+              {
+                name: "get_weather",
+                enabled: true,
+                description: "Get weather data",
+              },
+            ],
+          }),
+        },
+      });
+    });
+
+    it("appends suffix when server name already exists", async () => {
+      setupMockClient("my-server", []);
+      const onUpdate = vi.fn();
+      const { stdin } = renderMcp({
+        mcpServers: {
+          "my-server": { transport: "http", url: "https://existing.com" },
+        },
+        onUpdate,
+      });
+
+      // Navigate down to "Add..." (past existing server)
+      stdin.write("\x1B[B"); // arrow down
+      await flush();
+      stdin.write("\r"); // select "Add..."
+      await flush();
+      stdin.write("\r"); // select "http"
+      await flush();
+      stdin.write("mcp2.example.com"); // "https://" is pre-filled
+      await flush();
+      stdin.write("\r"); // submit URL
+      await flush();
+      await flush();
+      await flush();
+
+      expect(onUpdate).toHaveBeenCalledWith({
+        mcpServers: expect.objectContaining({
+          "my-server": expect.anything(),
+          "my-server-2": expect.objectContaining({
+            transport: "http",
+            url: "https://mcp2.example.com",
+          }),
+        }),
+      });
+    });
+
+    it("shows error on connection failure", async () => {
+      // biome-ignore lint/complexity/useArrowFunction: mockImplementation needs function for new
+      vi.mocked(McpClient).mockImplementation(function () {
+        return {
+          initialize: vi
+            .fn()
+            .mockRejectedValue(new Error("Connection refused")),
+          close: vi.fn(),
+        } as unknown as McpClient;
+      });
+
+      const { stdin, lastFrame } = renderMcp();
+
+      stdin.write("\r"); // Add
+      await flush();
+      stdin.write("\r"); // http
+      await flush();
+      stdin.write("bad.example.com"); // "https://" is pre-filled
+      await flush();
+      stdin.write("\r"); // submit
+      await flush();
+      await flush();
+      await flush();
+
+      const output = lastFrame() ?? "";
+      expect(output).toContain("Connection refused");
+    });
+
+    it("connects to stdio server", async () => {
+      setupMockClient("stdio-server", [{ name: "run_script" }]);
+      const onUpdate = vi.fn();
+      const { stdin } = renderMcp({ onUpdate });
+
+      stdin.write("\r"); // Add
+      await flush();
+      stdin.write("\x1B[B"); // arrow down to stdio
+      await flush();
+      stdin.write("\r"); // select stdio
+      await flush();
+      stdin.write("node server.js --port 3000");
+      await flush();
+      stdin.write("\r"); // submit
+      await flush();
+      await flush();
+      await flush();
+
+      expect(onUpdate).toHaveBeenCalledWith({
+        mcpServers: {
+          "stdio-server": expect.objectContaining({
+            transport: "stdio",
+            command: "node",
+            args: ["server.js", "--port", "3000"],
+            tools: [
+              { name: "run_script", enabled: true, description: undefined },
+            ],
+          }),
+        },
+      });
     });
   });
 });

--- a/src/hooks/use-chat.test.tsx
+++ b/src/hooks/use-chat.test.tsx
@@ -2,6 +2,8 @@ import { Text } from "ink";
 import { render } from "ink-testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getCommand, parse } from "../commands";
+import { getMcpServers, loadConfig } from "../config";
+import { McpManager } from "../mcp/manager";
 import type { ToolCall } from "../provider/client";
 import { streamChatCompletion } from "../provider/client";
 import { appendMessage } from "../session";
@@ -77,12 +79,19 @@ vi.mock("../session", () => ({
 vi.mock("../config", () => ({
   getMaxTokens: () => 8192,
   getProviderByName: vi.fn(),
-  loadConfig: () => ({}),
+  loadConfig: vi.fn().mockReturnValue({}),
   updateActiveModel: vi.fn(),
   updateActiveProvider: vi.fn(),
   getAllowedCommands: () => [],
-  getMcpServers: () => ({}),
-  getAllMcpServers: () => ({}),
+  getMcpServers: vi.fn().mockReturnValue({}),
+  getAllMcpServers: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../mcp/manager", () => ({
+  McpManager: vi.fn(),
+  encodeToolName: vi.fn(
+    (server: string, tool: string) => `mcp__${server}__${tool}`,
+  ),
 }));
 
 vi.mock("../commands", () => ({
@@ -1037,6 +1046,186 @@ describe("useChat", () => {
       expect(chat.messages[0].content).toBe("//nonexistent");
       expect(chat.messages[1].role).toBe("system");
       expect(chat.messages[1].content).toContain("Unknown skill");
+    });
+  });
+
+  describe("MCP startup", () => {
+    function createMockManager(overrides?: {
+      startAll?: ReturnType<typeof vi.fn>;
+      shutdown?: ReturnType<typeof vi.fn>;
+      getServerNames?: ReturnType<typeof vi.fn>;
+      getToolDefinitions?: ReturnType<typeof vi.fn>;
+    }) {
+      const manager = {
+        startAll: overrides?.startAll ?? vi.fn().mockResolvedValue([]),
+        shutdown: overrides?.shutdown ?? vi.fn(),
+        getServerNames:
+          overrides?.getServerNames ?? vi.fn().mockReturnValue([]),
+        getToolDefinitions:
+          overrides?.getToolDefinitions ?? vi.fn().mockResolvedValue([]),
+      };
+      // biome-ignore lint/complexity/useArrowFunction: mockImplementation needs function for new
+      vi.mocked(McpManager).mockImplementation(function () {
+        return manager as unknown as McpManager;
+      });
+      return manager;
+    }
+
+    it("starts MCP servers on mount when config has servers", async () => {
+      const mcpServers = {
+        "test-server": {
+          transport: "http" as const,
+          url: "https://mcp.example.com",
+        },
+      };
+      vi.mocked(getMcpServers).mockReturnValue(mcpServers);
+      const manager = createMockManager();
+
+      render(<TestApp />);
+      await flush();
+
+      expect(McpManager).toHaveBeenCalled();
+      expect(manager.startAll).toHaveBeenCalledWith(mcpServers);
+    });
+
+    it("surfaces warnings when MCP server fails to connect", async () => {
+      vi.mocked(getMcpServers).mockReturnValue({
+        "broken-server": {
+          transport: "http" as const,
+          url: "https://broken.example.com",
+        },
+      });
+      createMockManager({
+        startAll: vi.fn().mockResolvedValue(["broken-server"]),
+      });
+
+      render(<TestApp />);
+      await flush();
+      await flush();
+
+      expect(chat.mcpWarnings).toEqual([
+        'MCP server "broken-server": failed to connect',
+      ]);
+    });
+
+    it("does not create manager when no MCP servers configured", async () => {
+      vi.mocked(getMcpServers).mockReturnValue({});
+
+      render(<TestApp />);
+      await flush();
+
+      expect(McpManager).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("MCP restart on config change", () => {
+    function createMockManager(overrides?: {
+      startAll?: ReturnType<typeof vi.fn>;
+      shutdown?: ReturnType<typeof vi.fn>;
+      getServerNames?: ReturnType<typeof vi.fn>;
+      getToolDefinitions?: ReturnType<typeof vi.fn>;
+    }) {
+      const manager = {
+        startAll: overrides?.startAll ?? vi.fn().mockResolvedValue([]),
+        shutdown: overrides?.shutdown ?? vi.fn(),
+        getServerNames:
+          overrides?.getServerNames ?? vi.fn().mockReturnValue([]),
+        getToolDefinitions:
+          overrides?.getToolDefinitions ?? vi.fn().mockResolvedValue([]),
+      };
+      // biome-ignore lint/complexity/useArrowFunction: mockImplementation needs function for new
+      vi.mocked(McpManager).mockImplementation(function () {
+        return manager as unknown as McpManager;
+      });
+      return manager;
+    }
+
+    it("restarts manager when server config changes between submits", async () => {
+      // Mount with server-a
+      const mountServers = {
+        "server-a": {
+          transport: "http" as const,
+          url: "https://a.example.com",
+        },
+      };
+      vi.mocked(getMcpServers).mockReturnValue(mountServers);
+
+      const mountManager = createMockManager({
+        getServerNames: vi.fn().mockReturnValue(["server-a"]),
+      });
+
+      vi.mocked(parse).mockReturnValue(null);
+      vi.mocked(streamChatCompletion).mockImplementation(async (options) =>
+        createDeferredStream(options.signal),
+      );
+
+      render(<TestApp />);
+      await flush();
+
+      expect(mountManager.startAll).toHaveBeenCalledWith(mountServers);
+
+      // Submit with changed config (server-b instead of server-a)
+      const newServers = {
+        "server-b": {
+          transport: "http" as const,
+          url: "https://b.example.com",
+        },
+      };
+      vi.mocked(loadConfig).mockReturnValue(testConfig);
+      vi.mocked(getMcpServers).mockReturnValue(newServers);
+
+      const restartManager = createMockManager({
+        getServerNames: vi.fn().mockReturnValue(["server-b"]),
+      });
+
+      chat.submit("hello");
+      await flush();
+
+      // Old manager should be shut down
+      expect(mountManager.shutdown).toHaveBeenCalled();
+      // New manager should be started with new servers
+      expect(restartManager.startAll).toHaveBeenCalledWith(newServers);
+
+      streams[0].complete();
+      await flush();
+    });
+
+    it("keeps existing manager when server config is unchanged", async () => {
+      const servers = {
+        "server-a": {
+          transport: "http" as const,
+          url: "https://a.example.com",
+        },
+      };
+      vi.mocked(getMcpServers).mockReturnValue(servers);
+
+      const manager = createMockManager({
+        getServerNames: vi.fn().mockReturnValue(["server-a"]),
+      });
+
+      vi.mocked(parse).mockReturnValue(null);
+      vi.mocked(streamChatCompletion).mockImplementation(async (options) =>
+        createDeferredStream(options.signal),
+      );
+
+      render(<TestApp />);
+      await flush();
+
+      expect(manager.startAll).toHaveBeenCalledTimes(1);
+
+      // Submit with same config
+      vi.mocked(loadConfig).mockReturnValue(testConfig);
+      // getMcpServers still returns same servers
+
+      chat.submit("hello");
+      await flush();
+
+      // Manager should NOT be restarted (startAll only called once during mount)
+      expect(manager.shutdown).not.toHaveBeenCalled();
+      expect(manager.startAll).toHaveBeenCalledTimes(1);
+
+      streams[0].complete();
+      await flush();
     });
   });
 });

--- a/src/mcp/http-transport.test.ts
+++ b/src/mcp/http-transport.test.ts
@@ -27,6 +27,23 @@ function sseResponse(events: string[]): Response {
   });
 }
 
+/** Creates an SSE response where the raw string is split into separate chunks at given byte offsets. */
+function chunkedSseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
 describe("HttpTransport", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -224,6 +241,101 @@ describe("HttpTransport", () => {
       }),
     });
 
+    transport.close();
+  });
+
+  it("handles SSE event split across multiple chunks", async () => {
+    const transport = new HttpTransport("https://mcp.example.com");
+    transport.start();
+
+    const responseData = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { value: "chunked" },
+    });
+
+    // Split the SSE event in the middle of the data line
+    const fullEvent = `data: ${responseData}\n\n`;
+    const mid = Math.floor(fullEvent.length / 2);
+
+    mockFetch.mockResolvedValueOnce(
+      chunkedSseResponse([fullEvent.slice(0, mid), fullEvent.slice(mid)]),
+    );
+
+    const response = await transport.request({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "test",
+    });
+
+    expect(response.result).toEqual({ value: "chunked" });
+    transport.close();
+  });
+
+  it("handles SSE event split on double-newline boundary", async () => {
+    const transport = new HttpTransport("https://mcp.example.com");
+    transport.start();
+
+    const responseData = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: "ok",
+    });
+
+    // First chunk has data line and first newline, second chunk has second newline
+    mockFetch.mockResolvedValueOnce(
+      chunkedSseResponse([`data: ${responseData}\n`, "\n"]),
+    );
+
+    const response = await transport.request({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "test",
+    });
+
+    expect(response.result).toBe("ok");
+    transport.close();
+  });
+
+  it("handles multiple SSE events across many small chunks", async () => {
+    const transport = new HttpTransport("https://mcp.example.com");
+    const handler = vi.fn();
+    transport.start();
+    transport.onNotification(handler);
+
+    const notification = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/progress",
+    });
+    const responseData = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { done: true },
+    });
+
+    // Split across 4 tiny chunks: notification event split in two, then response event split in two
+    const notifEvent = `data: ${notification}\n\n`;
+    const respEvent = `data: ${responseData}\n\n`;
+
+    mockFetch.mockResolvedValueOnce(
+      chunkedSseResponse([
+        notifEvent.slice(0, 10),
+        notifEvent.slice(10),
+        respEvent.slice(0, 15),
+        respEvent.slice(15),
+      ]),
+    );
+
+    const response = await transport.request({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "test",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "notifications/progress" }),
+    );
+    expect(response.result).toEqual({ done: true });
     transport.close();
   });
 


### PR DESCRIPTION
## Summary

Adds integration-level tests for MCP features that were identified as gaps during review: settings connect flow, use-chat startup/restart, and chunked SSE parsing.

## GitHub Issue

Closes #202

## What Changed

**Settings connect flow** (4 tests in `mcp-server-selector.test.tsx`): Tests the async useEffect that runs when adding a new MCP server — HTTP and stdio transports, duplicate server name suffixing, and connection error display. Mocks `McpClient`, `HttpTransport`, and `StdioTransport` at the module level.

**use-chat MCP startup** (3 tests in `use-chat.test.tsx`): Tests mount-time `McpManager` creation and `startAll`, failure warnings surfaced via `mcpWarnings`, and the no-op path when no servers are configured. Config mock functions (`getMcpServers`, `getAllMcpServers`, `loadConfig`) were converted from plain functions to `vi.fn()` to enable per-test overrides.

**Manager restart on config change** (2 tests in `use-chat.test.tsx`): Tests the submit-time logic that compares desired vs current server names — verifies old manager shutdown + new manager creation on change, and no restart when config is unchanged.

**Chunked SSE parsing** (3 tests in `http-transport.test.ts`): Tests SSE events split across multiple `read()` calls — mid-data-line split, double-newline boundary split, and multiple events across many small chunks with interleaved notifications.