### PR TITLE
feat(mcp): add API key step to HTTP server setup wizard

### DIFF
--- a/src/components/mcp-server-selector.test.tsx
+++ b/src/components/mcp-server-selector.test.tsx
@@ -396,6 +396,8 @@ describe("McpServerSelector", () => {
       await flush();
       stdin.write("\r"); // submit URL
       await flush();
+      stdin.write("\r"); // skip API key (empty)
+      await flush();
       await flush(); // extra flush for async connect
       await flush();
 
@@ -437,6 +439,8 @@ describe("McpServerSelector", () => {
       await flush();
       stdin.write("\r"); // submit URL
       await flush();
+      stdin.write("\r"); // skip API key
+      await flush();
       await flush();
       await flush();
 
@@ -470,7 +474,9 @@ describe("McpServerSelector", () => {
       await flush();
       stdin.write("bad.example.com"); // "https://" is pre-filled
       await flush();
-      stdin.write("\r"); // submit
+      stdin.write("\r"); // submit URL
+      await flush();
+      stdin.write("\r"); // skip API key
       await flush();
       await flush();
       await flush();
@@ -509,6 +515,97 @@ describe("McpServerSelector", () => {
           }),
         },
       });
+    });
+
+    it("shows API key prompt after URL entry", async () => {
+      const { stdin, lastFrame } = renderMcp();
+
+      stdin.write("\r"); // Add
+      await flush();
+      stdin.write("\r"); // http
+      await flush();
+      stdin.write("mcp.example.com");
+      await flush();
+      stdin.write("\r"); // submit URL
+      await flush();
+
+      const output = lastFrame() ?? "";
+      expect(output).toContain("Enter API key");
+      expect(output).toContain("leave empty to skip");
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: testing literal output
+      expect(output).toContain("${VAR}");
+    });
+
+    it("masks API key input with asterisks", async () => {
+      const { stdin, lastFrame } = renderMcp();
+
+      stdin.write("\r"); // Add
+      await flush();
+      stdin.write("\r"); // http
+      await flush();
+      stdin.write("mcp.example.com");
+      await flush();
+      stdin.write("\r"); // submit URL
+      await flush();
+      stdin.write("secret123");
+      await flush();
+
+      const output = lastFrame() ?? "";
+      expect(output).toContain("*********");
+      expect(output).not.toContain("secret123");
+    });
+
+    it("stores API key as Authorization Bearer header", async () => {
+      setupMockClient("auth-server", []);
+      const onUpdate = vi.fn();
+      const { stdin } = renderMcp({ onUpdate });
+
+      stdin.write("\r"); // Add
+      await flush();
+      stdin.write("\r"); // http
+      await flush();
+      stdin.write("mcp.example.com");
+      await flush();
+      stdin.write("\r"); // submit URL
+      await flush();
+      stdin.write("my-secret-key");
+      await flush();
+      stdin.write("\r"); // submit API key
+      await flush();
+      await flush();
+      await flush();
+
+      expect(onUpdate).toHaveBeenCalledWith({
+        mcpServers: {
+          "auth-server": expect.objectContaining({
+            transport: "http",
+            url: "https://mcp.example.com",
+            headers: { Authorization: "Bearer my-secret-key" },
+          }),
+        },
+      });
+    });
+
+    it("skips headers when API key is empty", async () => {
+      setupMockClient("no-auth-server", []);
+      const onUpdate = vi.fn();
+      const { stdin } = renderMcp({ onUpdate });
+
+      stdin.write("\r"); // Add
+      await flush();
+      stdin.write("\r"); // http
+      await flush();
+      stdin.write("mcp.example.com");
+      await flush();
+      stdin.write("\r"); // submit URL
+      await flush();
+      stdin.write("\r"); // skip API key (empty)
+      await flush();
+      await flush();
+      await flush();
+
+      const config = onUpdate.mock.calls[0][0].mcpServers["no-auth-server"];
+      expect(config.headers).toBeUndefined();
     });
   });
 });

