### PR TITLE
fix(grep): handle file paths without ENOTDIR error

### DIFF
--- a/src/tools/grep.test.ts
+++ b/src/tools/grep.test.ts
@@ -216,6 +216,33 @@ describe("grep tool", () => {
     expect(result).toBe("The user denied this search.");
   });
 
+  it("searches a single file when path points to a file", async () => {
+    setupGitRepo();
+    const tool = getTool("grep");
+    const filePath = resolve(tmpDir, "src/index.ts");
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "hello", path: filePath }),
+      mockContext,
+    );
+
+    expect(result).toContain("hello");
+    // Should not include results from other files
+    expect(result).not.toContain("utils.ts");
+    expect(result).not.toContain("app.tsx");
+  });
+
+  it("returns no matches for file path with no hits", async () => {
+    setupGitRepo();
+    const tool = getTool("grep");
+    const filePath = resolve(tmpDir, "src/index.ts");
+    const result = await tool?.execute(
+      JSON.stringify({ pattern: "nonexistent_xyz", path: filePath }),
+      mockContext,
+    );
+
+    expect(result).toBe("No matches found.");
+  });
+
   it("prompts for paths outside cwd even with permission granted", async () => {
     setupGitRepo();
     const tool = getTool("grep");

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
-import { resolve } from "node:path";
+import { statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { createElement } from "react";
 import { z } from "zod";
 import { FileAccessConfirm } from "../components/file-access-confirm";
@@ -62,13 +63,19 @@ Effective search patterns:
   async execute(args: string, context: ToolContext): Promise<string> {
     const parsed = parseToolArgs(argsSchema, args);
     const { pattern, include, gitignore } = parsed;
-    const searchDir = parsed.path ? resolve(parsed.path) : process.cwd();
+    const resolved = parsed.path ? resolve(parsed.path) : process.cwd();
+    const isFile = parsed.path
+      ? statSync(resolved, { throwIfNoEntry: false })?.isFile()
+      : false;
+    const searchDir = isFile ? dirname(resolved) : resolved;
+    const searchTarget = isFile ? resolved : undefined;
 
     return withFilePermission({
       context,
       permission: "read_file",
       filePath: searchDir,
-      execute: () => runGrep(pattern, searchDir, include, gitignore),
+      execute: () =>
+        runGrep(pattern, searchDir, include, gitignore, searchTarget),
       renderConfirm: () =>
         context.renderInteractive((onResult) =>
           createElement(FileAccessConfirm, {
@@ -88,12 +95,19 @@ function runGrep(
   cwd: string,
   include: string | undefined,
   gitignore: boolean,
+  file?: string,
 ): string {
   try {
     const useGit = gitignore && isGitRepo(cwd);
     let output: string;
 
-    if (useGit) {
+    if (file) {
+      // Search a single file directly.
+      output = execSync(
+        `grep -n -E ${JSON.stringify(pattern)} ${JSON.stringify(file)}`,
+        { cwd, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+      );
+    } else if (useGit) {
       // Auto-prepend **/ so bare globs like *.ts match in subdirectories
       const globInclude = include?.includes("/") ? include : `**/${include}`;
       const includeArgs = include


### PR DESCRIPTION
## Summary

Fix ENOTDIR error when the grep tool receives a file path instead of a directory path.

## What Changed

When `path` points to a file, the grep tool now uses the file's parent directory as `cwd` and greps the specific file directly. Previously it passed the file path as the working directory to `execSync`, causing `spawnSync /bin/sh ENOTDIR`.

Two tests added: searching a single file by path, and no-matches for a single file.