### PR TITLE
fix(skill-sets): clean up cached repo and enabled sets on source delete

### DIFF
--- a/src/components/skill-set-sources-editor.test.tsx
+++ b/src/components/skill-set-sources-editor.test.tsx
@@ -1,7 +1,15 @@
 import { render } from "ink-testing-library";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SettingsState } from "./settings-selector";
 import { SkillSetSourcesEditor } from "./skill-set-sources-editor";
+
+vi.mock("../skill-sets/sources", () => ({
+  removeSource: vi.fn(),
+}));
+
+import { removeSource } from "../skill-sets/sources";
+
+const mockRemoveSource = vi.mocked(removeSource);
 
 const flush = () => new Promise((r) => setTimeout(r, 50));
 
@@ -35,6 +43,10 @@ function renderEditor(overrides?: {
 }
 
 describe("SkillSetSourcesEditor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("shows sources and Add option", () => {
     const { lastFrame } = renderEditor();
     const output = lastFrame() ?? "";
@@ -43,15 +55,29 @@ describe("SkillSetSourcesEditor", () => {
     expect(output).toContain("Add...");
   });
 
-  it("deletes source with d", async () => {
+  it("deletes source with d, removes cached repo, and cleans enabled sets", async () => {
     const onUpdate = vi.fn();
-    const { stdin } = renderEditor({ onUpdate });
+    const { stdin } = renderEditor({
+      state: {
+        enabledSkillSets: [
+          { sourceUrl: "https://github.com/org/skills-a.git", name: "dev" },
+          { sourceUrl: "https://github.com/org/skills-b.git", name: "ops" },
+        ],
+      },
+      onUpdate,
+    });
 
     stdin.write("d");
     await flush();
 
+    expect(mockRemoveSource).toHaveBeenCalledWith(
+      "https://github.com/org/skills-a.git",
+    );
     expect(onUpdate).toHaveBeenCalledWith({
       skillSetSources: [{ url: "https://github.com/org/skills-b.git" }],
+      enabledSkillSets: [
+        { sourceUrl: "https://github.com/org/skills-b.git", name: "ops" },
+      ],
     });
   });
 

--- a/src/components/skill-set-sources-editor.tsx
+++ b/src/components/skill-set-sources-editor.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useInput } from "ink";
 import { useState } from "react";
+import { removeSource } from "../skill-sets/sources";
 import { useListNavigation } from "../hooks/use-list-navigation";
 import { HintBar } from "./hint-bar";
 import type { SettingsState } from "./settings-selector";
@@ -57,8 +58,13 @@ export function SkillSetSourcesEditor({
     } else if (key.downArrow) {
       handleDown();
     } else if ((input === "d" || input === "D") && !isOnAdd) {
+      const deletedUrl = state.skillSetSources[cursor].url;
+      removeSource(deletedUrl);
       onUpdate({
         skillSetSources: state.skillSetSources.filter((_, i) => i !== cursor),
+        enabledSkillSets: state.enabledSkillSets.filter(
+          (s) => s.sourceUrl !== deletedUrl,
+        ),
       });
       if (cursor >= itemCount - 1) {
         setCursor((c) => Math.max(0, c - 1));

--- a/src/skill-sets/sources.test.ts
+++ b/src/skill-sets/sources.test.ts
@@ -1,8 +1,13 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { sourceSlug, findSkillSets } from "./sources";
+import {
+  sourceSlug,
+  findSkillSets,
+  removeSource,
+  sourceCacheDir,
+} from "./sources";
 
 describe("sourceSlug", () => {
   it("generates a stable slug for a git SSH URL", () => {
@@ -24,6 +29,32 @@ describe("sourceSlug", () => {
   it("generates same slug for same URL", () => {
     const url = "git@github.com:org/repo.git";
     expect(sourceSlug(url)).toBe(sourceSlug(url));
+  });
+});
+
+describe("removeSource", () => {
+  const testUrl = "git@github.com:org/test-remove.git";
+
+  afterEach(() => {
+    // Clean up in case test left the dir
+    const dir = join(sourceCacheDir(), sourceSlug(testUrl));
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes an existing cached directory", () => {
+    const dir = join(sourceCacheDir(), sourceSlug(testUrl));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "marker"), "test");
+
+    expect(existsSync(dir)).toBe(true);
+    removeSource(testUrl);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("does nothing for non-existent source", () => {
+    removeSource("git@github.com:nonexistent/repo.git");
   });
 });
 

--- a/src/skill-sets/sources.ts
+++ b/src/skill-sets/sources.ts
@@ -43,6 +43,14 @@ export function cloneSource(url: string): string {
   return dir;
 }
 
+/** Removes the cloned cache directory for a source. */
+export function removeSource(url: string): void {
+  const dir = join(sourceCacheDir(), sourceSlug(url));
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 /** Pulls latest changes for a cloned source. */
 export function pullSource(url: string): void {
   const dir = join(sourceCacheDir(), sourceSlug(url));


### PR DESCRIPTION
## Summary

When deleting a skill set source from Manage Sources, clean up the cloned repo from disk and remove any enabled skill sets belonging to that source from config.

## What Changed

Added `removeSource()` to delete the cached clone directory. The sources editor now calls it on delete and also filters out `enabledSkillSets` entries matching the deleted source URL. Unit tests added for `removeSource` and the editor's cleanup behaviour.