### PR TITLE
fix(chat-input): prevent autocomplete from blocking history navigation

### DIFF
--- a/src/components/chat-input.test.tsx
+++ b/src/components/chat-input.test.tsx
@@ -635,13 +635,10 @@ describe("ChatInput", () => {
       const { stdin } = render(
         <ChatInput onSubmit={onSubmit} inputHistory={["one", "two"]} />,
       );
-      // First up: recalls "two" (cursor at end)
+      // First up: recalls "two" (cursor at start)
       stdin.write("\x1B[A");
       await flush();
-      // Second up: moves cursor to start of "two"
-      stdin.write("\x1B[A");
-      await flush();
-      // Third up: recalls "one"
+      // Second up: recalls "one" (single press per entry while browsing)
       stdin.write("\x1B[A");
       await flush();
       stdin.write("\r");
@@ -696,13 +693,10 @@ describe("ChatInput", () => {
       const { stdin } = render(
         <ChatInput onSubmit={onSubmit} inputHistory={["only entry"]} />,
       );
-      // First up: recalls "only entry"
+      // First up: recalls "only entry" (cursor at start)
       stdin.write("\x1B[A");
       await flush();
-      // Second up: moves cursor to start
-      stdin.write("\x1B[A");
-      await flush();
-      // Third up: already at oldest — should be a no-op (cursor stays at 0)
+      // Second up: already at oldest — should be a no-op (cursor stays at 0)
       stdin.write("\x1B[A");
       await flush();
       // Type at cursor position to verify it's still at start
@@ -711,6 +705,86 @@ describe("ChatInput", () => {
       stdin.write("\r");
       await flush();
       expect(onSubmit).toHaveBeenCalledWith("Xonly entry");
+    });
+
+    it("up arrow navigates past slash-prefixed history entries without autocomplete capturing input", async () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <ChatInput
+          onSubmit={onSubmit}
+          inputHistory={["first", "/help", "third"]}
+        />,
+      );
+      // Up 1: recalls "third" (cursor at start)
+      stdin.write("\x1B[A");
+      await flush();
+      // Up 2: recalls "/help" — NOT captured by autocomplete
+      stdin.write("\x1B[A");
+      await flush();
+      // Up 3: recalls "first"
+      stdin.write("\x1B[A");
+      await flush();
+      stdin.write("\r");
+      await flush();
+      expect(onSubmit).toHaveBeenLastCalledWith("first");
+    });
+
+    it("down arrow navigates past slash-prefixed history entries without autocomplete capturing input", async () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <ChatInput
+          onSubmit={onSubmit}
+          inputHistory={["first", "/help", "third"]}
+        />,
+      );
+      // Navigate to oldest: single up per entry
+      stdin.write("\x1B[A"); // "third"
+      await flush();
+      stdin.write("\x1B[A"); // "/help"
+      await flush();
+      stdin.write("\x1B[A"); // "first"
+      await flush();
+      // Down 1: recalls "/help" — NOT captured by autocomplete
+      stdin.write("\x1B[B");
+      await flush();
+      // Down 2: recalls "third"
+      stdin.write("\x1B[B");
+      await flush();
+      stdin.write("\r");
+      await flush();
+      expect(onSubmit).toHaveBeenLastCalledWith("third");
+    });
+
+    it("editing a recalled slash-prefixed history entry re-activates autocomplete", async () => {
+      const { lastFrame, stdin } = render(
+        <ChatInput onSubmit={vi.fn()} inputHistory={["/he"]} />,
+      );
+      // Recall "/he" from history (cursor at start)
+      stdin.write("\x1B[A");
+      await flush();
+      // Autocomplete should be suppressed while browsing history
+      expect(lastFrame()).not.toContain("List available commands");
+      // Move cursor to end, then type to edit — this leaves history mode
+      stdin.write("\x05"); // Ctrl+E
+      await flush();
+      stdin.write("l");
+      await flush();
+      // Now autocomplete should activate since we're editing "/hel"
+      const output = lastFrame() ?? "";
+      expect(output).toContain("help");
+    });
+
+    it("does not show autocomplete dropdown for slash-prefixed history entries", async () => {
+      const { lastFrame, stdin } = render(
+        <ChatInput onSubmit={vi.fn()} inputHistory={["/help"]} />,
+      );
+      // Recall "/help" from history
+      stdin.write("\x1B[A");
+      await flush();
+      const output = lastFrame() ?? "";
+      // The input should contain /help but the autocomplete list should not render
+      expect(output).toContain("/help");
+      expect(output).not.toContain("List available commands");
     });
 
     it("preserves draft when scrolling through history", async () => {
@@ -723,18 +797,15 @@ describe("ChatInput", () => {
       stdin.write("my draft");
       await flush();
 
-      // Up arrow: first goes to start of line
+      // Up arrow: goes to start of line (not yet in history)
       stdin.write("\x1B[A");
       await flush();
-      // Up arrow again: recalls "old message"
+      // Up arrow: recalls "old message"
       stdin.write("\x1B[A");
       await flush();
       expect(lastFrame()).toContain("old message");
 
-      // Down arrow: goes to end of "old message"
-      stdin.write("\x1B[B");
-      await flush();
-      // Down arrow again: restores draft
+      // Down arrow: restores draft (single press while browsing history)
       stdin.write("\x1B[B");
       await flush();
       expect(lastFrame()).toContain("my draft");

--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -103,7 +103,14 @@ export function ChatInput({
   const totalImages = clipboardImages.length;
 
   const autocomplete = useAutocomplete(defaultProviders, value, cursor);
-  const { active: isAutocomplete, ghost, showGhost } = autocomplete;
+  const {
+    active: isAutocomplete,
+    ghost,
+    showGhost: rawShowGhost,
+  } = autocomplete;
+  // Suppress ghost text while browsing input history — autocomplete should
+  // only activate when the user is actively typing, not replaying history.
+  const showGhost = rawShowGhost && historyIndexRef.current < 0;
 
   useInput(
     (input, key) => {
@@ -217,7 +224,11 @@ export function ChatInput({
 
       // Vertical cursor movement — autocomplete, multi-line, or input history
       if (key.upArrow) {
-        if (isAutocomplete && autocomplete.visibleEntries.length > 0) {
+        if (
+          isAutocomplete &&
+          autocomplete.visibleEntries.length > 0 &&
+          historyIndexRef.current < 0
+        ) {
           autocomplete.moveUp();
           return;
         }
@@ -230,8 +241,10 @@ export function ChatInput({
           setCursor(prevLineStart + Math.min(col, prevLineLength));
           return;
         }
-        // On first line — go to start of line first, then recall history
-        if (cursor > 0) {
+        // On first line — go to start of line first, then recall history.
+        // When already browsing history, skip the cursor-to-start step so a
+        // single up arrow moves to the previous entry immediately.
+        if (cursor > 0 && historyIndexRef.current < 0) {
           setCursor(0);
           return;
         }
@@ -248,12 +261,16 @@ export function ChatInput({
               : historyIndexRef.current - 1;
           historyIndexRef.current = nextIdx;
           setValue(inputHistory[nextIdx]);
-          setCursor(inputHistory[nextIdx].length);
+          setCursor(0);
         }
         return;
       }
       if (key.downArrow) {
-        if (isAutocomplete && autocomplete.visibleEntries.length > 0) {
+        if (
+          isAutocomplete &&
+          autocomplete.visibleEntries.length > 0 &&
+          historyIndexRef.current < 0
+        ) {
           autocomplete.moveDown();
           return;
         }
@@ -270,8 +287,10 @@ export function ChatInput({
           setCursor(nextLineStart + Math.min(col, nextLineLength));
           return;
         }
-        // On last line — go to end of line first, then history/image nav
-        if (cursor < value.length) {
+        // On last line — go to end of line first, then history/image nav.
+        // When already browsing history, skip the cursor-to-end step so a
+        // single down arrow moves to the next entry immediately.
+        if (cursor < value.length && historyIndexRef.current < 0) {
           setCursor(value.length);
           return;
         }
@@ -361,6 +380,8 @@ export function ChatInput({
         (input === "w" && key.ctrl)
       ) {
         if (cursor > 0) {
+          historyIndexRef.current = -1;
+          draftRef.current = null;
           const boundary = findPrevWordBoundary(value, cursor);
           setValue((v) => v.slice(0, boundary) + v.slice(cursor));
           setCursor(boundary);
@@ -370,6 +391,8 @@ export function ChatInput({
 
       if (key.delete) {
         if (cursor > 0) {
+          historyIndexRef.current = -1;
+          draftRef.current = null;
           setValue((v) => v.slice(0, cursor - 1) + v.slice(cursor));
           setCursor((c) => c - 1);
         }
@@ -377,6 +400,8 @@ export function ChatInput({
       }
 
       if (input && !key.ctrl && !key.meta) {
+        historyIndexRef.current = -1;
+        draftRef.current = null;
         // Use refs to get the real accumulated value during paste bursts
         // (React batches setValue calls, so the closure `value` may be stale).
         const prev = valueRef.current;
@@ -520,7 +545,9 @@ export function ChatInput({
         {"─".repeat(bottomLineWidth)}
         {contextLabel}
       </Text>
-      {isAutocomplete && autocomplete.visibleEntries.length > 0 ? (
+      {isAutocomplete &&
+      autocomplete.visibleEntries.length > 0 &&
+      historyIndexRef.current < 0 ? (
         <Box flexDirection="column">
           {(() => {
             const maxName = Math.max(


### PR DESCRIPTION
## Summary

Fix input history navigation being blocked by autocomplete when a previous entry starts with `/` or `//`. Arrow keys now skip through history entries with a single press each, and autocomplete only activates when the user is actively typing.

## GitHub Issue

Closes #196

## What Changed

When browsing input history with up/down arrows, autocomplete (arrow nav, ghost text, dropdown) is now suppressed for the duration of history browsing. This prevents slash-prefixed history entries from activating the autocomplete dropdown and capturing arrow key events.

The cursor is now placed at the start of the message on up-recall and at the end on down-recall. The intermediate "move cursor to boundary" step is skipped while browsing history, so each arrow press moves directly to the next/previous entry. Editing the input (typing or deleting) exits history mode and re-activates autocomplete normally.

4 new tests cover: navigating past slash entries in both directions, autocomplete dropdown suppression during history browsing, and re-activation on edit.