### PR TITLE
feat(tools): support batched edits with optional replaceAll in edit_file

### DIFF
--- a/src/prompt/build-system-prompt.ts
+++ b/src/prompt/build-system-prompt.ts
@@ -22,11 +22,11 @@ If you make independent tool calls across separate responses, you are doing it w
 You MUST read a file with read_file before editing or overwriting it. Do not guess file contents from memory. Do not assume you know what a file contains. Read it first, then modify it.
 
 WRONG — editing without reading:
-[tool call: edit_file path="src/foo.ts" oldString="..." newString="..."]
+[tool call: edit_file path="src/foo.ts" edits=[{oldString: "...", newString: "..."}]]
 
 CORRECT — read first, then edit:
 Response 1: [tool call: read_file path="src/foo.ts"]
-Response 2: [tool call: edit_file path="src/foo.ts" oldString="..." newString="..."]
+Response 2: [tool call: edit_file path="src/foo.ts" edits=[{oldString: "...", newString: "..."}]]
 
 # CRITICAL: Use Dedicated Tools, Not Shell Commands
 

--- a/src/tools/edit-file.test.ts
+++ b/src/tools/edit-file.test.ts
@@ -12,8 +12,26 @@ describe("editFileTool", () => {
   });
 
   describe("formatCall", () => {
-    it("returns the path argument", () => {
-      expect(editFileTool.formatCall({ path: "./baz.ts" })).toBe("./baz.ts");
+    it("returns the path argument when there is a single edit", () => {
+      expect(
+        editFileTool.formatCall({
+          path: "./baz.ts",
+          edits: [{ oldString: "a", newString: "b" }],
+        }),
+      ).toBe("./baz.ts");
+    });
+
+    it("appends the count when there are multiple edits", () => {
+      expect(
+        editFileTool.formatCall({
+          path: "./baz.ts",
+          edits: [
+            { oldString: "a", newString: "b" },
+            { oldString: "c", newString: "d" },
+            { oldString: "e", newString: "f" },
+          ],
+        }),
+      ).toBe("./baz.ts (3 edits)");
     });
 
     it("returns empty string when path is missing", () => {
@@ -33,7 +51,10 @@ describe("editFileTool", () => {
       fs = mockFs({ [filePath]: "hello world\n" });
 
       const result = await editFileTool.execute(
-        { path: "test.txt", oldString: "world", newString: "earth" },
+        {
+          path: "test.txt",
+          edits: [{ oldString: "world", newString: "earth" }],
+        },
         mockToolContext(),
       );
 
@@ -51,8 +72,12 @@ describe("editFileTool", () => {
       const result = await editFileTool.execute(
         {
           path: "multi.txt",
-          oldString: "line two\nline three",
-          newString: "replaced",
+          edits: [
+            {
+              oldString: "line two\nline three",
+              newString: "replaced",
+            },
+          ],
         },
         mockToolContext(),
       );
@@ -61,30 +86,109 @@ describe("editFileTool", () => {
       expect(fs.getFile(filePath)).toBe("line one\nreplaced\n");
     });
 
+    it("applies multiple edits sequentially in order", async () => {
+      const filePath = resolve("seq.txt");
+      fs = mockFs({ [filePath]: "alpha beta gamma\n" });
+
+      const result = await editFileTool.execute(
+        {
+          path: "seq.txt",
+          edits: [
+            { oldString: "alpha", newString: "one" },
+            { oldString: "beta", newString: "two" },
+            { oldString: "gamma", newString: "three" },
+          ],
+        },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("ok");
+      expect(fs.getFile(filePath)).toBe("one two three\n");
+    });
+
+    it("applies edits to the result of previous edits, not the original", async () => {
+      const filePath = resolve("chain.txt");
+      fs = mockFs({ [filePath]: "foo\n" });
+
+      const result = await editFileTool.execute(
+        {
+          path: "chain.txt",
+          edits: [
+            { oldString: "foo", newString: "bar" },
+            { oldString: "bar", newString: "baz" },
+          ],
+        },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("ok");
+      expect(fs.getFile(filePath)).toBe("baz\n");
+    });
+
+    it("replaces every occurrence when replaceAll is true", async () => {
+      const filePath = resolve("rename.txt");
+      fs = mockFs({ [filePath]: "foo foo foo\n" });
+
+      const result = await editFileTool.execute(
+        {
+          path: "rename.txt",
+          edits: [{ oldString: "foo", newString: "bar", replaceAll: true }],
+        },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("ok");
+      expect(fs.getFile(filePath)).toBe("bar bar bar\n");
+    });
+
+    it("succeeds with replaceAll true even when only one occurrence exists", async () => {
+      const filePath = resolve("single.txt");
+      fs = mockFs({ [filePath]: "hello world\n" });
+
+      const result = await editFileTool.execute(
+        {
+          path: "single.txt",
+          edits: [{ oldString: "world", newString: "earth", replaceAll: true }],
+        },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("ok");
+      expect(fs.getFile(filePath)).toBe("hello earth\n");
+    });
+
     it("returns error when oldString is not found", async () => {
       const filePath = resolve("test.txt");
       fs = mockFs({ [filePath]: "hello world\n" });
 
       const result = await editFileTool.execute(
-        { path: "test.txt", oldString: "missing", newString: "new" },
+        {
+          path: "test.txt",
+          edits: [{ oldString: "missing", newString: "new" }],
+        },
         mockToolContext(),
       );
 
       expect(result.status).toBe("error");
       expect(result.output).toContain("not found in file");
+      expect(result.output).toContain("edit 1");
     });
 
-    it("returns error when oldString appears multiple times", async () => {
+    it("returns error when oldString appears multiple times without replaceAll", async () => {
       const filePath = resolve("test.txt");
       fs = mockFs({ [filePath]: "foo bar foo\n" });
 
       const result = await editFileTool.execute(
-        { path: "test.txt", oldString: "foo", newString: "baz" },
+        {
+          path: "test.txt",
+          edits: [{ oldString: "foo", newString: "baz" }],
+        },
         mockToolContext(),
       );
 
       expect(result.status).toBe("error");
       expect(result.output).toContain("2 times");
+      expect(result.output).toContain("replaceAll");
     });
 
     it("returns error when oldString and newString are identical", async () => {
@@ -92,7 +196,10 @@ describe("editFileTool", () => {
       fs = mockFs({ [filePath]: "hello\n" });
 
       const result = await editFileTool.execute(
-        { path: "test.txt", oldString: "hello", newString: "hello" },
+        {
+          path: "test.txt",
+          edits: [{ oldString: "hello", newString: "hello" }],
+        },
         mockToolContext(),
       );
 
@@ -100,11 +207,57 @@ describe("editFileTool", () => {
       expect(result.output).toContain("identical");
     });
 
+    it("fails atomically and does not modify the file when one edit in the batch fails", async () => {
+      const filePath = resolve("atomic.txt");
+      fs = mockFs({ [filePath]: "alpha beta\n" });
+
+      const result = await editFileTool.execute(
+        {
+          path: "atomic.txt",
+          edits: [
+            { oldString: "alpha", newString: "one" },
+            { oldString: "missing", newString: "x" },
+            { oldString: "beta", newString: "two" },
+          ],
+        },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("error");
+      expect(result.output).toContain("edit 2");
+      expect(result.output).toContain("not found");
+      expect(fs.getFile(filePath)).toBe("alpha beta\n");
+    });
+
+    it("identifies the failing edit by 1-based index", async () => {
+      const filePath = resolve("indexed.txt");
+      fs = mockFs({ [filePath]: "a b c\n" });
+
+      const result = await editFileTool.execute(
+        {
+          path: "indexed.txt",
+          edits: [
+            { oldString: "a", newString: "x" },
+            { oldString: "b", newString: "y" },
+            { oldString: "nope", newString: "z" },
+          ],
+        },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("error");
+      expect(result.output).toContain("edit 3");
+      expect(fs.getFile(filePath)).toBe("a b c\n");
+    });
+
     it("returns error for missing file", async () => {
       fs = mockFs();
 
       const result = await editFileTool.execute(
-        { path: "nope.txt", oldString: "a", newString: "b" },
+        {
+          path: "nope.txt",
+          edits: [{ oldString: "a", newString: "b" }],
+        },
         mockToolContext(),
       );
 
@@ -117,7 +270,10 @@ describe("editFileTool", () => {
       fs = mockFs({ [`${dirPath}/foo.ts`]: "content" });
 
       const result = await editFileTool.execute(
-        { path: "src", oldString: "a", newString: "b" },
+        {
+          path: "src",
+          edits: [{ oldString: "a", newString: "b" }],
+        },
         mockToolContext(),
       );
 
@@ -141,7 +297,10 @@ describe("editFileTool", () => {
         });
 
         const result = await editFileTool.execute(
-          { path: "allowed.txt", oldString: "old", newString: "new" },
+          {
+            path: "allowed.txt",
+            edits: [{ oldString: "old", newString: "new" }],
+          },
           ctx,
         );
 
@@ -149,9 +308,9 @@ describe("editFileTool", () => {
         expect(confirm).not.toHaveBeenCalled();
       });
 
-      it("prompts for confirmation with diff when write permission not granted", async () => {
+      it("prompts once with a combined diff when write permission not granted", async () => {
         const filePath = resolve("restricted.txt");
-        fs = mockFs({ [filePath]: "old content\n" });
+        fs = mockFs({ [filePath]: "alpha beta\n" });
         const confirm = vi.fn(async () => true);
         const ctx = mockToolContext({
           permissions: {
@@ -164,7 +323,13 @@ describe("editFileTool", () => {
         });
 
         const result = await editFileTool.execute(
-          { path: "restricted.txt", oldString: "old", newString: "new" },
+          {
+            path: "restricted.txt",
+            edits: [
+              { oldString: "alpha", newString: "one" },
+              { oldString: "beta", newString: "two" },
+            ],
+          },
           ctx,
         );
 
@@ -175,6 +340,9 @@ describe("editFileTool", () => {
           diff: expect.any(String),
         });
         expect(result.status).toBe("ok");
+        expect(result.output).toContain("-alpha beta");
+        expect(result.output).toContain("+one two");
+        expect(fs.getFile(filePath)).toBe("one two\n");
       });
 
       it("returns denied and does not write when user rejects confirmation", async () => {
@@ -192,7 +360,10 @@ describe("editFileTool", () => {
         });
 
         const result = await editFileTool.execute(
-          { path: "restricted.txt", oldString: "old", newString: "new" },
+          {
+            path: "restricted.txt",
+            edits: [{ oldString: "old", newString: "new" }],
+          },
           ctx,
         );
 

--- a/src/tools/edit-file.ts
+++ b/src/tools/edit-file.ts
@@ -6,23 +6,78 @@ import { checkFilePermission } from "./permissions";
 import type { Tool, ToolContext, ToolResult } from "./types";
 import { denied, err, okDiff } from "./types";
 
+/** Zod schema for a single edit within an edit_file call. */
+const editSchema = z.object({
+  oldString: z.string().min(1, "oldString must not be empty"),
+  newString: z.string(),
+  replaceAll: z.boolean().default(false),
+});
+
 /** Zod schema for edit_file arguments. */
 const argsSchema = z.object({
   path: z.string().min(1, "no file path provided"),
-  oldString: z.string().min(1, "oldString must not be empty"),
-  newString: z.string(),
+  edits: z.array(editSchema).min(1, "at least one edit is required"),
 });
+
+/** A single edit entry after schema parsing. */
+type Edit = z.infer<typeof editSchema>;
+
+/** Result of applying the edits sequentially to a file's content. */
+type ApplyResult =
+  | { ok: true; content: string }
+  | { ok: false; message: string };
+
+/** Applies edits sequentially to the given content, in memory. */
+function applyEdits(original: string, edits: readonly Edit[]): ApplyResult {
+  let working = original;
+
+  for (let i = 0; i < edits.length; i++) {
+    const edit = edits[i];
+    const label = `edit ${i + 1}`;
+
+    if (edit.oldString === edit.newString) {
+      return {
+        ok: false,
+        message: `${label}: oldString and newString are identical`,
+      };
+    }
+
+    const occurrences = working.split(edit.oldString).length - 1;
+
+    if (occurrences === 0) {
+      return { ok: false, message: `${label}: oldString not found in file` };
+    }
+
+    if (occurrences > 1 && !edit.replaceAll) {
+      return {
+        ok: false,
+        message: `${label}: oldString found ${occurrences} times — set replaceAll: true or add surrounding context to disambiguate`,
+      };
+    }
+
+    working = edit.replaceAll
+      ? working.split(edit.oldString).join(edit.newString)
+      : working.replace(edit.oldString, edit.newString);
+  }
+
+  return { ok: true, content: working };
+}
 
 /** The edit_file tool definition. */
 export const editFileTool: Tool = {
   name: "edit_file",
   displayName: "Edit File",
-  description: `Replace an exact string match in a file with new content.
+  description: `Apply one or more edits to a file in a single atomic call.
 
-- The oldString must appear exactly once in the file. If it appears zero or multiple times, the edit fails.
+- Each edit has an oldString to find, a newString to replace it with, and an optional replaceAll flag (default false).
+- When replaceAll is false, oldString must appear exactly once in the current file content. If it appears zero or multiple times, the edit fails.
+- When replaceAll is true, every occurrence of oldString is replaced. The edit fails only if oldString appears zero times.
+- Edits are applied sequentially: each edit operates on the result of the previous edit, not the original file content. Order matters.
+- The whole call is atomic. If any edit fails, the file is not modified and the call returns an error identifying which edit failed.
+- Prefer batching multiple edits to the same file in a single call over multiple calls — it is faster and produces a single combined diff for review.
 - You MUST read the file before editing it. Never edit a file you have not read in the current conversation.
-- Use this tool for small, targeted changes. Use write_file for full rewrites or new files.
-- The oldString and newString must be different.`,
+- Use this tool for targeted changes. Use write_file for full rewrites or new files.
+- oldString and newString within an edit must be different.`,
   parameters: {
     type: "object",
     properties: {
@@ -30,20 +85,43 @@ export const editFileTool: Tool = {
         type: "string",
         description: "The file path to edit (absolute or relative to cwd)",
       },
-      oldString: {
-        type: "string",
-        description: "The exact string to find and replace (must be unique)",
-      },
-      newString: {
-        type: "string",
-        description: "The replacement string",
+      edits: {
+        type: "array",
+        description:
+          "One or more edits to apply sequentially to the file. Each edit operates on the result of the previous edit.",
+        minItems: 1,
+        items: {
+          type: "object",
+          properties: {
+            oldString: {
+              type: "string",
+              description:
+                "The exact string to find. Must be unique in the file unless replaceAll is true.",
+            },
+            newString: {
+              type: "string",
+              description: "The replacement string",
+            },
+            replaceAll: {
+              type: "boolean",
+              description:
+                "If true, replace every occurrence of oldString. Default false.",
+            },
+          },
+          required: ["oldString", "newString"],
+        },
       },
     },
-    required: ["path", "oldString", "newString"],
+    required: ["path", "edits"],
   },
   argsSchema,
   formatCall(args: Record<string, unknown>): string {
-    return String(args.path ?? "");
+    const path = String(args.path ?? "");
+    const edits = args.edits;
+    if (Array.isArray(edits) && edits.length > 1) {
+      return `${path} (${edits.length} edits)`;
+    }
+    return path;
   },
   async execute(args: unknown, context: ToolContext): Promise<ToolResult> {
     const parsed = argsSchema.parse(args);
@@ -57,24 +135,14 @@ export const editFileTool: Tool = {
       return err(`file not found: ${filePath}`);
     }
 
-    const content = readFile(filePath);
+    const original = readFile(filePath);
+    const result = applyEdits(original, parsed.edits);
 
-    if (parsed.oldString === parsed.newString) {
-      return err("oldString and newString are identical");
+    if (!result.ok) {
+      return err(result.message);
     }
 
-    const occurrences = content.split(parsed.oldString).length - 1;
-    if (occurrences === 0) {
-      return err("oldString not found in file");
-    }
-    if (occurrences > 1) {
-      return err(
-        `oldString found ${occurrences} times — it must be unique. Add surrounding context to disambiguate.`,
-      );
-    }
-
-    const newContent = content.replace(parsed.oldString, parsed.newString);
-    const diff = unifiedDiff(filePath, content, newContent);
+    const diff = unifiedDiff(filePath, original, result.content);
 
     const permission = checkFilePermission(
       filePath,
@@ -93,7 +161,7 @@ export const editFileTool: Tool = {
       }
     }
 
-    writeFile(filePath, newContent);
+    writeFile(filePath, result.content);
 
     return okDiff(diff);
   },


### PR DESCRIPTION
## Summary

Extend `edit_file` to accept an array of edits and an optional `replaceAll` flag per edit, so the model can complete a multi-spot refactor in a single tool call with one combined diff and one confirmation prompt.

## GitHub Issue

Closes #273

## What Changed

The schema for `edit_file` now takes `path` and an `edits` array. Each edit is `{ oldString, newString, replaceAll? }` (replaceAll defaults to false). The single-pair shape is gone.

**Sequential, atomic application.** Edits are applied to the file content in order, in memory. Each edit operates on the *result* of the previous edit, not the original content — this matches how a person would think about a sequence of changes and avoids forcing the model to mentally diff non-overlapping windows in the original. The whole call is atomic per file: if any edit fails the file is left untouched and the error message identifies which edit (1-based) failed and why.

**replaceAll opt-in.** With `replaceAll: false` (the default) the existing unique-match guardrail still applies — `oldString` must appear exactly once or the edit fails. With `replaceAll: true` every occurrence is replaced and the edit fails only if there are zero matches. This removes the friction of having to add surrounding context to disambiguate when the model legitimately wants to rename every occurrence (variable rename, import path change), without weakening the default safety.

**One diff, one prompt.** A single combined unified diff is built from the original file content vs. the final post-all-edits content, and the confirmation prompt fires once with that combined diff. Permission semantics are unchanged.

**`formatCall`** shows `path` for a single edit and `path (N edits)` for N>1, so the collapsed tool header carries the batch size.

**Description rewrite.** The tool description now explains sequential application, atomicity, `replaceAll` semantics, and explicitly nudges the model to prefer batching over multiple calls — LLMs follow tool descriptions closely and this is where the speedup actually lands.

The system prompt's read-before-write example (`src/prompt/build-system-prompt.ts`) was updated to use the new `edits` array shape so the model sees a consistent contract.

## Notes for Reviewers

Regex matching was discussed and intentionally left out — it's a footgun for LLM callers (escaping/flavour confusion, silent corruption on auto-approved edits) and almost everything people reach for regex for is covered by `replaceAll` with a literal string. If a real need surfaces later it can ship as an opt-in `mode: "regex"` with stricter confirmation rules.