### PR TITLE
feat(mcp): add header key/value configurator and align settings keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,29 +70,7 @@ Agent spawns headless sub-agents that can read files, search code, and explore t
 
 Tomo supports the [Model Context Protocol](https://modelcontextprotocol.io) (MCP) for connecting to external tool servers. MCP servers extend Tomo with additional tools — database access, API integrations, file systems, and more.
 
-### Adding a Server
-
-Use `/settings` → **MCP Servers** → press **a** to add a new server. The setup wizard walks through:
-
-1. Select transport type (`http` or `stdio`)
-2. Enter connection details (URL for HTTP, command for stdio)
-3. For HTTP: optionally provide an API key (stored as an `Authorization` header)
-4. Tomo connects, discovers available tools, and saves the config
-
-### Managing Servers
-
-From `/settings` → **MCP Servers**:
-
-| Key       | Action                              |
-| --------- | ----------------------------------- |
-| `Space`   | Toggle server on/off                |
-| `Enter`   | View and toggle individual tools    |
-| `a`       | Add a new server                    |
-| `d`       | Delete a server                     |
-| `r`       | Reconnect a failed server           |
-| `Esc`     | Save and exit                       |
-
-Disabled servers won't start. Individual tools within a server can be toggled off to hide them from the model while keeping the server connected.
+Use `/settings` → **MCP Servers** to add, remove, and configure servers. Individual tools within a server can be toggled off to hide them from the model while keeping the server connected.
 
 ### Config
 

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -84,7 +84,6 @@ const settings: Command = {
           saveSettings(state);
           callbacks.onComplete({ output: "Settings updated." });
         },
-        onCancel: callbacks.onCancel,
       }),
     };
   },

