### PR TITLE
chore(instructions): recommend single commands over compound in system prompt

### DIFF
--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -119,6 +119,13 @@ Do NOT use run_command for tasks that have dedicated tools. Dedicated tools are 
 
 Reserve run_command for operations that have no dedicated tool: running tests, builds, linters, git commands, and package managers.
 
+Prefer single commands over compound commands: Use separate \`run_command\` calls instead of chaining commands with \`&&\`, \`;\`, \`||\`, etc. Single commands are more likely to match allowed command patterns (like \`git:*\`) and run without user approval, whereas compound commands often require approval because they don't match predefined patterns. Single commands can also run in parallel when independent.
+
+Example: Instead of \`git status && git log --oneline -1\` (one compound command), use two separate calls:
+- \`git status\` 
+- \`git log --oneline -1\`
+These can run in parallel and each matches \`git:*\` in allowed commands.
+
 ### Parallel tool calls
 
 When you need to make multiple tool calls that are independent of each other, make them all in the same response. This runs them in parallel and is significantly faster.


### PR DESCRIPTION
## Summary

Update the system prompt tool usage guidance to recommend running single commands instead of compound commands (using &&, ;, etc.). Compound commands are more likely to require user approval because they don't match allowed command patterns, whereas single commands like `git status` match `git:*` and run without prompting.

## GitHub Issue

Closes #227

## What Changed

Added guidance in the "Use dedicated tools, not shell commands" section to prefer single `run_command` calls over compound commands. Explains that single commands are more likely to match allowed command patterns and run without user approval. Includes a concrete example showing two parallel `run_command` calls vs one compound command.

## Notes for Reviewers

The changes are limited to the tool usage guidance in src/instructions.ts. No functional changes to the codebase—only documentation updates to improve agent effectiveness.