### PR TITLE
fix(ask): allow text-only input without options

### DIFF
--- a/src/components/ask-selector.tsx
+++ b/src/components/ask-selector.tsx
@@ -11,7 +11,7 @@ interface AskSelectorProps {
 /** Interactive multiple-choice selector with a free-text input as the last option. */
 export function AskSelector({
   question,
-  options,
+  options = [],
   onSelect,
   onCancel,
 }: AskSelectorProps) {

--- a/src/tools/ask.test.ts
+++ b/src/tools/ask.test.ts
@@ -23,18 +23,19 @@ describe("ask tool", () => {
         options: {
           type: "array",
           items: { type: "string" },
-          description: "The available choices (2 or more)",
+          description: "The available choices (0 or more; omit to enable free-text input only)",
         },
       },
-      required: ["question", "options"],
+      required: ["question"],
     });
   });
 
-  it("throws when no options provided", async () => {
+  it("supports text-only input when no options provided", async () => {
     const tool = getTool("ask");
+    const renderFactory = vi.fn().mockResolvedValue("custom answer");
     const context = {
-      renderInteractive: vi.fn(),
       reportProgress: vi.fn(),
+      renderInteractive: renderFactory,
       permissions: {},
       signal: new AbortController().signal,
       depth: 0,
@@ -49,10 +50,13 @@ describe("ask tool", () => {
       allowedCommands: [],
     };
 
-    await expect(
-      tool?.execute(JSON.stringify({ question: "pick", options: [] }), context),
-    ).rejects.toThrow("no options provided");
-    expect(context.renderInteractive).not.toHaveBeenCalled();
+    const result = await tool?.execute(
+      JSON.stringify({ question: "What would you like to do?", options: [] }),
+      context,
+    );
+
+    expect(renderFactory).toHaveBeenCalledTimes(1);
+    expect(result).toBe("custom answer");
   });
 
   it("uses default question when none provided", async () => {

--- a/src/tools/ask.ts
+++ b/src/tools/ask.ts
@@ -6,7 +6,7 @@ import { parseToolArgs, type ToolContext } from "./types";
 
 const argsSchema = z.object({
   question: z.string().default("Please choose:"),
-  options: z.array(z.string()).min(1, "no options provided"),
+  options: z.array(z.string()).optional(),
 });
 
 registerTool({
@@ -17,7 +17,8 @@ registerTool({
 - Use sparingly — only when you genuinely need the user to choose between meaningfully different options.
 - Do not ask for confirmation on routine actions. Do not ask questions you can resolve by reading the codebase.
 - Provide clear, distinct options. The returned value is the exact option string the user selected.
-- A free-text input is always shown as the last option so the user can type a custom response instead of choosing a predefined option. Never include "Other", "Custom", or any free-text escape hatch in the options array — the tool provides this automatically.`,
+- A free-text input is always shown as the last option so the user can type a custom response instead of choosing a predefined option. Never include "Other", "Custom", or any free-text escape hatch in the options array — the tool provides this automatically.
+- To enable a plain text input without predefined options, omit the options array or pass an empty array. The tool will render a free-text input where the user can type responses freely.`,
   parameters: {
     type: "object",
     properties: {
@@ -28,10 +29,11 @@ registerTool({
       options: {
         type: "array",
         items: { type: "string" },
-        description: "The available choices (2 or more)",
+        description:
+          "The available choices (0 or more; omit to enable free-text input only)",
       },
     },
-    required: ["question", "options"],
+    required: ["question"],
   },
   async execute(args: string, context: ToolContext): Promise<string> {
     const { question, options } = parseToolArgs(argsSchema, args);
@@ -39,7 +41,7 @@ registerTool({
     return context.renderInteractive((onResult, onCancel) =>
       React.createElement(AskSelector, {
         question,
-        options,
+        options: options ?? [],
         onSelect: onResult,
         onCancel,
       }),


### PR DESCRIPTION
## Summary

Allow the ask tool to accept 0 options, enabling plain text-only input without predefined choices.

## GitHub Issue

Closes #228

## What Changed

- Updated Zod schema validation to allow `options` to be optional (previously required at least 1 option)
- Updated tool description to document how to enable plain text input mode
- Updated parameter schema to reflect that options can be omitted (0 or more)
- Added default value `options = []` to AskSelector component to handle undefined options
- Updated tests to verify new text-only input behavior instead of testing the error case

This change unblocks existing UI capabilities that already supported rendering the ask selector with an empty options array for free-text input.