--- a/src/components/allowed-commands-editor.test.tsx
+++ b/src/components/allowed-commands-editor.test.tsx
@@ -54,12 +54,7 @@ describe("AllowedCommandsEditor", () => {
     const onUpdate = vi.fn();
     const { stdin } = renderEditor({ onUpdate });
 
-    // Navigate to Add row
-    stdin.write("\x1B[B");
-    await flush();
-    stdin.write("\x1B[B");
-    await flush();
-    stdin.write("\r");
+    stdin.write("a");
     await flush();
     stdin.write("cargo:*");
     await flush();
@@ -110,17 +105,6 @@ describe("AllowedCommandsEditor", () => {
     stdin.write("\x1B");
     await flush();
 
-    expect(onBack).toHaveBeenCalled();
-  });
-
-  it("calls onBack on q", async () => {
-    const onBack = vi.fn();
-    const { stdin } = renderEditor({ onBack });
-
-    stdin.write("q");
-    await flush();
-
-    // q triggers add mode via 'a' check... actually q doesn't match 'a'
     expect(onBack).toHaveBeenCalled();
   });
 

--- a/src/components/allowed-commands-editor.tsx
+++ b/src/components/allowed-commands-editor.tsx
@@ -50,7 +50,7 @@ export function AllowedCommandsEditor({
       return;
     }
 
-    if (key.escape || input === "q" || input === "Q") {
+    if (key.escape) {
       onBack();
       return;
     }
@@ -70,8 +70,6 @@ export function AllowedCommandsEditor({
       }
     } else if (input === "a" || input === "A") {
       setCursor(state.allowedCommands.length);
-      setAdding(true);
-    } else if ((input === " " || key.return) && isOnAdd) {
       setAdding(true);
     }
   });

--- a/src/components/mcp-server-selector.test.tsx
+++ b/src/components/mcp-server-selector.test.tsx
@@ -80,16 +80,6 @@ describe("McpServerSelector", () => {
       expect(onBack).toHaveBeenCalled();
     });
 
-    it("calls onBack on q", async () => {
-      const onBack = vi.fn();
-      const { stdin } = renderMcp({ onBack });
-
-      stdin.write("q");
-      await flush();
-
-      expect(onBack).toHaveBeenCalled();
-    });
-
     it("toggles server enabled with Space", async () => {
       const onUpdate = vi.fn();
       const { stdin } = renderMcp({
@@ -282,7 +272,7 @@ describe("McpServerSelector", () => {
     it("navigates to transport type selection on Add", async () => {
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r");
+      stdin.write("a");
       await flush();
 
       const output = lastFrame() ?? "";
@@ -293,7 +283,7 @@ describe("McpServerSelector", () => {
     it("navigates to URL input for http", async () => {
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r");
+      stdin.write("a");
       await flush();
       stdin.write("\r");
       await flush();
@@ -305,7 +295,7 @@ describe("McpServerSelector", () => {
     it("navigates to command input for stdio", async () => {
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r");
+      stdin.write("a");
       await flush();
       stdin.write("\x1B[B");
       await flush();
@@ -319,7 +309,7 @@ describe("McpServerSelector", () => {
     it("returns to server list on Esc from add steps", async () => {
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r");
+      stdin.write("a");
       await flush();
       expect(lastFrame()).toContain("http");
 
@@ -388,7 +378,7 @@ describe("McpServerSelector", () => {
       const { stdin } = renderMcp({ onUpdate });
 
       // Navigate: Add → http → enter URL (pre-filled with "https://") → submit
-      stdin.write("\r"); // select "Add..."
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // select "http"
       await flush();
@@ -431,7 +421,7 @@ describe("McpServerSelector", () => {
       // Navigate down to "Add..." (past existing server)
       stdin.write("\x1B[B"); // arrow down
       await flush();
-      stdin.write("\r"); // select "Add..."
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // select "http"
       await flush();
@@ -468,7 +458,7 @@ describe("McpServerSelector", () => {
 
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // http
       await flush();
@@ -490,7 +480,7 @@ describe("McpServerSelector", () => {
       const onUpdate = vi.fn();
       const { stdin } = renderMcp({ onUpdate });
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\x1B[B"); // arrow down to stdio
       await flush();
@@ -520,7 +510,7 @@ describe("McpServerSelector", () => {
     it("shows header configurator after URL entry", async () => {
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // http
       await flush();
@@ -540,7 +530,7 @@ describe("McpServerSelector", () => {
     it("adds a header via key/value prompts", async () => {
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // http
       await flush();
@@ -574,7 +564,7 @@ describe("McpServerSelector", () => {
       const onUpdate = vi.fn();
       const { stdin } = renderMcp({ onUpdate });
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // http
       await flush();
@@ -615,7 +605,7 @@ describe("McpServerSelector", () => {
       const onUpdate = vi.fn();
       const { stdin } = renderMcp({ onUpdate });
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // http
       await flush();
@@ -666,7 +656,7 @@ describe("McpServerSelector", () => {
     it("deletes a header with d", async () => {
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // http
       await flush();
@@ -695,7 +685,7 @@ describe("McpServerSelector", () => {
     it("edits an existing header value with e", async () => {
       const { stdin, lastFrame } = renderMcp();
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // http
       await flush();
@@ -816,7 +806,7 @@ describe("McpServerSelector", () => {
       const onUpdate = vi.fn();
       const { stdin } = renderMcp({ onUpdate });
 
-      stdin.write("\r"); // Add
+      stdin.write("a"); // Add
       await flush();
       stdin.write("\r"); // http
       await flush();

--- a/src/components/mcp-server-selector.tsx
+++ b/src/components/mcp-server-selector.tsx
@@ -193,26 +193,6 @@ export function McpServerSelector({
       return;
     }
 
-    if (input === "q" || input === "Q") {
-      if (step === "servers") {
-        onBack();
-      } else if (step === "serverTools") {
-        setActiveServer(null);
-        setStep("servers");
-      } else if (subSteps.includes(step)) {
-        setTextValue("");
-        setConnectError(null);
-        setPendingConfig(null);
-        setPendingUrl(null);
-        setPendingHeaders({});
-        setPendingHeaderKey(null);
-        setEditingServerName(null);
-        setReconnectName(null);
-        setStep("servers");
-      }
-      return;
-    }
-
     switch (step) {
       case "servers": {
         const isOnAdd = cursor === serverNames.length;
@@ -261,11 +241,7 @@ export function McpServerSelector({
           setEditingServerName(name);
           setPendingHeaders({ ...currentHeaders });
           setStep("addHeaders");
-        } else if (
-          input === "a" ||
-          input === "A" ||
-          ((input === " " || key.return) && isOnAdd)
-        ) {
+        } else if (input === "a" || input === "A") {
           setTextValue("");
           setConnectError(null);
           setStep("addType");
@@ -278,7 +254,7 @@ export function McpServerSelector({
           handleUp();
         } else if (key.downArrow) {
           handleDown();
-        } else if ((input === " " || key.return) && activeServer) {
+        } else if (input === " " && activeServer) {
           const tool = activeTools[cursor];
           if (!tool) break;
           const updated = activeTools.map((t) =>
@@ -466,7 +442,7 @@ export function McpServerSelector({
         <Box flexDirection="column">
           <Text dimColor>
             {
-              "  MCP Servers (Space toggle, Enter tools, e headers, d delete, a add, r reconnect, Esc back):"
+              "  MCP Servers (Space toggle, Enter tools, a add, e headers, d delete, r reconnect, Esc back):"
             }
           </Text>
           <Text>{""}</Text>
@@ -494,7 +470,7 @@ export function McpServerSelector({
       return (
         <Box flexDirection="column">
           <Text dimColor>
-            {`  ${activeServer} — Tools (Space/Enter toggle, Esc back):`}
+            {`  ${activeServer} — Tools (Space toggle, Esc back):`}
           </Text>
           <Text>{""}</Text>
           {items.length === 0 ? (

--- a/src/components/settings-selector.test.tsx
+++ b/src/components/settings-selector.test.tsx
@@ -34,19 +34,16 @@ function renderSettings(overrides?: {
   state?: Partial<SettingsState>;
   toolMeta?: Partial<ToolMeta>;
   onSave?: (state: SettingsState) => void;
-  onCancel?: () => void;
 }) {
   const onSave = overrides?.onSave ?? vi.fn();
-  const onCancel = overrides?.onCancel ?? vi.fn();
   const result = render(
     <SettingsSelector
       initialState={{ ...defaultState, ...overrides?.state }}
       toolMeta={{ ...defaultToolMeta, ...overrides?.toolMeta }}
       onSave={onSave}
-      onCancel={onCancel}
     />,
   );
-  return { ...result, onSave, onCancel };
+  return { ...result, onSave };
 }
 
 describe("SettingsSelector", () => {
@@ -68,16 +65,6 @@ describe("SettingsSelector", () => {
       await flush();
 
       expect(onSave).toHaveBeenCalledWith(defaultState);
-    });
-
-    it("cancels on q from menu", async () => {
-      const onCancel = vi.fn();
-      const { stdin } = renderSettings({ onCancel });
-
-      stdin.write("q");
-      await flush();
-
-      expect(onCancel).toHaveBeenCalled();
     });
   });
 
@@ -304,11 +291,7 @@ describe("SettingsSelector", () => {
       await flush();
       stdin.write("\r");
       await flush();
-      stdin.write("\x1B[B");
-      await flush();
-      stdin.write("\x1B[B");
-      await flush();
-      stdin.write("\r");
+      stdin.write("a");
       await flush();
       stdin.write("cargo:*");
       await flush();
@@ -437,16 +420,6 @@ describe("SettingsSelector", () => {
       expect(lastFrame()).toContain("Tool Availability");
 
       stdin.write("\x1B");
-      await flush();
-      expect(lastFrame()).toContain("Settings");
-    });
-
-    it("returns to menu with q from a step", async () => {
-      const { stdin, lastFrame } = renderSettings();
-
-      stdin.write("\r");
-      await flush();
-      stdin.write("q");
       await flush();
       expect(lastFrame()).toContain("Settings");
     });

--- a/src/components/settings-selector.tsx
+++ b/src/components/settings-selector.tsx
@@ -39,7 +39,6 @@ export interface SettingsSelectorProps {
   toolMeta: ToolMeta;
   mcpFailedServers?: Set<string>;
   onSave: (state: SettingsState) => void;
-  onCancel: () => void;
 }
 
 /** Settings root. Owns a single config state; sub-components read/update it; saves on final Esc. */
@@ -48,7 +47,6 @@ export function SettingsSelector({
   toolMeta,
   mcpFailedServers,
   onSave,
-  onCancel,
 }: SettingsSelectorProps) {
   const [state, setState] = useState<SettingsState>({ ...initialState });
   const [step, setStep] = useState<Step>("menu");
@@ -66,16 +64,11 @@ export function SettingsSelector({
     setCursor(0);
   }, [step]);
 
-  useInput((input, key) => {
+  useInput((_input, key) => {
     if (step !== "menu") return;
 
     if (key.escape) {
       onSave(state);
-      return;
-    }
-
-    if (input === "q" || input === "Q") {
-      onCancel();
       return;
     }
 
@@ -95,7 +88,7 @@ export function SettingsSelector({
       return (
         <Box flexDirection="column">
           <Text dimColor>
-            {"  Settings (↑↓ navigate, Enter select, Esc save, q cancel):"}
+            {"  Settings (↑↓ navigate, Enter select, Esc save):"}
           </Text>
           <Text>{""}</Text>
           {MENU_OPTIONS.map((option, i) => {

--- a/src/components/tool-availability-editor.tsx
+++ b/src/components/tool-availability-editor.tsx
@@ -38,7 +38,7 @@ export function ToolAvailabilityEditor({
   );
 
   useInput((input, key) => {
-    if (key.escape || input === "q" || input === "Q") {
+    if (key.escape) {
       onBack();
       return;
     }
@@ -47,7 +47,7 @@ export function ToolAvailabilityEditor({
       handleUp();
     } else if (key.downArrow) {
       handleDown();
-    } else if (input === " " || key.return) {
+    } else if (input === " ") {
       const item = allToolItems[cursor];
       if (item?.type === "builtin") {
         onUpdate({
@@ -117,9 +117,7 @@ export function ToolAvailabilityEditor({
 
   return (
     <Box flexDirection="column">
-      <Text dimColor>
-        {"  Tool Availability (Space/Enter toggle, Esc back):"}
-      </Text>
+      <Text dimColor>{"  Tool Availability (Space toggle, Esc back):"}</Text>
       <Text>{""}</Text>
       {builtInItems.map((item, i) => {
         const isCurrent = i === cursor;

--- a/src/components/tool-permissions-editor.test.tsx
+++ b/src/components/tool-permissions-editor.test.tsx
@@ -62,14 +62,4 @@ describe("ToolPermissionsEditor", () => {
 
     expect(onBack).toHaveBeenCalled();
   });
-
-  it("calls onBack on q", async () => {
-    const onBack = vi.fn();
-    const { stdin } = renderEditor({ onBack });
-
-    stdin.write("q");
-    await flush();
-
-    expect(onBack).toHaveBeenCalled();
-  });
 });

--- a/src/components/tool-permissions-editor.tsx
+++ b/src/components/tool-permissions-editor.tsx
@@ -39,7 +39,7 @@ export function ToolPermissionsEditor({
   );
 
   useInput((input, key) => {
-    if (key.escape || input === "q" || input === "Q") {
+    if (key.escape) {
       onBack();
       return;
     }
@@ -48,7 +48,7 @@ export function ToolPermissionsEditor({
       handleUp();
     } else if (key.downArrow) {
       handleDown();
-    } else if (input === " " || key.return) {
+    } else if (input === " ") {
       const row = PERMISSION_ROWS[cursor];
       onUpdate({
         permissions: {
@@ -68,9 +68,7 @@ export function ToolPermissionsEditor({
 
   return (
     <Box flexDirection="column">
-      <Text dimColor>
-        {"  Tool Permissions (Space/Enter toggle, Esc back):"}
-      </Text>
+      <Text dimColor>{"  Tool Permissions (Space toggle, Esc back):"}</Text>
       <Text>{""}</Text>
       <CheckboxList items={items} cursor={cursor} />
     </Box>


### PR DESCRIPTION
## Summary

Replace the single API key prompt with a generic header key/value configurator for HTTP MCP servers, and align keybindings across all settings screens for consistency.

## GitHub Issue

Closes #211

## What Changed

**Header configurator:** The HTTP server setup wizard now prompts for headers as key/value pairs instead of a single API key. Users can add multiple headers (`Authorization`, `X-API-Key`, etc.), edit existing headers with `e`, and delete with `d`. Values are masked. Existing servers' headers can be edited from the server list with `e`.

**Settings save fix:** The save logic now writes the full server config instead of only persisting `enabled` and `tools`, so header changes (and removals) are correctly saved to disk.

**Keybinding alignment:** Dropped `q` from all settings screens — it had confusing dual semantics (discard on root, back on sub-screens) and was a bug on text input screens where pressing `q` cancelled instead of typing the letter. Made `Space` the only toggle key (removed `Enter` as toggle), `Enter` the primary action (select/confirm/view details), and `a` the only add key. Removed `onCancel` prop from `SettingsSelector` since `Esc` now always saves.

**README:** Trimmed MCP section to remove key control details that duplicate in-app hints.