### PR TITLE
feat(skill-sets): add update sources action to settings

### DIFF
--- a/src/components/skill-sets-manager.test.tsx
+++ b/src/components/skill-sets-manager.test.tsx
@@ -6,12 +6,22 @@ import { SkillSetsManager } from "./skill-sets-manager";
 vi.mock("../skill-sets/sources", () => ({
   cloneSource: vi.fn(),
   discoverSkillSets: vi.fn(),
+  pullSource: vi.fn(),
 }));
 
-import { cloneSource, discoverSkillSets } from "../skill-sets/sources";
+vi.mock("../skills", () => ({
+  reloadSkills: vi.fn(),
+}));
+
+import {
+  cloneSource,
+  discoverSkillSets,
+  pullSource,
+} from "../skill-sets/sources";
 
 const mockCloneSource = vi.mocked(cloneSource);
 const mockDiscoverSkillSets = vi.mocked(discoverSkillSets);
+const mockPullSource = vi.mocked(pullSource);
 
 const flush = () => new Promise((r) => setTimeout(r, 50));
 
@@ -138,7 +148,9 @@ describe("SkillSetsManager", () => {
     const { stdin, lastFrame } = renderManager();
     await flush();
 
-    // Navigate down to "Manage Sources..."
+    // Navigate down past "Update Sources..." to "Manage Sources..."
+    stdin.write("\x1B[B");
+    await flush();
     stdin.write("\x1B[B");
     await flush();
     stdin.write("\r");
@@ -213,5 +225,60 @@ describe("SkillSetsManager", () => {
     const output = lastFrame() ?? "";
     expect(output).toContain("dev");
     expect(output).toContain("design");
+  });
+
+  it("shows Update Sources row", async () => {
+    const { lastFrame } = renderManager();
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("Update Sources...");
+  });
+
+  it("pulls sources on Enter at Update Sources", async () => {
+    const { stdin } = renderManager();
+    await flush();
+
+    // Navigate to "Update Sources..."
+    stdin.write("\x1B[B");
+    await flush();
+    stdin.write("\r");
+    await flush();
+
+    expect(mockPullSource).toHaveBeenCalledWith(
+      "git@github.com:org/skills.git",
+    );
+  });
+
+  it("shows success result after update", async () => {
+    const { stdin, lastFrame } = renderManager();
+    await flush();
+
+    stdin.write("\x1B[B");
+    await flush();
+    stdin.write("\r");
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("✔");
+    expect(output).toContain("git@github.com:org/skills.git");
+  });
+
+  it("shows failure result when pull fails", async () => {
+    mockPullSource.mockImplementation(() => {
+      throw new Error("network error");
+    });
+
+    const { stdin, lastFrame } = renderManager();
+    await flush();
+
+    stdin.write("\x1B[B");
+    await flush();
+    stdin.write("\r");
+    await flush();
+
+    const output = lastFrame() ?? "";
+    expect(output).toContain("✗");
+    expect(output).toContain("git@github.com:org/skills.git");
   });
 });

--- a/src/components/skill-sets-manager.tsx
+++ b/src/components/skill-sets-manager.tsx
@@ -4,7 +4,9 @@ import {
   cloneSource,
   type DiscoveredSkillSet,
   discoverSkillSets,
+  pullSource,
 } from "../skill-sets/sources";
+import { reloadSkills } from "../skills";
 import { useListNavigation } from "../hooks/use-list-navigation";
 import { HintBar } from "./hint-bar";
 import type { SettingsState } from "./settings-selector";
