### PR TITLE
chore(tool): add universal tool result size limits and fix ANSI display

### DIFF
--- a/src/completion-loop.test.ts
+++ b/src/completion-loop.test.ts
@@ -268,6 +268,42 @@ describe("runCompletionLoop", () => {
     expect(toolMsg?.content).not.toMatch(/\x1b/);
   });
 
+  it("preserves ANSI in onMessage for display while stripping for API", async () => {
+    const toolCall: ToolCall = {
+      id: "tc_1",
+      type: "function",
+      function: { name: "run_command", arguments: "{}" },
+    };
+
+    mockStream.mockResolvedValueOnce(mockCompletion([], [toolCall]));
+    mockStream.mockResolvedValueOnce(mockCompletion(["done"]));
+
+    const ansiContent =
+      "\x1b[1m\x1b[33mRun Command\x1b[39m\x1b[22m\nExit code: 0";
+    mockExecuteTools.mockResolvedValueOnce([
+      {
+        id: "msg_1",
+        role: "tool",
+        content: ansiContent,
+        tool_call_id: "tc_1",
+      },
+    ]);
+
+    const onMessage = vi.fn();
+    const result = await runCompletionLoop(baseOptions({ onMessage }));
+
+    // onMessage should receive ANSI-rich content for display
+    const displayCall = onMessage.mock.calls.find(
+      (args) => args[0].role === "tool",
+    );
+    expect(displayCall).toBeDefined();
+    expect(displayCall?.[0].content).toBe(ansiContent);
+
+    // result.messages (API) should be stripped
+    const apiMsg = result.messages.find((m) => m.role === "tool");
+    expect(apiMsg?.content).toBe("Run Command\nExit code: 0");
+  });
+
   it("propagates non-abort errors", async () => {
     mockStream.mockRejectedValueOnce(new Error("connection failed"));
 

--- a/src/completion-loop.ts
+++ b/src/completion-loop.ts
@@ -187,12 +187,18 @@ export async function runCompletionLoop(
 
       for (const dm of toolResultDisplayMessages) {
         if (dm.role !== "tool") continue;
-        const toolMsg: ChatMessage = {
+        // API messages use ANSI-stripped content; display/session keeps rich content.
+        const apiMsg: ChatMessage = {
           role: "tool",
           content: stripAnsi(dm.content),
           tool_call_id: dm.tool_call_id,
         };
-        addMessage(toolMsg);
+        currentMessages = [...currentMessages, apiMsg];
+        onMessage?.({
+          role: "tool",
+          content: dm.content,
+          tool_call_id: dm.tool_call_id,
+        });
       }
 
       onContent?.("");

--- a/src/hooks/tool-execution.test.ts
+++ b/src/hooks/tool-execution.test.ts
@@ -4,6 +4,7 @@ import {
   executeToolCalls,
   formatToolHeader,
   ToolDismissedError,
+  truncateResult,
 } from "./tool-execution";
 
 vi.mock("../tools", () => ({
@@ -644,6 +645,52 @@ describe("executeToolCalls with mcpManager", () => {
     );
 
     expect(results[0].content).toContain("file contents");
+  });
+});
+
+describe("truncateResult", () => {
+  it("returns short results unchanged", () => {
+    const result = "short output";
+    expect(truncateResult(result)).toBe(result);
+  });
+
+  it("returns results at exactly the limit unchanged", () => {
+    const result = "x".repeat(30_000);
+    expect(truncateResult(result)).toBe(result);
+  });
+
+  it("truncates results exceeding the limit with head + tail", () => {
+    const result = "H".repeat(20_000) + "M".repeat(20_000) + "T".repeat(20_000);
+    const truncated = truncateResult(result);
+
+    expect(truncated.length).toBeLessThan(result.length);
+    expect(truncated).toMatch(/^H+/);
+    expect(truncated).toMatch(/T+$/);
+    expect(truncated).toContain("[output truncated");
+    expect(truncated).toContain("chars omitted]");
+  });
+
+  it("preserves the first 20,000 chars as head", () => {
+    const head = "A".repeat(20_000);
+    const rest = "B".repeat(40_000);
+    const truncated = truncateResult(head + rest);
+
+    expect(truncated.startsWith(head)).toBe(true);
+  });
+
+  it("preserves the last 10,000 chars as tail", () => {
+    const start = "A".repeat(40_000);
+    const tail = "Z".repeat(10_000);
+    const truncated = truncateResult(start + tail);
+
+    expect(truncated.endsWith(tail)).toBe(true);
+  });
+
+  it("reports correct number of omitted chars", () => {
+    const result = "x".repeat(60_000);
+    const truncated = truncateResult(result);
+    // 60,000 - 20,000 head - 10,000 tail = 30,000 omitted
+    expect(truncated).toContain("30,000 chars omitted");
   });
 });
 

--- a/src/hooks/tool-execution.ts
+++ b/src/hooks/tool-execution.ts
@@ -13,9 +13,26 @@ export class ToolDismissedError extends Error {
 
 const MAX_ARG_VALUE_LENGTH = 60;
 
+/**
+ * Maximum character length for a tool result. Results exceeding this are
+ * truncated to head + tail with an indicator in the middle.
+ */
+const MAX_RESULT_LENGTH = 30_000;
+const TRUNCATION_HEAD = 20_000;
+const TRUNCATION_TAIL = 10_000;
+
 /** Truncates a string to a max length with ellipsis. */
 function truncateValue(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+/** Truncates a tool result to head + tail with an indicator if it exceeds the max length. */
+export function truncateResult(result: string): string {
+  if (result.length <= MAX_RESULT_LENGTH) return result;
+  const omitted = result.length - TRUNCATION_HEAD - TRUNCATION_TAIL;
+  const head = result.slice(0, TRUNCATION_HEAD);
+  const tail = result.slice(-TRUNCATION_TAIL);
+  return `${head}\n\n[output truncated — ${omitted.toLocaleString()} chars omitted]\n\n${tail}`;
 }
 
 /** Formats a single arg value for display. */
@@ -90,7 +107,7 @@ async function executeSingleToolCall(
   return {
     id: crypto.randomUUID(),
     role: "tool",
-    content: `${header}\n${result}`,
+    content: `${header}\n${truncateResult(result)}`,
     tool_call_id: tc.id,
   };
 }

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { getCommand, parse } from "../commands";
 import { runCompletionLoop } from "../completion-loop";
 import type { DisplayMessage } from "../components/message-list";
+import { stripAnsi } from "../strip-ansi";
 import {
   type Config,
   getAllMcpServers,
@@ -76,7 +77,7 @@ function toChatMessages(
         if (m.role === "tool") {
           return {
             role: "tool",
-            content: m.content,
+            content: stripAnsi(m.content),
             tool_call_id: m.tool_call_id,
           };
         }


### PR DESCRIPTION
## Summary

This PR adds universal size limits for tool results to prevent excessively large outputs from overwhelming the LLM context, while preserving ANSI formatting for display purposes. It also ensures tool results sent to the LLM have ANSI escape codes stripped.

## GitHub Issue

Closes #235

## What Changed

- Added `truncateResult` function in `src/hooks/tool-execution.ts` that limits tool results to 30,000 characters (20k head + 10k tail) with an omission indicator.
- Updated `executeSingleToolCall` to apply truncation to tool results.
- Added comprehensive tests for `truncateResult` covering edge cases.
- Modified `runCompletionLoop` to retain ANSI-rich content for display via the `onMessage` callback while storing ANSI-stripped content in the message array for API consumption.
- Updated test in `completion-loop.test.ts` to verify ANSI preservation for display and stripping for API.
- Adjusted `use-chat.ts` to strip ANSI from tool messages when converting to chat messages for consistent display.

## Notes for Reviewers

- The truncation logic preserves the beginning and end of tool outputs, which are often most relevant for debugging.
- Display (via `onMessage`) retains original ANSI formatting for proper rendering in the UI.
- All existing tests pass; new tests cover the truncation and ANSI handling behavior.