--- a/src/components/mcp-server-selector.tsx
+++ b/src/components/mcp-server-selector.tsx
@@ -13,6 +13,7 @@ type Step =
   | "serverTools"
   | "addType"
   | "addUrl"
+  | "addApiKey"
   | "addCommand"
   | "connecting";
 
@@ -42,6 +43,7 @@ export function McpServerSelector({
   );
   const [reconnectName, setReconnectName] = useState<string | null>(null);
   const [activeServer, setActiveServer] = useState<string | null>(null);
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
 
   const activeTools = activeServer
     ? (state.mcpServers[activeServer]?.tools ?? [])
@@ -147,7 +149,13 @@ export function McpServerSelector({
     };
   }, [step, pendingConfig]);
 
-  const subSteps: Step[] = ["addType", "addUrl", "addCommand", "connecting"];
+  const subSteps: Step[] = [
+    "addType",
+    "addUrl",
+    "addApiKey",
+    "addCommand",
+    "connecting",
+  ];
 
   useInput((input, key) => {
     if (key.escape) {
@@ -160,6 +168,7 @@ export function McpServerSelector({
         setTextValue("");
         setConnectError(null);
         setPendingConfig(null);
+        setPendingUrl(null);
         setReconnectName(null);
         setStep("servers");
       }
@@ -176,6 +185,7 @@ export function McpServerSelector({
         setTextValue("");
         setConnectError(null);
         setPendingConfig(null);
+        setPendingUrl(null);
         setReconnectName(null);
         setStep("servers");
       }
@@ -273,8 +283,31 @@ export function McpServerSelector({
         if (key.return) {
           const url = textValue.trim();
           if (!url) return;
-          setPendingConfig({ transport: "http", url });
+          setPendingUrl(url);
+          setTextValue("");
+          setStep("addApiKey");
+        } else if (key.backspace || key.delete) {
+          setTextValue((v) => v.slice(0, -1));
+        } else if (input && !key.ctrl && !key.meta) {
+          setTextValue((v) => v + input);
+        }
+        break;
+      }
+
+      case "addApiKey": {
+        if (key.return) {
+          const apiKey = textValue.trim();
+          const headers = apiKey
+            ? { Authorization: `Bearer ${apiKey}` }
+            : undefined;
+          setPendingConfig({
+            transport: "http",
+            url: pendingUrl ?? "",
+            ...(headers ? { headers } : {}),
+          });
           setConnectError(null);
+          setTextValue("");
+          setPendingUrl(null);
           setStep("connecting");
         } else if (key.backspace || key.delete) {
           setTextValue((v) => v.slice(0, -1));
@@ -399,6 +432,24 @@ export function McpServerSelector({
           <Text>
             {"    "}
             {textValue}
+            <Text dimColor>█</Text>
+          </Text>
+        </Box>
+      );
+
+    case "addApiKey":
+      return (
+        <Box flexDirection="column">
+          <Text dimColor>
+            {"  Enter API key (Enter confirm, leave empty to skip, Esc back):"}
+          </Text>
+          <Text dimColor>
+            {"  Tip: use ${VAR} to reference environment variables"}
+          </Text>
+          <Text>{""}</Text>
+          <Text>
+            {"    "}
+            {"*".repeat(textValue.length)}
             <Text dimColor>█</Text>
           </Text>
         </Box>


### PR DESCRIPTION
## Summary

Adds an optional API key prompt to the MCP HTTP server add flow in /settings, so users can authenticate with remote servers without editing config YAML manually.

## GitHub Issue

Closes #204

## What Changed

A new `addApiKey` step is inserted between URL entry and connection for HTTP servers. When the user submits a URL, they're prompted for an API key before the transport connects. The step is skippable by pressing Enter with an empty input.

The key is stored as an `Authorization: Bearer <key>` header in the server config's `headers` field. Input is masked with asterisks matching the provider API key step pattern. A hint line reminds users they can use `${VAR}` syntax to reference environment variables instead of pasting raw keys.

Stdio servers bypass this step entirely. Existing servers with manually configured headers are unaffected — the wizard only writes headers on new server creation.