@@ -18,6 +20,12 @@ export interface SkillSetsManagerProps {
 
 type Step = "list" | "sources";
 
+interface UpdateResult {
+  url: string;
+  ok: boolean;
+  error?: string;
+}
+
 /** Skill sets manager with toggle list and source management sub-menu. */
 export function SkillSetsManager({
   state,
@@ -28,6 +36,9 @@ export function SkillSetsManager({
   const [discovered, setDiscovered] = useState<DiscoveredSkillSet[]>([]);
   const [failedSources, setFailedSources] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
+  const [updateResults, setUpdateResults] = useState<UpdateResult[] | null>(
+    null,
+  );
 
   // Clone sources and discover skill sets on mount / when sources change.
   useEffect(() => {
@@ -49,8 +60,40 @@ export function SkillSetsManager({
     setLoading(false);
   }, [state.skillSetSources]);
 
-  // +1 for "Manage Sources" row at the bottom.
-  const itemCount = discovered.length + 1;
+  const refreshDiscovered = () => {
+    const allSets: DiscoveredSkillSet[] = [];
+    for (const source of state.skillSetSources) {
+      try {
+        allSets.push(...discoverSkillSets(source.url));
+      } catch {
+        // already handled by failedSources
+      }
+    }
+    setDiscovered(allSets);
+    reloadSkills();
+  };
+
+  const handleUpdateSources = () => {
+    const results: UpdateResult[] = [];
+    for (const source of state.skillSetSources) {
+      try {
+        pullSource(source.url);
+        results.push({ url: source.url, ok: true });
+      } catch (e) {
+        results.push({
+          url: source.url,
+          ok: false,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+    setUpdateResults(results);
+    refreshDiscovered();
+  };
+
+  // +2 for "Update Sources" and "Manage Sources" rows at the bottom.
+  const actionRows = 2;
+  const itemCount = discovered.length + actionRows;
   const { cursor, handleUp, handleDown } = useListNavigation(itemCount);
 
   const isEnabled = (set: DiscoveredSkillSet) =>
@@ -75,6 +118,9 @@ export function SkillSetsManager({
     }
   };
 
+  const isOnUpdateSources = cursor === discovered.length;
+  const isOnManageSources = cursor === discovered.length + 1;
+
   useInput(
     (input, key) => {
       if (step !== "list") return;
@@ -84,14 +130,14 @@ export function SkillSetsManager({
         return;
       }
 
-      const isOnManageSources = cursor === discovered.length;
-
       if (key.upArrow) {
         handleUp();
       } else if (key.downArrow) {
         handleDown();
-      } else if (input === " " && !isOnManageSources) {
+      } else if (input === " " && !isOnUpdateSources && !isOnManageSources) {
         toggleSet(discovered[cursor]);
+      } else if (key.return && isOnUpdateSources) {
+        handleUpdateSources();
       } else if (key.return && isOnManageSources) {
         setStep("sources");
       }
@@ -164,15 +210,24 @@ export function SkillSetsManager({
         );
       })}
       <Text>{""}</Text>
-      {(() => {
-        const isCurrent = cursor === discovered.length;
-        return (
-          <Text color={isCurrent ? "cyan" : "dim"}>
-            {"    "}
-            {isCurrent ? "❯" : " "} Manage Sources...
-          </Text>
-        );
-      })()}
+      <Text color={isOnUpdateSources ? "cyan" : "dim"}>
+        {"    "}
+        {isOnUpdateSources ? "❯" : " "} Update Sources...
+      </Text>
+      <Text color={isOnManageSources ? "cyan" : "dim"}>
+        {"    "}
+        {isOnManageSources ? "❯" : " "} Manage Sources...
+      </Text>
+      {updateResults && (
+        <Box flexDirection="column" marginTop={1}>
+          {updateResults.map((r) => (
+            <Text key={r.url} color={r.ok ? "green" : "red"}>
+              {"    "}
+              {r.ok ? "✔" : "✗"} {r.url}
+            </Text>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

Adds an "Update Sources..." action to the Skill Sets settings menu that pulls latest changes from all cloned source repos and immediately reloads skills.

## GitHub Issue

Closes #221

## What Changed

Added an "Update Sources..." row to the `SkillSetsManager` component alongside the existing "Manage Sources..." row. On Enter, it runs `pullSource` on each configured source and displays per-source success (✔) or failure (✗) results inline. After updating, it re-discovers skill sets and reloads the skills registry so changes take effect immediately.