### PR TITLE
feat(skill-sets): clone sources and display skill sets with toggles

### DIFF
--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -8,9 +8,11 @@ import {
   addMcpServer,
   getAllMcpServers,
   getAllowedCommands,
+  getEnabledSkillSets,
   getSkillSetSources,
   loadConfig,
   removeMcpServer,
+  updateEnabledSkillSets,
   updateLocalAllowedCommands,
   updateLocalPermissions,
   updateLocalToolConfig,
@@ -27,8 +29,9 @@ function saveSettings(state: SettingsState): void {
   updateLocalPermissions(state.permissions);
   updateLocalAllowedCommands(state.allowedCommands);
 
-  // Global config: skill set sources
+  // Global config: skill set sources and enabled sets
   updateSkillSetSources(state.skillSetSources);
+  updateEnabledSkillSets(state.enabledSkillSets);
 
   // Global config: MCP servers
   const currentConfig = loadConfig();
@@ -79,6 +82,7 @@ const settings: Command = {
       allowedCommands: getAllowedCommands(config),
       mcpServers: getAllMcpServers(config),
       skillSetSources: getSkillSetSources(config),
+      enabledSkillSets: getEnabledSkillSets(config),
     };
 
     return {

--- a/src/components/allowed-commands-editor.test.tsx
+++ b/src/components/allowed-commands-editor.test.tsx
@@ -11,6 +11,7 @@ const baseState: SettingsState = {
   allowedCommands: ["git:*", "npm:*"],
   mcpServers: {},
   skillSetSources: [],
+  enabledSkillSets: [],
 };
 
 function renderEditor(overrides?: {

--- a/src/components/mcp-server-selector.test.tsx
+++ b/src/components/mcp-server-selector.test.tsx
@@ -23,6 +23,7 @@ const defaultState: SettingsState = {
   allowedCommands: [],
   mcpServers: {},
   skillSetSources: [],
+  enabledSkillSets: [],
 };
 
 function renderMcp(overrides?: {

--- a/src/components/settings-selector.test.tsx
+++ b/src/components/settings-selector.test.tsx
@@ -29,6 +29,7 @@ const defaultState: SettingsState = {
   allowedCommands: ["git:*", "npm:*"],
   mcpServers: {},
   skillSetSources: [],
+  enabledSkillSets: [],
 };
 
 function renderSettings(overrides?: {

--- a/src/components/settings-selector.tsx
+++ b/src/components/settings-selector.tsx
@@ -1,11 +1,15 @@
 import { Box, Text, useInput } from "ink";
 import { useEffect, useState } from "react";
-import type { McpServerConfig, SkillSetSource } from "../config";
+import type {
+  EnabledSkillSet,
+  McpServerConfig,
+  SkillSetSource,
+} from "../config";
 import { useListNavigation } from "../hooks/use-list-navigation";
 import { AllowedCommandsEditor } from "./allowed-commands-editor";
 import { HintBar } from "./hint-bar";
 import { McpServerSelector } from "./mcp-server-selector";
-import { SkillSetSourcesEditor } from "./skill-set-sources-editor";
+import { SkillSetsManager } from "./skill-sets-manager";
 import { ToolAvailabilityEditor } from "./tool-availability-editor";
 import { ToolPermissionsEditor } from "./tool-permissions-editor";
 
@@ -16,6 +20,7 @@ export interface SettingsState {
   allowedCommands: string[];
   mcpServers: Record<string, McpServerConfig>;
   skillSetSources: SkillSetSource[];
+  enabledSkillSets: EnabledSkillSet[];
 }
 
 /** Static tool metadata that doesn't change during the settings session. */
@@ -164,11 +169,7 @@ export function SettingsSelector({
 
     case "skillSetSources":
       return (
-        <SkillSetSourcesEditor
-          state={state}
-          onUpdate={update}
-          onBack={goBack}
-        />
+        <SkillSetsManager state={state} onUpdate={update} onBack={goBack} />
       );
   }
 }

--- a/src/components/skill-set-sources-editor.test.tsx
+++ b/src/components/skill-set-sources-editor.test.tsx
@@ -14,6 +14,7 @@ const baseState: SettingsState = {
     { url: "https://github.com/org/skills-a.git" },
     { url: "https://github.com/org/skills-b.git" },
   ],
+  enabledSkillSets: [],
 };
 
 function renderEditor(overrides?: {

--- a/src/components/skill-sets-manager.test.tsx
+++ b/src/components/skill-sets-manager.test.tsx
@@ -1,0 +1,217 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { SettingsState } from "./settings-selector";
+import { SkillSetsManager } from "./skill-sets-manager";
+
+vi.mock("../skill-sets/sources", () => ({
+  cloneSource: vi.fn(),
+  discoverSkillSets: vi.fn(),
+}));
+
+import { cloneSource, discoverSkillSets } from "../skill-sets/sources";
+
+const mockCloneSource = vi.mocked(cloneSource);
+const mockDiscoverSkillSets = vi.mocked(discoverSkillSets);
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+
+const baseState: SettingsState = {
+  toolAvailability: {},
+  permissions: {},
+  allowedCommands: [],
+  mcpServers: {},
+  skillSetSources: [{ url: "git@github.com:org/skills.git" }],
+  enabledSkillSets: [],
+};
+
+function renderManager(overrides?: {
+  state?: Partial<SettingsState>;
+  onUpdate?: (partial: Partial<SettingsState>) => void;
+  onBack?: () => void;
+}) {
+  const onUpdate = overrides?.onUpdate ?? vi.fn();
+  const onBack = overrides?.onBack ?? vi.fn();
+  const result = render(
+    <SkillSetsManager
+      state={{ ...baseState, ...overrides?.state }}
+      onUpdate={onUpdate}
+      onBack={onBack}
+    />,
+  );
+  return { ...result, onUpdate, onBack };
+}
+
+describe("SkillSetsManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCloneSource.mockReturnValue("/tmp/cloned");
+    mockDiscoverSkillSets.mockReturnValue([
+      {
+        name: "dev",
+        description: "Dev tools",
+        path: "/tmp/cloned/dev",
+        sourceUrl: "git@github.com:org/skills.git",
+      },
+    ]);
+  });
+
+  it("shows discovered skill sets", async () => {
+    const { lastFrame } = renderManager();
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("dev");
+    expect(output).toContain("Dev tools");
+    expect(output).toContain("Manage Sources...");
+  });
+
+  it("shows skill sets as unchecked by default", async () => {
+    const { lastFrame } = renderManager();
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("[ ]");
+    expect(output).not.toContain("[✔]");
+  });
+
+  it("shows skill sets as checked when enabled", async () => {
+    const { lastFrame } = renderManager({
+      state: {
+        enabledSkillSets: [
+          { sourceUrl: "git@github.com:org/skills.git", name: "dev" },
+        ],
+      },
+    });
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("[✔]");
+  });
+
+  it("toggles a skill set on with space", async () => {
+    const onUpdate = vi.fn();
+    const { stdin } = renderManager({ onUpdate });
+    await flush();
+
+    stdin.write(" ");
+    await flush();
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      enabledSkillSets: [
+        { sourceUrl: "git@github.com:org/skills.git", name: "dev" },
+      ],
+    });
+  });
+
+  it("toggles a skill set off with space", async () => {
+    const onUpdate = vi.fn();
+    const { stdin } = renderManager({
+      state: {
+        enabledSkillSets: [
+          { sourceUrl: "git@github.com:org/skills.git", name: "dev" },
+        ],
+      },
+      onUpdate,
+    });
+    await flush();
+
+    stdin.write(" ");
+    await flush();
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      enabledSkillSets: [],
+    });
+  });
+
+  it("calls onBack on Esc", async () => {
+    const onBack = vi.fn();
+    const { stdin } = renderManager({ onBack });
+    await flush();
+
+    stdin.write("\x1B");
+    await flush();
+
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("navigates to sources editor on Enter at Manage Sources", async () => {
+    const { stdin, lastFrame } = renderManager();
+    await flush();
+
+    // Navigate down to "Manage Sources..."
+    stdin.write("\x1B[B");
+    await flush();
+    stdin.write("\r");
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Skill Set Sources");
+  });
+
+  it("shows empty state when no sources configured", async () => {
+    mockDiscoverSkillSets.mockReturnValue([]);
+    const { lastFrame } = renderManager({
+      state: { skillSetSources: [] },
+    });
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("No skill sets found");
+  });
+
+  it("shows warning for failed clone and still renders UI", async () => {
+    mockCloneSource.mockImplementation(() => {
+      throw new Error("clone failed");
+    });
+    mockDiscoverSkillSets.mockReturnValue([]);
+
+    const { lastFrame } = renderManager();
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("⚠ Failed to clone");
+    expect(output).toContain("git@github.com:org/skills.git");
+    expect(output).toContain("Manage Sources...");
+  });
+
+  it("shows <no description> when description is empty", async () => {
+    mockDiscoverSkillSets.mockReturnValue([
+      {
+        name: "ops",
+        description: "",
+        path: "/tmp/cloned/ops",
+        sourceUrl: "git@github.com:org/skills.git",
+      },
+    ]);
+
+    const { lastFrame } = renderManager();
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("<no description>");
+  });
+
+  it("shows multiple skill sets from multiple sources", async () => {
+    mockDiscoverSkillSets.mockReturnValue([
+      {
+        name: "dev",
+        description: "Dev tools",
+        path: "/tmp/cloned/dev",
+        sourceUrl: "git@github.com:org/skills.git",
+      },
+      {
+        name: "design",
+        description: "Design tools",
+        path: "/tmp/cloned/design",
+        sourceUrl: "git@github.com:org/skills.git",
+      },
+    ]);
+
+    const { lastFrame } = renderManager();
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("dev");
+    expect(output).toContain("design");
+  });
+});

--- a/src/components/skill-sets-manager.tsx
+++ b/src/components/skill-sets-manager.tsx
@@ -1,0 +1,178 @@
+import { Box, Text, useInput } from "ink";
+import { useEffect, useState } from "react";
+import {
+  cloneSource,
+  type DiscoveredSkillSet,
+  discoverSkillSets,
+} from "../skill-sets/sources";
+import { useListNavigation } from "../hooks/use-list-navigation";
+import { HintBar } from "./hint-bar";
+import type { SettingsState } from "./settings-selector";
+import { SkillSetSourcesEditor } from "./skill-set-sources-editor";
+
+export interface SkillSetsManagerProps {
+  state: SettingsState;
+  onUpdate: (partial: Partial<SettingsState>) => void;
+  onBack: () => void;
+}
+
+type Step = "list" | "sources";
+
+/** Skill sets manager with toggle list and source management sub-menu. */
+export function SkillSetsManager({
+  state,
+  onUpdate,
+  onBack,
+}: SkillSetsManagerProps) {
+  const [step, setStep] = useState<Step>("list");
+  const [discovered, setDiscovered] = useState<DiscoveredSkillSet[]>([]);
+  const [failedSources, setFailedSources] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Clone sources and discover skill sets on mount / when sources change.
+  useEffect(() => {
+    setLoading(true);
+    const allSets: DiscoveredSkillSet[] = [];
+    const failed: string[] = [];
+
+    for (const source of state.skillSetSources) {
+      try {
+        cloneSource(source.url);
+        allSets.push(...discoverSkillSets(source.url));
+      } catch {
+        failed.push(source.url);
+      }
+    }
+
+    setDiscovered(allSets);
+    setFailedSources(failed);
+    setLoading(false);
+  }, [state.skillSetSources]);
+
+  // +1 for "Manage Sources" row at the bottom.
+  const itemCount = discovered.length + 1;
+  const { cursor, handleUp, handleDown } = useListNavigation(itemCount);
+
+  const isEnabled = (set: DiscoveredSkillSet) =>
+    state.enabledSkillSets.some(
+      (e) => e.sourceUrl === set.sourceUrl && e.name === set.name,
+    );
+
+  const toggleSet = (set: DiscoveredSkillSet) => {
+    if (isEnabled(set)) {
+      onUpdate({
+        enabledSkillSets: state.enabledSkillSets.filter(
+          (e) => !(e.sourceUrl === set.sourceUrl && e.name === set.name),
+        ),
+      });
+    } else {
+      onUpdate({
+        enabledSkillSets: [
+          ...state.enabledSkillSets,
+          { sourceUrl: set.sourceUrl, name: set.name },
+        ],
+      });
+    }
+  };
+
+  useInput(
+    (input, key) => {
+      if (step !== "list") return;
+
+      if (key.escape) {
+        onBack();
+        return;
+      }
+
+      const isOnManageSources = cursor === discovered.length;
+
+      if (key.upArrow) {
+        handleUp();
+      } else if (key.downArrow) {
+        handleDown();
+      } else if (input === " " && !isOnManageSources) {
+        toggleSet(discovered[cursor]);
+      } else if (key.return && isOnManageSources) {
+        setStep("sources");
+      }
+    },
+    { isActive: step === "list" },
+  );
+
+  if (step === "sources") {
+    return (
+      <SkillSetSourcesEditor
+        state={state}
+        onUpdate={onUpdate}
+        onBack={() => setStep("list")}
+      />
+    );
+  }
+
+  if (loading) {
+    return (
+      <Box flexDirection="column">
+        <Text dimColor>{"  Loading skill sets..."}</Text>
+      </Box>
+    );
+  }
+
+  const maxName = Math.max(...discovered.map((s) => s.name.length), 0);
+
+  return (
+    <Box flexDirection="column">
+      <HintBar
+        label="Skill Sets"
+        hints={[
+          { key: "Space", action: "toggle" },
+          { key: "Enter", action: "select" },
+          { key: "Esc", action: "back" },
+        ]}
+      />
+      <Text>{""}</Text>
+      {failedSources.length > 0 &&
+        failedSources.map((url) => (
+          <Text key={url} color="yellow">
+            {"    ⚠ Failed to clone: "}
+            {url}
+          </Text>
+        ))}
+      {discovered.length === 0 && failedSources.length === 0 && (
+        <Text dimColor>{"    No skill sets found. Add sources first."}</Text>
+      )}
+      {discovered.map((set, i) => {
+        const isCurrent = i === cursor;
+        const enabled = isEnabled(set);
+        const desc = set.description || "<no description>";
+        return (
+          <Text key={`${set.sourceUrl}:${set.name}`}>
+            {"    "}
+            <Text color={isCurrent ? "cyan" : undefined}>
+              {isCurrent ? "❯" : " "}
+            </Text>{" "}
+            {enabled ? (
+              <Text color="green">[✔]</Text>
+            ) : (
+              <Text dimColor>[ ]</Text>
+            )}{" "}
+            <Text color="cyan">{set.name.padEnd(maxName)}</Text>
+            <Text color="cyan" dimColor>
+              {"  "}
+              {desc}
+            </Text>
+          </Text>
+        );
+      })}
+      <Text>{""}</Text>
+      {(() => {
+        const isCurrent = cursor === discovered.length;
+        return (
+          <Text color={isCurrent ? "cyan" : "dim"}>
+            {"    "}
+            {isCurrent ? "❯" : " "} Manage Sources...
+          </Text>
+        );
+      })()}
+    </Box>
+  );
+}

--- a/src/components/tool-availability-editor.test.tsx
+++ b/src/components/tool-availability-editor.test.tsx
@@ -18,6 +18,7 @@ const baseState: SettingsState = {
   allowedCommands: [],
   mcpServers: {},
   skillSetSources: [],
+  enabledSkillSets: [],
 };
 
 function renderEditor(overrides?: {

--- a/src/components/tool-permissions-editor.test.tsx
+++ b/src/components/tool-permissions-editor.test.tsx
@@ -11,6 +11,7 @@ const baseState: SettingsState = {
   allowedCommands: [],
   mcpServers: {},
   skillSetSources: [],
+  enabledSkillSets: [],
 };
 
 function renderEditor(overrides?: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,11 @@ const skillSetSourceSchema = z.object({
   url: z.string().min(1, "source URL is required"),
 });
 
+const enabledSkillSetSchema = z.object({
+  sourceUrl: z.string().min(1),
+  name: z.string().min(1),
+});
+
 const configSchema = z.object({
   activeProvider: z.string().default(""),
   activeModel: z.string().default(""),
@@ -90,12 +95,14 @@ const configSchema = z.object({
   allowed_commands: z.array(z.string()).optional(),
   mcpServers: z.record(z.string(), mcpServerSchema).optional(),
   skillSetSources: z.array(skillSetSourceSchema).optional(),
+  enabledSkillSets: z.array(enabledSkillSetSchema).optional(),
 });
 
 export type ProviderConfig = z.infer<typeof providerSchema>;
 export type McpServerConfig = z.infer<typeof mcpServerSchema>;
 export type McpToolConfig = z.infer<typeof mcpToolSchema>;
 export type SkillSetSource = z.infer<typeof skillSetSourceSchema>;
+export type EnabledSkillSet = z.infer<typeof enabledSkillSetSchema>;
 export type Config = z.infer<typeof configSchema>;
 
 export interface AgentsConfig {
@@ -384,6 +391,18 @@ export function getSkillSetSources(config: Config): SkillSetSource[] {
 export function updateSkillSetSources(sources: SkillSetSource[]): void {
   updateConfigFile(globalConfigPath(), (raw) => {
     raw.skillSetSources = sources;
+  });
+}
+
+/** Returns enabled skill sets from config, falling back to empty. */
+export function getEnabledSkillSets(config: Config): EnabledSkillSet[] {
+  return config.enabledSkillSets ?? [];
+}
+
+/** Updates enabled skill sets in the global config. */
+export function updateEnabledSkillSets(sets: EnabledSkillSet[]): void {
+  updateConfigFile(globalConfigPath(), (raw) => {
+    raw.enabledSkillSets = sets;
   });
 }
 

--- a/src/skill-sets/sources.test.ts
+++ b/src/skill-sets/sources.test.ts
@@ -1,0 +1,167 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sourceSlug, findSkillSets } from "./sources";
+
+describe("sourceSlug", () => {
+  it("generates a stable slug for a git SSH URL", () => {
+    const slug = sourceSlug("git@github.com:org/repo.git");
+    expect(slug).toMatch(/^org-repo-[a-f0-9]{12}$/);
+  });
+
+  it("generates a stable slug for an HTTPS URL", () => {
+    const slug = sourceSlug("https://github.com/org/repo.git");
+    expect(slug).toMatch(/^org-repo-[a-f0-9]{12}$/);
+  });
+
+  it("generates different slugs for different URLs", () => {
+    const a = sourceSlug("git@github.com:org/repo-a.git");
+    const b = sourceSlug("git@github.com:org/repo-b.git");
+    expect(a).not.toBe(b);
+  });
+
+  it("generates same slug for same URL", () => {
+    const url = "git@github.com:org/repo.git";
+    expect(sourceSlug(url)).toBe(sourceSlug(url));
+  });
+});
+
+describe("findSkillSets", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `tomo-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty for non-existent directory", () => {
+    expect(findSkillSets("/does/not/exist", "test-url")).toEqual([]);
+  });
+
+  it("returns empty for directory with no skill sets", () => {
+    mkdirSync(join(tmpDir, "random-dir"), { recursive: true });
+    writeFileSync(join(tmpDir, "random-dir", "README.md"), "hello");
+    expect(findSkillSets(tmpDir, "test-url")).toEqual([]);
+  });
+
+  it("discovers a skill set with name and description", () => {
+    const setDir = join(tmpDir, "dev");
+    mkdirSync(setDir, { recursive: true });
+    writeFileSync(
+      join(setDir, "tomo-skills.json"),
+      JSON.stringify({ name: "dev", description: "Dev tools" }),
+    );
+
+    const sets = findSkillSets(tmpDir, "test-url");
+    expect(sets).toEqual([
+      {
+        name: "dev",
+        description: "Dev tools",
+        path: setDir,
+        sourceUrl: "test-url",
+      },
+    ]);
+  });
+
+  it("discovers a skill set with name only (no description)", () => {
+    const setDir = join(tmpDir, "ops");
+    mkdirSync(setDir, { recursive: true });
+    writeFileSync(
+      join(setDir, "tomo-skills.json"),
+      JSON.stringify({ name: "ops" }),
+    );
+
+    const sets = findSkillSets(tmpDir, "test-url");
+    expect(sets).toHaveLength(1);
+    expect(sets[0].name).toBe("ops");
+    expect(sets[0].description).toBe("");
+  });
+
+  it("discovers multiple skill sets", () => {
+    for (const name of ["dev", "design", "ops"]) {
+      const setDir = join(tmpDir, name);
+      mkdirSync(setDir, { recursive: true });
+      writeFileSync(join(setDir, "tomo-skills.json"), JSON.stringify({ name }));
+    }
+
+    const sets = findSkillSets(tmpDir, "test-url");
+    expect(sets).toHaveLength(3);
+    expect(sets.map((s) => s.name).sort()).toEqual(["design", "dev", "ops"]);
+  });
+
+  it("skips directories without tomo-skills.json", () => {
+    // Has manifest
+    const devDir = join(tmpDir, "dev");
+    mkdirSync(devDir, { recursive: true });
+    writeFileSync(
+      join(devDir, "tomo-skills.json"),
+      JSON.stringify({ name: "dev" }),
+    );
+
+    // No manifest
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, "docs", "README.md"), "hello");
+
+    const sets = findSkillSets(tmpDir, "test-url");
+    expect(sets).toHaveLength(1);
+    expect(sets[0].name).toBe("dev");
+  });
+
+  it("skips hidden directories", () => {
+    const hiddenDir = join(tmpDir, ".git");
+    mkdirSync(hiddenDir, { recursive: true });
+    writeFileSync(
+      join(hiddenDir, "tomo-skills.json"),
+      JSON.stringify({ name: "hidden" }),
+    );
+
+    expect(findSkillSets(tmpDir, "test-url")).toEqual([]);
+  });
+
+  it("skips invalid JSON in tomo-skills.json", () => {
+    const setDir = join(tmpDir, "bad");
+    mkdirSync(setDir, { recursive: true });
+    writeFileSync(join(setDir, "tomo-skills.json"), "not valid json{{{");
+
+    expect(findSkillSets(tmpDir, "test-url")).toEqual([]);
+  });
+
+  it("skips tomo-skills.json missing name field", () => {
+    const setDir = join(tmpDir, "no-name");
+    mkdirSync(setDir, { recursive: true });
+    writeFileSync(
+      join(setDir, "tomo-skills.json"),
+      JSON.stringify({ description: "no name here" }),
+    );
+
+    expect(findSkillSets(tmpDir, "test-url")).toEqual([]);
+  });
+
+  it("skips files (non-directories) in the root", () => {
+    writeFileSync(join(tmpDir, "README.md"), "hello");
+    writeFileSync(
+      join(tmpDir, "tomo-skills.json"),
+      JSON.stringify({ name: "root" }),
+    );
+
+    expect(findSkillSets(tmpDir, "test-url")).toEqual([]);
+  });
+
+  it("passes sourceUrl through to discovered sets", () => {
+    const setDir = join(tmpDir, "dev");
+    mkdirSync(setDir, { recursive: true });
+    writeFileSync(
+      join(setDir, "tomo-skills.json"),
+      JSON.stringify({ name: "dev" }),
+    );
+
+    const url = "git@github.com:org/my-skills.git";
+    const sets = findSkillSets(tmpDir, url);
+    expect(sets[0].sourceUrl).toBe(url);
+  });
+});

--- a/src/skill-sets/sources.ts
+++ b/src/skill-sets/sources.ts
@@ -1,0 +1,121 @@
+import { execSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+/** Returns the directory where skill set sources are cloned to. */
+export function sourceCacheDir(): string {
+  return resolve(homedir(), ".tomo", "skill-set-sources");
+}
+
+/** Generates a stable directory name for a source URL. */
+export function sourceSlug(url: string): string {
+  // Use a short hash to avoid filesystem issues with special chars in URLs.
+  const hash = createHash("sha256").update(url).digest("hex").slice(0, 12);
+  // Extract a human-readable suffix from the URL for easier debugging.
+  const name = url
+    .replace(/\.git$/, "")
+    .split(/[/:]/g)
+    .filter(Boolean)
+    .slice(-2)
+    .join("-");
+  return `${name}-${hash}`;
+}
+
+/** Clones a git repo to the cache directory. Returns the local path. Cleans up on failure. */
+export function cloneSource(url: string): string {
+  const dir = join(sourceCacheDir(), sourceSlug(url));
+  if (existsSync(join(dir, ".git"))) {
+    return dir;
+  }
+  try {
+    execSync(`git clone --depth 1 ${url} ${dir}`, {
+      stdio: "pipe",
+    });
+  } catch (e) {
+    // Clean up partial clone directory on failure.
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    throw e;
+  }
+  return dir;
+}
+
+/** Pulls latest changes for a cloned source. */
+export function pullSource(url: string): void {
+  const dir = join(sourceCacheDir(), sourceSlug(url));
+  if (!existsSync(join(dir, ".git"))) return;
+  execSync("git pull origin main", { cwd: dir, stdio: "pipe" });
+}
+
+/** A discovered skill set within a cloned source. */
+export interface DiscoveredSkillSet {
+  /** The name from tomo-skills.json. */
+  name: string;
+  /** The description from tomo-skills.json, or empty string if absent. */
+  description: string;
+  /** The absolute path to the skill set directory. */
+  path: string;
+  /** The source URL this skill set belongs to. */
+  sourceUrl: string;
+}
+
+/** Parses a tomo-skills.json file. Returns null if invalid. */
+function parseSkillSetManifest(
+  filePath: string,
+): { name: string; description: string } | null {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    if (typeof parsed.name !== "string" || !parsed.name) return null;
+    return {
+      name: parsed.name,
+      description:
+        typeof parsed.description === "string" ? parsed.description : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Discovers all skill sets in a directory by finding tomo-skills.json files. */
+export function findSkillSets(
+  dir: string,
+  sourceUrl: string,
+): DiscoveredSkillSet[] {
+  if (!existsSync(dir)) return [];
+
+  const results: DiscoveredSkillSet[] = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".")) continue;
+
+    const entryPath = join(dir, entry.name);
+    const manifestPath = join(entryPath, "tomo-skills.json");
+
+    if (existsSync(manifestPath)) {
+      const manifest = parseSkillSetManifest(manifestPath);
+      if (manifest) {
+        results.push({
+          name: manifest.name,
+          description: manifest.description,
+          path: entryPath,
+          sourceUrl,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/** Discovers all skill sets from a cloned source. */
+export function discoverSkillSets(url: string): DiscoveredSkillSet[] {
+  const dir = join(sourceCacheDir(), sourceSlug(url));
+  if (!existsSync(dir)) return [];
+  return findSkillSets(dir, url);
+}


### PR DESCRIPTION
## Summary

Adds the core skill set infrastructure: cloning git sources to a local cache, discovering skill sets via `tomo-skills.json` markers, and a toggle UI in settings. Failed clones are handled gracefully with warnings rather than blocking the UI.

## GitHub Issue

Closes #219

## What Changed

New `src/skill-sets/sources.ts` module handles cloning sources to `~/.tomo/skill-set-sources/` (shallow clone, cleanup on failure) and discovering skill sets by scanning for `tomo-skills.json` files. A new `SkillSetsManager` component replaces the direct routing to the sources editor — it shows discovered skill sets with toggle checkboxes (off by default) and a "Manage Sources..." option that navigates to the existing sources editor. `enabledSkillSets` (array of `{ sourceUrl, name }`) is added to global config to persist toggle state.

## Notes for Reviewers

The "Skill Sets" settings menu is now a two-level navigation: skill set toggles at the top level, with "Manage Sources..." leading to the existing source URL editor. Failed source clones show a yellow warning per source but don't prevent the rest of the UI from functioning.