### PR TITLE
fix: cap ask question length and shimmer only the tool name

### DIFF
--- a/src/chat/chat.test.tsx
+++ b/src/chat/chat.test.tsx
@@ -1368,6 +1368,96 @@ describe("Chat", () => {
       expect(lastFrame()).not.toContain("streaming output");
     });
 
+    it("renders the tool summary alongside the display name in the live tool view", async () => {
+      let requestCount = 0;
+
+      mswServer.use(
+        http.post("http://localhost:11434/v1/chat/completions", async () => {
+          requestCount++;
+          if (requestCount === 1) {
+            return new HttpResponse(
+              sseBody([
+                {
+                  choices: [
+                    {
+                      delta: {
+                        tool_calls: [
+                          {
+                            index: 0,
+                            id: "call_summary",
+                            function: {
+                              name: "summary_tool",
+                              arguments: '{"path":"/tmp/file.txt"}',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ]),
+              { headers: { "Content-Type": "text/event-stream" } },
+            );
+          }
+          return new HttpResponse(
+            sseBody([{ choices: [{ delta: { content: "Done" } }] }]),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        }),
+      );
+
+      // Gate that holds tool execution open so we can inspect the live frame
+      let releaseTool: () => void = () => {};
+      const toolGate = new Promise<void>((resolve) => {
+        releaseTool = resolve;
+      });
+
+      const toolRegistry = createToolRegistry();
+      toolRegistry.register({
+        name: "summary_tool",
+        displayName: "Summary Tool",
+        description: "A tool with a non-empty formatCall summary",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+        argsSchema: z.object({ path: z.string() }),
+        formatCall: (args) => String(args.path),
+        async execute() {
+          await toolGate;
+          return ok("done");
+        },
+      });
+
+      setColumns(COLUMNS);
+      const { stdin, lastFrame } = renderInk(
+        <Chat skillRegistry={emptySkillRegistry} toolRegistry={toolRegistry} />,
+        {
+          global: {
+            providers: [PROVIDER],
+            activeProvider: PROVIDER.name,
+            activeModel: "llama3",
+          },
+        },
+      );
+
+      await stdin.write("run summary tool");
+      await stdin.write(keys.enter);
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Tool is still executing — both displayName and summary should be
+      // visible in the live tool view (the truthy summary branch).
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("Summary Tool");
+      expect(frame).toContain("/tmp/file.txt");
+
+      releaseTool();
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(requestCount).toBe(2);
+    });
+
     it("shows ask prompt and returns user answer", async () => {
       let requestCount = 0;
 

--- a/src/chat/chat.tsx
+++ b/src/chat/chat.tsx
@@ -1,4 +1,4 @@
-import { Box } from "ink";
+import { Box, Text } from "ink";
 import {
   useCallback,
   useEffect,
@@ -616,10 +616,8 @@ export function Chat(props: ChatProps) {
         return (
           <Box key={tc.id} flexDirection="column">
             <Indent>
-              <LoadingIndicator
-                text={[tc.displayName, tc.summary].filter(Boolean).join(" ")}
-                color={theme.tool}
-              />
+              <LoadingIndicator text={tc.displayName} color={theme.tool} />
+              {tc.summary ? <Text dimColor> {tc.summary}</Text> : null}
             </Indent>
             {output !== undefined && <LiveToolOutput output={output} />}
           </Box>

--- a/src/tools/ask.test.ts
+++ b/src/tools/ask.test.ts
@@ -93,7 +93,7 @@ describe("askTool", () => {
       ).rejects.toThrow(/single line/);
     });
 
-    it("accepts an option label at the 80 character boundary", async () => {
+    it("accepts an option label at the 80 character hard limit", async () => {
       const ask = vi.fn(async () => "x".repeat(80));
       await expect(
         askTool.execute(
@@ -103,13 +103,15 @@ describe("askTool", () => {
       ).resolves.toMatchObject({ status: "ok" });
     });
 
-    it("rejects an option label longer than 80 characters", async () => {
+    it("rejects an option label longer than the 80 character hard limit", async () => {
+      // Error references the soft target (60) shown to the LLM, even though
+      // the hard validator limit is 80.
       await expect(
         askTool.execute(
           { question: "Pick one", options: ["x".repeat(81)] },
           mockToolContext({}),
         ),
-      ).rejects.toThrow(/80 characters/);
+      ).rejects.toThrow(/60 characters/);
     });
   });
 });

--- a/src/tools/ask.test.ts
+++ b/src/tools/ask.test.ts
@@ -55,4 +55,61 @@ describe("askTool", () => {
       expect(result.output).toContain("dismissed");
     });
   });
+
+  describe("validation", () => {
+    it("accepts a question at the 200 character hard limit", async () => {
+      const ask = vi.fn(async () => "ok");
+      await expect(
+        askTool.execute(
+          { question: "x".repeat(200) },
+          mockToolContext({ ask }),
+        ),
+      ).resolves.toMatchObject({ status: "ok" });
+    });
+
+    it("rejects a question longer than the 200 character hard limit", async () => {
+      // Error references the soft target (175) shown to the LLM, even though
+      // the hard validator limit is 200.
+      await expect(
+        askTool.execute({ question: "x".repeat(201) }, mockToolContext({})),
+      ).rejects.toThrow(/175 characters/);
+    });
+
+    it("rejects a question containing a newline", async () => {
+      await expect(
+        askTool.execute(
+          { question: "line one\nline two" },
+          mockToolContext({}),
+        ),
+      ).rejects.toThrow(/single line/);
+    });
+
+    it("rejects a question containing a carriage return", async () => {
+      await expect(
+        askTool.execute(
+          { question: "line one\rline two" },
+          mockToolContext({}),
+        ),
+      ).rejects.toThrow(/single line/);
+    });
+
+    it("accepts an option label at the 80 character boundary", async () => {
+      const ask = vi.fn(async () => "x".repeat(80));
+      await expect(
+        askTool.execute(
+          { question: "Pick one", options: ["x".repeat(80)] },
+          mockToolContext({ ask }),
+        ),
+      ).resolves.toMatchObject({ status: "ok" });
+    });
+
+    it("rejects an option label longer than 80 characters", async () => {
+      await expect(
+        askTool.execute(
+          { question: "Pick one", options: ["x".repeat(81)] },
+          mockToolContext({}),
+        ),
+      ).rejects.toThrow(/80 characters/);
+    });
+  });
 });

--- a/src/tools/ask.ts
+++ b/src/tools/ask.ts
@@ -2,21 +2,65 @@ import { z } from "zod";
 import type { Tool, ToolContext, ToolResult } from "./types";
 import { err, ok } from "./types";
 
+// LLMs are imprecise at counting characters, so we tell the model the limit
+// is 175 (in the tool description, JSON schema, and rejection error message)
+// but accept up to 200 in the zod validator. The 25-char buffer prevents
+// spurious rejections when the model lands slightly over its target while
+// still keeping prompts tight in practice. This discrepancy is intentional.
+/** Soft target shown to the LLM in the description, schema, and errors. */
+const QUESTION_SOFT_LIMIT = 175;
+/** Hard limit enforced by the zod validator. */
+const QUESTION_HARD_LIMIT = 200;
+/** Maximum length of each option label. */
+const OPTION_MAX_LENGTH = 80;
+
 /** Zod schema for ask arguments. */
 const argsSchema = z.object({
-  question: z.string().min(1, "question must not be empty"),
-  options: z.array(z.string()).optional(),
+  question: z
+    .string()
+    .min(1, "question must not be empty")
+    .max(
+      QUESTION_HARD_LIMIT,
+      `question must be ${QUESTION_SOFT_LIMIT} characters or fewer. Show long content in your assistant message first, then call ask with a short decision question.`,
+    )
+    .refine(
+      (s) => !/[\n\r]/.test(s),
+      "question must be a single line — newlines are not allowed. Show multi-line content in your assistant message and call ask with a short decision question.",
+    ),
+  options: z
+    .array(
+      z
+        .string()
+        .max(
+          OPTION_MAX_LENGTH,
+          `option labels must be ${OPTION_MAX_LENGTH} characters or fewer.`,
+        ),
+    )
+    .optional(),
 });
 
 /** The ask tool definition. */
 export const askTool: Tool = {
   name: "ask",
   displayName: "Ask",
-  description: `Present the user with a question and return their response.
+  description: `Present the user with a single short decision question and return their response.
 
 Two modes:
 1. **With options** — pass an array of choices. The user picks one from the list, or presses tab to type a free-text response instead.
 2. **Without options** — omit the options array entirely. The user types a free-form answer. Use this for open-ended questions.
+
+Length & format:
+- The question must be a single line, no newlines, max ${QUESTION_SOFT_LIMIT} characters.
+- Each option label must be max ${OPTION_MAX_LENGTH} characters.
+
+If you need to show a draft, code snippet, summary, or other long content for approval, write it as your normal assistant message first, then call this tool with a brief question. Do NOT stuff the content into the question itself — the prompt is rendered in a small bordered panel and long content makes it unreadable.
+
+Good:
+  [assistant message containing the draft]
+  ask({ question: "Send this draft?", options: ["Send", "Edit", "Cancel"] })
+
+Bad:
+  ask({ question: "Send the following draft...\\n\\nSubject: ...\\n\\nBody: ..." })
 
 Guidelines:
 - Use sparingly — only when you genuinely need user input to proceed.
@@ -28,11 +72,13 @@ Guidelines:
     properties: {
       question: {
         type: "string",
-        description: "The question to ask the user",
+        description:
+          "The question to ask the user. Must be a single short line, no newlines.",
+        maxLength: QUESTION_SOFT_LIMIT,
       },
       options: {
         type: "array",
-        items: { type: "string" },
+        items: { type: "string", maxLength: OPTION_MAX_LENGTH },
         description:
           "Predefined choices. Omit entirely for a free-text-only input.",
       },

--- a/src/tools/ask.ts
+++ b/src/tools/ask.ts
@@ -2,17 +2,23 @@ import { z } from "zod";
 import type { Tool, ToolContext, ToolResult } from "./types";
 import { err, ok } from "./types";
 
-// LLMs are imprecise at counting characters, so we tell the model the limit
-// is 175 (in the tool description, JSON schema, and rejection error message)
-// but accept up to 200 in the zod validator. The 25-char buffer prevents
-// spurious rejections when the model lands slightly over its target while
-// still keeping prompts tight in practice. This discrepancy is intentional.
-/** Soft target shown to the LLM in the description, schema, and errors. */
+// LLMs are imprecise at counting characters, so each length cap has a soft
+// target (shown to the model in the description, JSON schema, and rejection
+// error messages) and a larger hard limit enforced by the zod validator. The
+// gap prevents spurious rejections when the model lands slightly over its
+// target while still keeping prompts tight in practice. The option soft
+// target is pulled lower than necessary on purpose: option labels render in
+// the SelectList and stop being scannable past ~60 chars, so the soft target
+// nudges the model toward compact, choice-like labels rather than sentences.
+// This discrepancy is intentional.
+/** Soft target for the question shown to the LLM. */
 const QUESTION_SOFT_LIMIT = 175;
-/** Hard limit enforced by the zod validator. */
+/** Hard limit for the question enforced by the zod validator. */
 const QUESTION_HARD_LIMIT = 200;
-/** Maximum length of each option label. */
-const OPTION_MAX_LENGTH = 80;
+/** Soft target for option labels shown to the LLM. */
+const OPTION_SOFT_LIMIT = 60;
+/** Hard limit for option labels enforced by the zod validator. */
+const OPTION_HARD_LIMIT = 80;
 
 /** Zod schema for ask arguments. */
 const argsSchema = z.object({
@@ -32,8 +38,8 @@ const argsSchema = z.object({
       z
         .string()
         .max(
-          OPTION_MAX_LENGTH,
-          `option labels must be ${OPTION_MAX_LENGTH} characters or fewer.`,
+          OPTION_HARD_LIMIT,
+          `option labels must be ${OPTION_SOFT_LIMIT} characters or fewer.`,
         ),
     )
     .optional(),
@@ -51,7 +57,7 @@ Two modes:
 
 Length & format:
 - The question must be a single line, no newlines, max ${QUESTION_SOFT_LIMIT} characters.
-- Each option label must be max ${OPTION_MAX_LENGTH} characters.
+- Each option label must be max ${OPTION_SOFT_LIMIT} characters.
 
 If you need to show a draft, code snippet, summary, or other long content for approval, write it as your normal assistant message first, then call this tool with a brief question. Do NOT stuff the content into the question itself — the prompt is rendered in a small bordered panel and long content makes it unreadable.
 
@@ -78,7 +84,7 @@ Guidelines:
       },
       options: {
         type: "array",
-        items: { type: "string", maxLength: OPTION_MAX_LENGTH },
+        items: { type: "string", maxLength: OPTION_SOFT_LIMIT },
         description:
           "Predefined choices. Omit entirely for a free-text-only input.",
       },


### PR DESCRIPTION
## Summary

Two related fixes that keep the live tool view from blowing up the
dynamic region of the chat. Long ask questions overflowed the bordered
panel and pushed everything off-screen, and the live tool indicator was
shimmering the entire `displayName + summary` blob in tool yellow rather
than just the tool name.

## GitHub Issue

N/A

## What Changed

**`fix(ask)`** — `src/tools/ask.ts`

The ask tool now rejects multi-line questions and caps the question
length. Tells the model the limit is **175 characters** (in the tool
description, JSON schema `maxLength`, and rejection error message), but
the zod validator accepts up to **200**. The 25-char buffer is
intentional: LLMs are imprecise at counting characters, so a strict
175-char hard limit would produce spurious rejections every time the
model lands a few chars over its target. Option labels are also capped
at 80 chars.

The tool description was rewritten with a `Length & format` section and
a good/bad example pair so the model knows to render long content
(drafts, snippets, summaries) in its assistant message and call ask
only with a short decision question.

**`fix(chat)`** — `src/chat/chat.tsx`

The live tool call view was passing `[displayName, summary].join(" ")`
to `LoadingIndicator`, which shimmered the entire string in tool
yellow. For tools with long summaries (e.g. ask with a verbose
question, agent with a long prompt) this filled the dynamic region with
shimmering text. Now only `displayName` runs through `LoadingIndicator`
and the summary renders alongside as static dim text — mirroring the
static `ToolCallMessageView` pattern in `chat-list.tsx`.

## Notes for Reviewers

- The 175 / 200 split in `ask.ts` is deliberate and documented in a
  comment above the constants. Don't "tidy" them into a single value.
- Visual de-duplication of the ask question (it still renders both in
  chat history and inside the bordered ask panel) was considered and
  intentionally left out — the duplication helps identify which prompt
  is currently active.
- The selection-clobber / scroll-snap problem during long agent runs is
  not fixed here, but should be much less painful in practice now that
  the dynamic region stays small.