### PR TITLE
feat(skills): populate registry from enabled sets and improve autocomplete

### DIFF
--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -19,6 +19,7 @@ import {
   updateSkillSetSources,
 } from "../config";
 import { resolvePermissions } from "../permissions";
+import { reloadSkills } from "../skills";
 import { getAllTools, resolveToolAvailability } from "../tools";
 import { register } from "./registry";
 import type { Command } from "./types";
@@ -92,6 +93,7 @@ const settings: Command = {
         mcpFailedServers: new Set(callbacks.mcpFailedServers),
         onSave: (state: SettingsState) => {
           saveSettings(state);
+          reloadSkills();
           callbacks.onComplete({ output: "Settings updated." });
         },
       }),

--- a/src/components/chat-input.test.tsx
+++ b/src/components/chat-input.test.tsx
@@ -112,15 +112,6 @@ describe("ChatInput", () => {
     expect(output).toContain("help");
   });
 
-  it("shows ghost text for the top match", async () => {
-    const { lastFrame, stdin } = render(<ChatInput onSubmit={vi.fn()} />);
-    stdin.write("/he");
-    await flush();
-    const output = lastFrame() ?? "";
-    // Should show "lp" as ghost text after "/he"
-    expect(output).toContain("lp");
-  });
-
   it("submits the full command on Enter with partial input", async () => {
     const onSubmit = vi.fn();
     const { stdin } = render(<ChatInput onSubmit={onSubmit} />);

--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -102,15 +102,8 @@ export function ChatInput({
 
   const totalImages = clipboardImages.length;
 
-  const autocomplete = useAutocomplete(defaultProviders, value, cursor);
-  const {
-    active: isAutocomplete,
-    ghost,
-    showGhost: rawShowGhost,
-  } = autocomplete;
-  // Suppress ghost text while browsing input history — autocomplete should
-  // only activate when the user is actively typing, not replaying history.
-  const showGhost = rawShowGhost && historyIndexRef.current < 0;
+  const autocomplete = useAutocomplete(defaultProviders, value);
+  const { active: isAutocomplete } = autocomplete;
 
   useInput(
     (input, key) => {
@@ -323,12 +316,6 @@ export function ChatInput({
         return;
       }
       if (key.rightArrow) {
-        if (isAutocomplete && autocomplete.submitValue && showGhost) {
-          const accepted = `${autocomplete.submitValue} `;
-          setValue(accepted);
-          setCursor(accepted.length);
-          return;
-        }
         setCursor((c) => Math.min(value.length, c + 1));
         return;
       }
@@ -451,13 +438,8 @@ export function ChatInput({
         ? `${chalk.inverse(" ")}\n`
         : charAtCursor !== null
           ? chalk.inverse(charAtCursor)
-          : showGhost
-            ? chalk.inverse(ghost[0])
-            : chalk.inverse(" ");
+          : chalk.inverse(" ");
     inputDisplay = before + cursorStr + after;
-    if (showGhost) {
-      inputDisplay += chalk.dim(ghost.slice(1));
-    }
   }
 
   const hasContext = contextPercent != null;

--- a/src/hooks/use-autocomplete.test.tsx
+++ b/src/hooks/use-autocomplete.test.tsx
@@ -38,12 +38,10 @@ function Harness({
   controls: HarnessControls;
 }) {
   const [value, setValue] = useState("");
-  const [cursor, setCursor] = useState(0);
-  const state = useAutocomplete(providers, value, cursor);
+  const state = useAutocomplete(providers, value);
   controls.state = state;
   controls.setValue = (v: string) => {
     setValue(v);
-    setCursor(v.length);
   };
 
   return <Text>{JSON.stringify({ active: state.active })}</Text>;
@@ -99,6 +97,30 @@ describe("useAutocomplete", () => {
     expect(c.state?.visibleEntries.every((e) => e.matched)).toBe(true);
   });
 
+  it("matches items containing the partial anywhere, sorted by index", async () => {
+    const includesProviders: AutocompleteProvider[] = [
+      {
+        prefix: "/",
+        items: () => [
+          { name: "dev:pr", description: "Dev PR" },
+          { name: "pr", description: "Create PR" },
+          { name: "approve", description: "Approve PR" },
+          { name: "other", description: "Other" },
+        ],
+      },
+    ];
+    const c = setup(includesProviders);
+    c.setValue("/pr");
+    await flush();
+
+    const matched = c.state?.visibleEntries.filter((e) => e.matched) ?? [];
+    // "pr" matches at index 0, "dev:pr" at index 4, "approve" at index 2
+    expect(matched).toHaveLength(3);
+    expect(matched[0].name).toBe("pr");
+    expect(matched[1].name).toBe("approve");
+    expect(matched[2].name).toBe("dev:pr");
+  });
+
   it("shows no entries when nothing matches", async () => {
     const c = setup();
     c.setValue("/zzz");
@@ -106,36 +128,6 @@ describe("useAutocomplete", () => {
     expect(c.state?.active).toBe(true);
     expect(c.state?.visibleEntries).toHaveLength(0);
     expect(c.state?.submitValue).toBeNull();
-  });
-
-  it("computes ghost text from the selected match", async () => {
-    const c = setup();
-    c.setValue("/he");
-    await flush();
-    expect(c.state?.ghost).toBe("lp");
-    expect(c.state?.showGhost).toBe(true);
-  });
-
-  it("shows full name as ghost when only prefix is typed", async () => {
-    const c = setup();
-    c.setValue("/");
-    await flush();
-    expect(c.state?.ghost).toBe("context");
-  });
-
-  it("clears ghost text when a non-match is selected", async () => {
-    const c = setup();
-    c.setValue("/he");
-    await flush();
-    // Navigate past the 2 matches into non-matches
-    c.state?.moveDown();
-    await flush();
-    c.state?.moveDown();
-    await flush();
-    expect(c.state?.visibleEntries[c.state.visibleSelectedIndex].matched).toBe(
-      false,
-    );
-    expect(c.state?.ghost).toBe("");
   });
 
   it("returns submitValue with prefix + selected name", async () => {
@@ -255,17 +247,6 @@ describe("useAutocomplete", () => {
     // Should be back at the top
     expect(c.state?.visibleSelectedIndex).toBe(0);
     expect(c.state?.visibleEntries[0].name).toBe("context");
-  });
-
-  it("ghost text reflects the selected matched item after navigation", async () => {
-    const c = setup();
-    c.setValue("/h");
-    await flush();
-    expect(c.state?.ghost).toBe("elp");
-
-    c.state?.moveDown();
-    await flush();
-    expect(c.state?.ghost).toBe("istory");
   });
 
   it("matches the longest prefix first", async () => {

--- a/src/hooks/use-autocomplete.ts
+++ b/src/hooks/use-autocomplete.ts
@@ -23,10 +23,6 @@ export interface AutocompleteState {
   visibleEntries: AutocompleteEntry[];
   /** Index of the selected entry within visibleEntries. */
   visibleSelectedIndex: number;
-  /** Ghost text to append after the input. */
-  ghost: string;
-  /** Whether the ghost text should be displayed. */
-  showGhost: boolean;
   /** The full string to submit (prefix + selected name), or null if no match. */
   submitValue: string | null;
   /** Move the selection up (wraps around). */
@@ -48,7 +44,6 @@ const MAX_VISIBLE = 5;
 export function useAutocomplete(
   providers: AutocompleteProvider[],
   value: string,
-  cursor: number,
 ): AutocompleteState {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const prevValueRef = useRef(value);
@@ -79,15 +74,19 @@ export function useAutocomplete(
   const partial = active ? value.slice(prefix.length) : "";
   const allItems = active ? (activeProvider?.items() ?? []) : [];
 
-  // Matches first, then non-matches. Only show non-matches when there are matches.
-  const matched = allItems.filter((item) => item.name.startsWith(partial));
-  const unmatched =
-    matched.length > 0
-      ? allItems.filter((item) => !item.name.startsWith(partial))
-      : [];
+  // Score items by earliest indexOf match, sorted closest-to-0 first.
+  // Items that don't contain the partial are unmatched and shown after matches.
+  const scored = allItems.map((item) => {
+    const index = partial ? item.name.indexOf(partial) : 0;
+    return { item, index, matched: index >= 0 };
+  });
+  const matched = scored
+    .filter((s) => s.matched)
+    .sort((a, b) => a.index - b.index);
+  const unmatched = matched.length > 0 ? scored.filter((s) => !s.matched) : [];
   const entries: AutocompleteEntry[] = [
-    ...matched.map((item) => ({ ...item, matched: true })),
-    ...unmatched.map((item) => ({ ...item, matched: false })),
+    ...matched.map((s) => ({ ...s.item, matched: true })),
+    ...unmatched.map((s) => ({ ...s.item, matched: false })),
   ];
 
   // Clamp index so it never exceeds the entry list.
@@ -113,14 +112,6 @@ export function useAutocomplete(
   );
   const visibleSelectedIndex = clamped - visibleStart;
 
-  // Ghost text only for matched entries.
-  const ghost =
-    selectedEntry?.matched && partial.length > 0
-      ? selectedEntry.name.slice(partial.length)
-      : selectedEntry?.matched
-        ? selectedEntry.name
-        : "";
-  const showGhost = active && !!ghost && cursor === value.length;
   const submitValue = selectedEntry ? `${prefix}${selectedEntry.name}` : null;
 
   const moveUp = () => {
@@ -136,8 +127,6 @@ export function useAutocomplete(
     prefix,
     visibleEntries,
     visibleSelectedIndex,
-    ghost,
-    showGhost,
     submitValue,
     moveUp,
     moveDown,

--- a/src/skill-sets/sources.ts
+++ b/src/skill-sets/sources.ts
@@ -119,3 +119,13 @@ export function discoverSkillSets(url: string): DiscoveredSkillSet[] {
   if (!existsSync(dir)) return [];
   return findSkillSets(dir, url);
 }
+
+/** Returns the absolute path of a specific skill set within a cloned source, or null if not found. */
+export function getSkillSetPath(
+  sourceUrl: string,
+  setName: string,
+): string | null {
+  const sets = discoverSkillSets(sourceUrl);
+  const match = sets.find((s) => s.name === setName);
+  return match?.path ?? null;
+}

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -217,4 +217,127 @@ Review body.`,
     const skills = loadSkills(globalDir, localDir);
     expect(skills).toHaveLength(0);
   });
+
+  it("namespaces skill set skills as setName:skillName", () => {
+    const setDir = join(testDir, "skill-set");
+    writeSkill(
+      setDir,
+      "deploy",
+      `---
+name: deploy
+description: Deploy app
+---
+
+Deploy instructions.`,
+    );
+
+    const skills = loadSkills(globalDir, localDir, [
+      { name: "ops", path: setDir },
+    ]);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe("ops:deploy");
+    expect(skills[0].local).toBe(false);
+    expect(skills[0].skillSet).toBe("ops");
+  });
+
+  it("skill set skills coexist with global skills of same base name", () => {
+    const setDir = join(testDir, "skill-set");
+    writeSkill(
+      setDir,
+      "commit",
+      `---
+name: commit
+description: Set commit
+---
+
+Set body.`,
+    );
+    writeSkill(
+      globalDir,
+      "commit",
+      `---
+name: commit
+description: Global commit
+---
+
+Global body.`,
+    );
+
+    const skills = loadSkills(globalDir, localDir, [
+      { name: "dev", path: setDir },
+    ]);
+    expect(skills).toHaveLength(2);
+    expect(skills.find((s) => s.name === "dev:commit")?.skillSet).toBe("dev");
+    expect(skills.find((s) => s.name === "commit")?.skillSet).toBeUndefined();
+  });
+
+  it("loads skills from multiple skill set directories", () => {
+    const setDir1 = join(testDir, "set-a");
+    const setDir2 = join(testDir, "set-b");
+    writeSkill(
+      setDir1,
+      "deploy",
+      `---
+name: deploy
+description: Deploy
+---
+
+Deploy.`,
+    );
+    writeSkill(
+      setDir2,
+      "migrate",
+      `---
+name: migrate
+description: Migrate
+---
+
+Migrate.`,
+    );
+
+    const skills = loadSkills(globalDir, localDir, [
+      { name: "ops", path: setDir1 },
+      { name: "db", path: setDir2 },
+    ]);
+    expect(skills).toHaveLength(2);
+    expect(skills.map((s) => s.name).sort()).toEqual([
+      "db:migrate",
+      "ops:deploy",
+    ]);
+    expect(skills.find((s) => s.name === "ops:deploy")?.skillSet).toBe("ops");
+    expect(skills.find((s) => s.name === "db:migrate")?.skillSet).toBe("db");
+  });
+
+  it("later skill set with same namespaced name wins", () => {
+    const setDir1 = join(testDir, "set-a");
+    const setDir2 = join(testDir, "set-b");
+    writeSkill(
+      setDir1,
+      "deploy",
+      `---
+name: deploy
+description: From set A
+---
+
+A body.`,
+    );
+    writeSkill(
+      setDir2,
+      "deploy",
+      `---
+name: deploy
+description: From set B
+---
+
+B body.`,
+    );
+
+    const skills = loadSkills(globalDir, localDir, [
+      { name: "ops", path: setDir1 },
+      { name: "ops", path: setDir2 },
+    ]);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe("ops:deploy");
+    expect(skills[0].description).toBe("From set B");
+  });
 });

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -64,26 +64,52 @@ function loadFromDir(dir: string, local: boolean): Skill[] {
   return skills;
 }
 
+/** A skill set directory with its name for tagging loaded skills. */
+export interface SkillSetDir {
+  name: string;
+  path: string;
+}
+
 /**
- * Discovers and loads all skills from global and local directories.
- * Local skills shadow global skills with the same name.
+ * Discovers and loads all skills from skill set directories, global, and local directories.
+ * Precedence (later wins): skill sets → global → local.
  * Local skills have "(local)" prefixed to their description.
  */
-export function loadSkills(globalDir?: string, localDir?: string): Skill[] {
+export function loadSkills(
+  globalDir?: string,
+  localDir?: string,
+  skillSetDirs?: SkillSetDir[],
+): Skill[] {
+  const byName = new Map<string, Skill>();
+
+  // Skill set skills are namespaced as setName:skillName.
+  if (skillSetDirs) {
+    for (const setDir of skillSetDirs) {
+      const skills = loadFromDir(setDir.path, false);
+      for (const skill of skills) {
+        const namespacedName = `${setDir.name}:${skill.name}`;
+        byName.set(namespacedName, {
+          ...skill,
+          name: namespacedName,
+          skillSet: setDir.name,
+        });
+      }
+    }
+  }
+
+  // Global skills override skill set skills.
   const globalSkills = loadFromDir(globalDir ?? globalSkillsDir(), false);
+  for (const skill of globalSkills) {
+    byName.set(skill.name, skill);
+  }
+
+  // Local skills override everything.
   const localSkills = loadFromDir(localDir ?? localSkillsDir(), true).map(
     (skill) => ({
       ...skill,
       description: `(local) ${skill.description}`,
     }),
   );
-
-  const byName = new Map<string, Skill>();
-
-  for (const skill of globalSkills) {
-    byName.set(skill.name, skill);
-  }
-  // Local skills overwrite global with same name.
   for (const skill of localSkills) {
     byName.set(skill.name, skill);
   }

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -1,12 +1,27 @@
+import { getEnabledSkillSets, loadConfig } from "../config";
+import { getSkillSetPath } from "../skill-sets/sources";
+import type { SkillSetDir } from "./loader";
 import { loadSkills } from "./loader";
 import type { Skill } from "./types";
 
 let skills: Skill[] | null = null;
 
+/** Resolves the directories of enabled skill sets from config. */
+function resolveSkillSetDirs(): SkillSetDir[] {
+  const config = loadConfig();
+  const enabled = getEnabledSkillSets(config);
+  const dirs: SkillSetDir[] = [];
+  for (const entry of enabled) {
+    const path = getSkillSetPath(entry.sourceUrl, entry.name);
+    if (path) dirs.push({ name: entry.name, path });
+  }
+  return dirs;
+}
+
 /** Loads skills from disk (if not already loaded) and returns all discovered skills. */
 export function getAllSkills(): Skill[] {
   if (!skills) {
-    skills = loadSkills();
+    skills = loadSkills(undefined, undefined, resolveSkillSetDirs());
   }
   return skills;
 }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -8,4 +8,6 @@ export interface Skill {
   body: string;
   /** Whether this skill was loaded from the local project directory. */
   local: boolean;
+  /** The skill set name this skill was loaded from, if any. */
+  skillSet?: string;
 }


### PR DESCRIPTION
## Summary

This PR implements two main changes:
1. Updates the autocomplete to use substring matching (indexOf) instead of prefix matching, and removes the ghost text feature.
2. Implements loading skills from enabled skill set sources, namespacing them as `setName:skillName`, and reloading skills when settings are saved.

## GitHub Issue

Closes #220

## What Changed

### Autocomplete Improvements
- Removed ghost text functionality and related state (`ghost`, `showGhost`) from the autocomplete hook and chat input component.
- Changed matching strategy from `startsWith` to `indexOf` (substring matching) with sorting by match index (earliest match first).
- Updated tests to reflect the new behavior: removed ghost text tests and added a test for substring matching sorted by index.
- Simplified the `useAutocomplete` hook signature by removing the `cursor` parameter (no longer needed for ghost text).

### Skill Set Loading
- Added `getSkillSetPath` function to retrieve the absolute path of a specific skill set within a cloned source.
- Extended `Skill` interface with an optional `skillSet` property to track which skill set a skill originated from.
- Rewrote `loadSkills` to accept an optional array of `SkillSetDir` and load skills from skill set directories with namespacing (`setName:skillName`).
- Updated skill loading precedence: skill sets → global → local (later wins).
- Modified the skills registry to resolve enabled skill set directories from config and pass them to the loader.
- Added `reloadSkills()` call in settings save callback to refresh skills when skill set sources are updated.
- Added comprehensive tests for skill set loading, namespacing, coexistence with global skills, multiple skill sets, and precedence rules.

### Files Modified
- `src/commands/settings.ts`: Import `reloadSkills` and call it after saving settings.
- `src/components/chat-input.tsx`: Simplify autocomplete usage, remove ghost text related code.
- `src/components/chat-input.test.tsx`: Remove outdated ghost text test.
- `src/hooks/use-autocomplete.ts`: Rewrite matching logic, remove ghost text, adjust return values.
- `src/hooks/use-autocomplete.test.tsx`: Remove ghost text tests, add substring matching test.
- `src/skill-sets/sources.ts`: Add `getSkillSetPath` helper function.
- `src/skills/loader.ts`: Rewrite to load from skill set directories with namespacing and updated precedence.
- `src/skills/loader.test.ts`: Add extensive test suite for skill set loading behavior.
- `src/skills/registry.ts`: Resolve enabled skill set directories and pass to loader.
- `src/skills/types.ts`: Add `skillSet` property to Skill interface.

## Notes for Reviewers

- The autocomplete now shows all items containing the typed substring anywhere in the name, sorted by the position of the match (earliest index first). For example, typing "pr" will match "pr", "approve" (contains "pr" at index 2), and "dev:pr" (contains "pr" at index 4) in that order.
- Skill set skills are namespaced in the registry as `setName:skillName` (e.g., "ops:deploy") to avoid naming conflicts and allow explicit reference.
- When loading skills from multiple sources, later sources win: skill set skills override global skills with the same namespaced name, and local skills override everything.
- The skills registry now automatically reloads when settings are saved, ensuring newly added or updated skill set sources are picked up without a restart.