### PR TITLE
fix(ask): allow ask tool to accept 0 options for text-only input

### DIFF
--- a/src/components/ask-selector.test.tsx
+++ b/src/components/ask-selector.test.tsx
@@ -208,6 +208,55 @@ describe("AskSelector", () => {
     expect(onSelect).toHaveBeenCalledWith("B");
   });
 
+  it("renders as text-only input when no options are provided", async () => {
+    const onSelect = vi.fn();
+    const { stdin, lastFrame } = render(
+      <AskSelector
+        question="What is your name?"
+        options={[]}
+        onSelect={onSelect}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain("What is your name?");
+    // Cursor starts on text input (typing mode active), so the caret ❯ is shown
+    // rather than the placeholder — the placeholder only shows in non-typing mode.
+    expect(output).toContain("❯");
+
+    // Cursor starts on text input — typing works immediately
+    stdin.write("Alice");
+    await flush();
+    stdin.write("\r");
+    await flush();
+
+    expect(onSelect).toHaveBeenCalledWith("Alice");
+  });
+
+  it("up arrow in text-only mode does nothing (no options to navigate to)", async () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <AskSelector
+        question="What is your name?"
+        options={[]}
+        onSelect={onSelect}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Cursor already on text input — up arrow should not crash or move elsewhere
+    stdin.write("\x1B[A");
+    await flush();
+
+    stdin.write("Bob");
+    await flush();
+    stdin.write("\r");
+    await flush();
+
+    expect(onSelect).toHaveBeenCalledWith("Bob");
+  });
+
   it("preserves typed text when navigating away and back", async () => {
     const { stdin, lastFrame } = render(
       <AskSelector

--- a/src/components/ask-selector.tsx
+++ b/src/components/ask-selector.tsx
@@ -17,7 +17,9 @@ export function AskSelector({
 }: AskSelectorProps) {
   const textInputIndex = options.length;
   const totalItems = options.length + 1;
-  const [cursor, setCursor] = useState(0);
+  const [cursor, setCursor] = useState(
+    options.length === 0 ? textInputIndex : 0,
+  );
   const [customValue, setCustomValue] = useState("");
 
   // Typing mode is active when the cursor is on the text input row.
@@ -45,7 +47,9 @@ export function AskSelector({
         return;
       }
       if (key.upArrow) {
-        setCursor(textInputIndex - 1);
+        if (options.length > 0) {
+          setCursor(textInputIndex - 1);
+        }
         return;
       }
       if (input && !key.ctrl && !key.meta) {

--- a/src/tools/ask.test.ts
+++ b/src/tools/ask.test.ts
@@ -23,17 +23,18 @@ describe("ask tool", () => {
         options: {
           type: "array",
           items: { type: "string" },
-          description: "The available choices (2 or more)",
+          description:
+            "The available choices. Omit or pass an empty array for a plain text input with no predefined choices.",
         },
       },
-      required: ["question", "options"],
+      required: ["question"],
     });
   });
 
-  it("throws when no options provided", async () => {
+  it("accepts 0 options and renders text-only input", async () => {
     const tool = getTool("ask");
     const context = {
-      renderInteractive: vi.fn(),
+      renderInteractive: vi.fn().mockResolvedValue("typed answer"),
       reportProgress: vi.fn(),
       permissions: {},
       signal: new AbortController().signal,
@@ -49,10 +50,13 @@ describe("ask tool", () => {
       allowedCommands: [],
     };
 
-    await expect(
-      tool?.execute(JSON.stringify({ question: "pick", options: [] }), context),
-    ).rejects.toThrow("no options provided");
-    expect(context.renderInteractive).not.toHaveBeenCalled();
+    const result = await tool?.execute(
+      JSON.stringify({ question: "What is your name?", options: [] }),
+      context,
+    );
+
+    expect(context.renderInteractive).toHaveBeenCalledTimes(1);
+    expect(result).toBe("typed answer");
   });
 
   it("uses default question when none provided", async () => {

--- a/src/tools/ask.ts
+++ b/src/tools/ask.ts
@@ -6,7 +6,7 @@ import { parseToolArgs, type ToolContext } from "./types";
 
 const argsSchema = z.object({
   question: z.string().default("Please choose:"),
-  options: z.array(z.string()).min(1, "no options provided"),
+  options: z.array(z.string()).default([]),
 });
 
 registerTool({
@@ -17,7 +17,8 @@ registerTool({
 - Use sparingly — only when you genuinely need the user to choose between meaningfully different options.
 - Do not ask for confirmation on routine actions. Do not ask questions you can resolve by reading the codebase.
 - Provide clear, distinct options. The returned value is the exact option string the user selected.
-- A free-text input is always shown as the last option so the user can type a custom response instead of choosing a predefined option. Never include "Other", "Custom", or any free-text escape hatch in the options array — the tool provides this automatically.`,
+- A free-text input is always shown as the last option so the user can type a custom response instead of choosing a predefined option. Never include "Other", "Custom", or any free-text escape hatch in the options array — the tool provides this automatically.
+- Omitting options (or passing an empty array) renders a plain text input with no predefined choices — use this when you need a free-form answer.`,
   parameters: {
     type: "object",
     properties: {
@@ -28,10 +29,11 @@ registerTool({
       options: {
         type: "array",
         items: { type: "string" },
-        description: "The available choices (2 or more)",
+        description:
+          "The available choices. Omit or pass an empty array for a plain text input with no predefined choices.",
       },
     },
-    required: ["question", "options"],
+    required: ["question"],
   },
   async execute(args: string, context: ToolContext): Promise<string> {
     const { question, options } = parseToolArgs(argsSchema, args);


### PR DESCRIPTION
## Summary

The `ask` tool previously rejected an empty `options` array with a validation error. This PR removes that restriction so the tool can be called with no options, rendering a plain free-text prompt with no predefined choices.

## GitHub Issue

Closes #228

## What Changed

- **Validation:** The `options` Zod schema constraint was changed from `.min(1)` to `.default([])`, making the field optional and accepting an empty array without error.
- **Component behaviour:** When `options` is empty, `AskSelector` now initialises the cursor directly on the text input row, so typing is immediately active — no navigation required.
- **Up-arrow guard:** In typing mode, the up-arrow key now only moves the cursor back to option rows when options actually exist; pressing it with zero options is a no-op, preventing a cursor index of `-1`.
- **Tool description & schema:** The tool description and JSON Schema parameter description both now document that omitting `options` (or passing `[]`) produces a plain text prompt. `options` has also been removed from the `required` array since it now has a default.
- **Tests:** The old "throws when no options provided" test has been replaced with a positive acceptance test. Two new `AskSelector` component tests cover the zero-options rendering and the up-arrow no-op behaviour.