### PR TITLE
chore(context): strip ANSI codes from tool results sent to the LLM

### DIFF
--- a/src/completion-loop.test.ts
+++ b/src/completion-loop.test.ts
@@ -241,6 +241,33 @@ describe("runCompletionLoop", () => {
     });
   });
 
+  it("strips ANSI escape codes from tool results sent to the LLM", async () => {
+    const toolCall: ToolCall = {
+      id: "tc_1",
+      type: "function",
+      function: { name: "run_command", arguments: "{}" },
+    };
+
+    mockStream.mockResolvedValueOnce(mockCompletion([], [toolCall]));
+    mockStream.mockResolvedValueOnce(mockCompletion(["done"]));
+
+    mockExecuteTools.mockResolvedValueOnce([
+      {
+        id: "msg_1",
+        role: "tool",
+        content: "\x1b[1m\x1b[33mRun Command\x1b[39m\x1b[22m\nExit code: 0",
+        tool_call_id: "tc_1",
+      },
+    ]);
+
+    const result = await runCompletionLoop(baseOptions());
+
+    const toolMsg = result.messages.find((m) => m.role === "tool");
+    expect(toolMsg?.content).toBe("Run Command\nExit code: 0");
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: asserting ANSI codes are absent
+    expect(toolMsg?.content).not.toMatch(/\x1b/);
+  });
+
   it("propagates non-abort errors", async () => {
     mockStream.mockRejectedValueOnce(new Error("connection failed"));
 

--- a/src/completion-loop.ts
+++ b/src/completion-loop.ts
@@ -1,6 +1,7 @@
 import type { DisplayMessage } from "./components/message-list";
 import { truncateMessages } from "./context/truncate";
 import { executeToolCalls, ToolDismissedError } from "./hooks/tool-execution";
+import { stripAnsi } from "./strip-ansi";
 import type { McpManager } from "./mcp/manager";
 import type {
   ChatMessage,
@@ -188,7 +189,7 @@ export async function runCompletionLoop(
         if (dm.role !== "tool") continue;
         const toolMsg: ChatMessage = {
           role: "tool",
-          content: dm.content,
+          content: stripAnsi(dm.content),
           tool_call_id: dm.tool_call_id,
         };
         addMessage(toolMsg);

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -2,14 +2,7 @@ import chalk from "chalk";
 import { highlight } from "cli-highlight";
 import { Text } from "ink";
 import { Marked } from "marked";
-
-// biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape codes requires control characters
-const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
-
-/** Strips ANSI escape codes to get the visible character length. */
-function stripAnsi(str: string): string {
-  return str.replace(ANSI_REGEX, "");
-}
+import { stripAnsi } from "../strip-ansi";
 
 /** Pads a string to a visible width, accounting for ANSI codes. */
 function padEnd(str: string, width: number): string {

--- a/src/strip-ansi.test.ts
+++ b/src/strip-ansi.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { stripAnsi } from "./strip-ansi";
+
+describe("stripAnsi", () => {
+  it("removes ANSI color codes", () => {
+    expect(stripAnsi("\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("removes bold/dim codes", () => {
+    expect(stripAnsi("\x1b[1m\x1b[33mBold Yellow\x1b[39m\x1b[22m")).toBe(
+      "Bold Yellow",
+    );
+  });
+
+  it("returns plain strings unchanged", () => {
+    expect(stripAnsi("no codes here")).toBe("no codes here");
+  });
+
+  it("handles per-character coloring from biome", () => {
+    const biomeStyle = "\x1b[0m\x1b[0mP\x1b[0m\x1b[0mr\x1b[0m\x1b[0me\x1b[0m";
+    expect(stripAnsi(biomeStyle)).toBe("Pre");
+  });
+
+  it("handles empty string", () => {
+    expect(stripAnsi("")).toBe("");
+  });
+});

--- a/src/strip-ansi.ts
+++ b/src/strip-ansi.ts
@@ -1,0 +1,7 @@
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape codes requires control characters
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+
+/** Strips ANSI escape codes from a string. */
+export function stripAnsi(str: string): string {
+  return str.replace(ANSI_REGEX, "");
+}

--- a/src/tools/format-diff.test.ts
+++ b/src/tools/format-diff.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { stripAnsi } from "../strip-ansi";
 import { formatDiff, formatNewFile } from "./format-diff";
-
-// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
-const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;]*m/g, "");
 
 describe("formatNewFile", () => {
   it("formats all lines as additions", () => {


### PR DESCRIPTION

## Summary
This PR adds a utility function to strip ANSI escape codes from tool results before they are sent to the LLM, ensuring that the LLM receives clean text without formatting codes.

## GitHub Issue
Closes #234

## What Changed
- Created a new  utility function in  with corresponding tests in .
- Updated  to use  on tool message content before adding to the conversation.
- Removed the duplicate  function from  and imported the new utility.
- Updated  to use the new  utility.
- Added a test in  to verify that ANSI escape codes are stripped from tool results.

## Notes for Reviewers
- The  function uses a regular expression to remove ANSI escape codes (BIOS ignores this line due to the need for control characters in the regex).
- This change ensures that tool outputs with color/formatting codes (like those from  or Biome official CLI. Use it to check the health of your project or run it to check single files.

Usage: biome COMMAND ...

Available options:
    -h, --help     Prints help information
    -V, --version  Prints version information

Available commands:
    version        Shows the Biome version information and quit.
    rage           Prints information for debugging.
    start          Starts the Biome daemon server process.
    stop           Stops the Biome daemon server process.
    check          Runs formatter, linter and import sorting to the requested files.
    lint           Run various checks on a set of files.
    format         Run the formatter on a set of files.
    ci             Command to use in CI environments. Runs formatter, linter and import sorting to
                   the requested files.
    init           Bootstraps a new biome project. Creates a configuration file with some defaults.
    lsp-proxy      Acts as a server for the Language Server Protocol over stdin/stdout.
    migrate        Updates the configuration when there are breaking changes.
    search         EXPERIMENTAL: Searches for Grit patterns across a project.
    explain        Shows documentation of various aspects of the CLI.
    clean          Cleans the logs emitted by the daemon.) do not interfere with the LLM's processing.
