### PR TITLE
feat(provider): add mlx provider with local context-window detection

### DIFF
--- a/src/chat/chat.test.tsx
+++ b/src/chat/chat.test.tsx
@@ -537,9 +537,10 @@ describe("Chat", () => {
       await stdin.write(keys.enter);
       await new Promise((r) => setTimeout(r, 50));
 
-      // Should show live streaming content and loading indicator
+      // Should show live streaming content and loading indicator.
+      // Match any spinner frame since it cycles on a timer.
       expect(lastFrame()).toContain("streaming...");
-      expect(lastFrame()).toContain("⠋");
+      expect(lastFrame()).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
 
       cleanup.resolve?.();
     });

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -22,6 +22,16 @@ describe("providerSchema", () => {
     expect(result.apiKey).toBeUndefined();
   });
 
+  it("parses an mlx provider", () => {
+    const result = providerSchema.parse({
+      name: "mlx",
+      type: "mlx",
+      baseUrl: "http://127.0.0.1:8080",
+    });
+    expect(result.type).toBe("mlx");
+    expect(result.baseUrl).toBe("http://127.0.0.1:8080");
+  });
+
   it("parses a provider with apiKey", () => {
     const result = providerSchema.parse({
       name: "openrouter",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5,6 +5,7 @@ export const providerTypeSchema = z.enum([
   "ollama",
   "opencode-zen",
   "openrouter",
+  "mlx",
 ]);
 
 /** Schema for a single provider connection. */

--- a/src/model/model-selector.test.tsx
+++ b/src/model/model-selector.test.tsx
@@ -139,7 +139,7 @@ describe("ModelSelector", () => {
         global: { providers: [OLLAMA_PROVIDER] },
       });
       await stdin.write(keys.enter);
-      expect(lastFrame()).toContain("⠋");
+      expect(lastFrame()).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
       expect(lastFrame()).toContain("Select Model — my-ollama");
     });
 

--- a/src/provider/client.test.ts
+++ b/src/provider/client.test.ts
@@ -33,6 +33,11 @@ describe("resolveApiKey", () => {
     expect(resolveApiKey("openrouter")).toBe("sk-env");
   });
 
+  it("falls back to MLX_API_KEY env var for mlx", () => {
+    vi.stubEnv("MLX_API_KEY", "sk-env");
+    expect(resolveApiKey("mlx")).toBe("sk-env");
+  });
+
   it("prefers config key over env var", () => {
     vi.stubEnv("OPENCODE_API_KEY", "sk-env");
     expect(resolveApiKey("opencode-zen", "sk-config")).toBe("sk-config");
@@ -57,6 +62,10 @@ describe("PROVIDER_DEFAULT_URLS", () => {
 
   it("has default URL for openrouter", () => {
     expect(PROVIDER_DEFAULT_URLS.openrouter).toBe("https://openrouter.ai/api");
+  });
+
+  it("has default URL for mlx", () => {
+    expect(PROVIDER_DEFAULT_URLS.mlx).toBe("http://127.0.0.1:8080");
   });
 });
 

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -88,6 +88,7 @@ export const PROVIDER_DEFAULT_URLS: Record<ProviderType, string> = {
   ollama: "http://localhost:11434",
   "opencode-zen": "https://opencode.ai/zen",
   openrouter: "https://openrouter.ai/api",
+  mlx: "http://127.0.0.1:8080",
 };
 
 /** Environment variable names for provider API keys. */
@@ -95,6 +96,7 @@ export const API_KEY_ENV_VARS: Record<ProviderType, string> = {
   ollama: "OLLAMA_API_KEY",
   "opencode-zen": "OPENCODE_API_KEY",
   openrouter: "OPENROUTER_API_KEY",
+  mlx: "MLX_API_KEY",
 };
 
 /**

--- a/src/provider/openai-compatible.test.ts
+++ b/src/provider/openai-compatible.test.ts
@@ -34,6 +34,27 @@ describe("createOpenAICompatibleClient", () => {
       expect(models).toEqual([{ id: "llama3" }, { id: "mistral" }]);
     });
 
+    it("uses /v1/models for mlx", async () => {
+      let requestUrl = "";
+      server.use(
+        http.get("http://127.0.0.1:8080/v1/models", (info) => {
+          requestUrl = info.request.url;
+          return HttpResponse.json({ data: [{ id: "mlx-community/llama" }] });
+        }),
+      );
+
+      const client = createOpenAICompatibleClient(
+        makeProvider({
+          type: "mlx",
+          baseUrl: "http://127.0.0.1:8080",
+        }),
+      );
+      const models = await client.fetchModels();
+
+      expect(requestUrl).toBe("http://127.0.0.1:8080/v1/models");
+      expect(models).toEqual([{ id: "mlx-community/llama" }]);
+    });
+
     it("uses /v1/models/user for openrouter with api key", async () => {
       let requestUrl = "";
       server.use(
@@ -308,6 +329,42 @@ describe("createOpenAICompatibleClient", () => {
 
       const client = createOpenAICompatibleClient(makeProvider());
       const result = await client.fetchContextWindow("llama3");
+      expect(result).toBe(8192);
+    });
+
+    it("fetches context window from /v1/models for mlx", async () => {
+      server.use(
+        http.get("http://127.0.0.1:8080/v1/models", () =>
+          HttpResponse.json({
+            data: [{ id: "mlx-community/llama", context_length: 32768 }],
+          }),
+        ),
+      );
+
+      const client = createOpenAICompatibleClient(
+        makeProvider({
+          type: "mlx",
+          baseUrl: "http://127.0.0.1:8080",
+        }),
+      );
+      const result = await client.fetchContextWindow("mlx-community/llama");
+      expect(result).toBe(32768);
+    });
+
+    it("falls back to default for mlx when context_length is missing", async () => {
+      server.use(
+        http.get("http://127.0.0.1:8080/v1/models", () =>
+          HttpResponse.json({ data: [{ id: "mlx-community/llama" }] }),
+        ),
+      );
+
+      const client = createOpenAICompatibleClient(
+        makeProvider({
+          type: "mlx",
+          baseUrl: "http://127.0.0.1:8080",
+        }),
+      );
+      const result = await client.fetchContextWindow("mlx-community/llama");
       expect(result).toBe(8192);
     });
 

--- a/src/provider/openai-compatible.test.ts
+++ b/src/provider/openai-compatible.test.ts
@@ -1,7 +1,28 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import type { Provider } from "../config/schema";
 import { setupMsw, http, HttpResponse } from "../test-utils/msw";
 import { createOpenAICompatibleClient } from "./openai-compatible";
+
+/**
+ * Builds a fake HF hub cache containing a single snapshot for the given
+ * model id and writes the supplied config.json body. Returns the cache
+ * root so tests can point HF_HUB_CACHE at it.
+ */
+function makeHfCache(modelId: string, config: unknown): string {
+  const cacheRoot = mkdtempSync(join(tmpdir(), "tomo-hf-"));
+  const snapshotDir = join(
+    cacheRoot,
+    `models--${modelId.replace(/\//g, "--")}`,
+    "snapshots",
+    "abc123",
+  );
+  mkdirSync(snapshotDir, { recursive: true });
+  writeFileSync(join(snapshotDir, "config.json"), JSON.stringify(config));
+  return cacheRoot;
+}
 
 /** Creates a minimal provider config for testing. */
 function makeProvider(overrides: Partial<Provider> = {}): Provider {
@@ -332,40 +353,251 @@ describe("createOpenAICompatibleClient", () => {
       expect(result).toBe(8192);
     });
 
-    it("fetches context window from /v1/models for mlx", async () => {
-      server.use(
-        http.get("http://127.0.0.1:8080/v1/models", () =>
-          HttpResponse.json({
-            data: [{ id: "mlx-community/llama", context_length: 32768 }],
-          }),
-        ),
-      );
-
-      const client = createOpenAICompatibleClient(
-        makeProvider({
-          type: "mlx",
-          baseUrl: "http://127.0.0.1:8080",
-        }),
-      );
-      const result = await client.fetchContextWindow("mlx-community/llama");
-      expect(result).toBe(32768);
+    it("reads mlx context window from HF cache max_position_embeddings", async () => {
+      const cacheRoot = makeHfCache("mlx-community/llama", {
+        max_position_embeddings: 131072,
+      });
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(131072);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
     });
 
-    it("falls back to default for mlx when context_length is missing", async () => {
-      server.use(
-        http.get("http://127.0.0.1:8080/v1/models", () =>
-          HttpResponse.json({ data: [{ id: "mlx-community/llama" }] }),
-        ),
-      );
+    it.each([
+      ["max_sequence_length", 40960],
+      ["seq_length", 16384],
+      ["n_positions", 2048],
+      ["sliding_window", 4096],
+    ])("reads mlx context window from %s", async (field, value) => {
+      const cacheRoot = makeHfCache("mlx-community/llama", { [field]: value });
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(value);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
 
-      const client = createOpenAICompatibleClient(
-        makeProvider({
-          type: "mlx",
-          baseUrl: "http://127.0.0.1:8080",
-        }),
+    it("prefers max_position_embeddings over later fields", async () => {
+      const cacheRoot = makeHfCache("mlx-community/llama", {
+        max_position_embeddings: 131072,
+        sliding_window: 4096,
+      });
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(131072);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("reads mlx context window from nested text_config for multimodal models", async () => {
+      const cacheRoot = makeHfCache("mlx-community/gemma", {
+        text_config: { max_position_embeddings: 65536 },
+      });
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/gemma");
+        expect(result).toBe(65536);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to default when mlx HF cache entry is missing", async () => {
+      const cacheRoot = mkdtempSync(join(tmpdir(), "tomo-hf-"));
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(8192);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to default when mlx HF cache snapshots dir is empty", async () => {
+      const cacheRoot = mkdtempSync(join(tmpdir(), "tomo-hf-"));
+      mkdirSync(join(cacheRoot, "models--mlx-community--llama", "snapshots"), {
+        recursive: true,
+      });
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(8192);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to default when mlx HF config.json is malformed", async () => {
+      const cacheRoot = mkdtempSync(join(tmpdir(), "tomo-hf-"));
+      const snapshotDir = join(
+        cacheRoot,
+        "models--mlx-community--llama",
+        "snapshots",
+        "abc123",
       );
-      const result = await client.fetchContextWindow("mlx-community/llama");
+      mkdirSync(snapshotDir, { recursive: true });
+      writeFileSync(join(snapshotDir, "config.json"), "{ not json");
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(8192);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to default when mlx HF config has no context fields", async () => {
+      const cacheRoot = makeHfCache("mlx-community/llama", {
+        hidden_size: 4096,
+      });
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(8192);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("uses HF_HOME/hub when HF_HUB_CACHE is unset", async () => {
+      const hfHome = mkdtempSync(join(tmpdir(), "tomo-hf-home-"));
+      const snapshotDir = join(
+        hfHome,
+        "hub",
+        "models--mlx-community--llama",
+        "snapshots",
+        "abc123",
+      );
+      mkdirSync(snapshotDir, { recursive: true });
+      writeFileSync(
+        join(snapshotDir, "config.json"),
+        JSON.stringify({ max_position_embeddings: 8000 }),
+      );
+      vi.stubEnv("HF_HUB_CACHE", "");
+      vi.stubEnv("HF_HOME", hfHome);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(8000);
+      } finally {
+        rmSync(hfHome, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to ~/.cache/huggingface/hub when no HF env vars are set", async () => {
+      vi.stubEnv("HF_HUB_CACHE", "");
+      vi.stubEnv("HF_HOME", "");
+      const client = createOpenAICompatibleClient(
+        makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+      );
+      // Unique id guarantees no collision with a real cache entry; the path
+      // won't exist, so this exercises the default-dir branch and returns 8192.
+      const result = await client.fetchContextWindow(
+        `tomo-test-nonexistent/model-${Date.now()}`,
+      );
       expect(result).toBe(8192);
+    });
+
+    it("falls back to default when absolute mlx path has no config.json", async () => {
+      const modelDir = mkdtempSync(join(tmpdir(), "tomo-mlx-empty-"));
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow(modelDir);
+        expect(result).toBe(8192);
+      } finally {
+        rmSync(modelDir, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to default when mlx HF config.json is a JSON scalar", async () => {
+      // z.record requires an object; null/strings/numbers fail the top-level schema.
+      const cacheRoot = mkdtempSync(join(tmpdir(), "tomo-hf-"));
+      const snapshotDir = join(
+        cacheRoot,
+        "models--mlx-community--llama",
+        "snapshots",
+        "abc123",
+      );
+      mkdirSync(snapshotDir, { recursive: true });
+      writeFileSync(join(snapshotDir, "config.json"), "null");
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(8192);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to default when text_config has no context fields", async () => {
+      const cacheRoot = makeHfCache("mlx-community/llama", {
+        text_config: { hidden_size: 4096 },
+      });
+      vi.stubEnv("HF_HUB_CACHE", cacheRoot);
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow("mlx-community/llama");
+        expect(result).toBe(8192);
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("reads mlx context window from an absolute local model path", async () => {
+      const modelDir = mkdtempSync(join(tmpdir(), "tomo-mlx-model-"));
+      writeFileSync(
+        join(modelDir, "config.json"),
+        JSON.stringify({ max_position_embeddings: 16384 }),
+      );
+      try {
+        const client = createOpenAICompatibleClient(
+          makeProvider({ type: "mlx", baseUrl: "http://127.0.0.1:8080" }),
+        );
+        const result = await client.fetchContextWindow(modelDir);
+        expect(result).toBe(16384);
+      } finally {
+        rmSync(modelDir, { recursive: true, force: true });
+      }
     });
 
     it("fetches context window from /v1/models for openrouter", async () => {

--- a/src/provider/openai-compatible.ts
+++ b/src/provider/openai-compatible.ts
@@ -1,3 +1,6 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 import { z } from "zod";
 import type { Provider } from "../config/schema";
 import type {
@@ -98,6 +101,92 @@ async function fetchOllamaContextWindow(
   return DEFAULT_CONTEXT_WINDOW;
 }
 
+/**
+ * Candidate fields for the context length, in priority order. Different
+ * architectures use different names: Llama/Gemma/Mistral/Qwen use
+ * max_position_embeddings, GPT-2 uses n_positions, some Mistral variants
+ * expose only sliding_window, etc.
+ */
+const CONTEXT_LENGTH_FIELDS = [
+  "max_position_embeddings",
+  "max_sequence_length",
+  "seq_length",
+  "n_positions",
+  "sliding_window",
+] as const;
+
+/** Loose schema for a HuggingFace config.json — we inspect specific keys by hand. */
+const hfConfigSchema = z.record(z.string(), z.unknown());
+
+/** Returns the first numeric CONTEXT_LENGTH_FIELDS value found in a config object. */
+function extractContextLength(
+  config: Record<string, unknown>,
+): number | undefined {
+  for (const field of CONTEXT_LENGTH_FIELDS) {
+    const value = config[field];
+    if (typeof value === "number") return value;
+  }
+  return undefined;
+}
+
+/** Resolves the HuggingFace hub cache directory, honouring env overrides. */
+function hfHubCacheDir(): string {
+  if (process.env.HF_HUB_CACHE) return process.env.HF_HUB_CACHE;
+  if (process.env.HF_HOME) return join(process.env.HF_HOME, "hub");
+  return join(homedir(), ".cache", "huggingface", "hub");
+}
+
+/**
+ * Reads the context window from a HuggingFace model config.json on disk.
+ * mlx_lm.server downloads HF models into the local cache before serving,
+ * so the config is always available locally. For absolute local paths
+ * (mlx_lm.server accepts these as model ids), reads config.json from the
+ * model directory directly. Checks top-level first, then falls back to
+ * `text_config` for multimodal models (e.g. gemma-3) that nest the text
+ * model fields under that key.
+ */
+function fetchMlxContextWindow(modelId: string): number {
+  let configPath: string;
+
+  if (isAbsolute(modelId)) {
+    configPath = join(modelId, "config.json");
+  } else {
+    // HF cache layout: models--<org>--<repo>/snapshots/<hash>/config.json
+    const repoDir = join(
+      hfHubCacheDir(),
+      `models--${modelId.replace(/\//g, "--")}`,
+      "snapshots",
+    );
+    if (!existsSync(repoDir)) return DEFAULT_CONTEXT_WINDOW;
+    const snapshots = readdirSync(repoDir);
+    if (snapshots.length === 0) return DEFAULT_CONTEXT_WINDOW;
+    configPath = join(repoDir, snapshots[0], "config.json");
+  }
+
+  if (!existsSync(configPath)) return DEFAULT_CONTEXT_WINDOW;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch {
+    return DEFAULT_CONTEXT_WINDOW;
+  }
+
+  const result = hfConfigSchema.safeParse(parsed);
+  if (!result.success) return DEFAULT_CONTEXT_WINDOW;
+
+  const topLevel = extractContextLength(result.data);
+  if (topLevel !== undefined) return topLevel;
+
+  const textConfig = hfConfigSchema.safeParse(result.data.text_config);
+  if (textConfig.success) {
+    const nested = extractContextLength(textConfig.data);
+    if (nested !== undefined) return nested;
+  }
+
+  return DEFAULT_CONTEXT_WINDOW;
+}
+
 /** Schema for a model entry with optional context_length. */
 const modelEntrySchema = z.object({
   id: z.string(),
@@ -175,13 +264,18 @@ export function createOpenAICompatibleClient(
   /**
    * Fetches the context window size for a model.
    * Ollama exposes this via its native /api/show endpoint. OpenRouter and
-   * OpenCode Zen include context_length in the /v1/models metadata.
-   * Falls back to DEFAULT_CONTEXT_WINDOW if detection fails.
+   * OpenCode Zen include context_length in the /v1/models metadata. MLX
+   * doesn't expose it over HTTP at all, so we read max_position_embeddings
+   * from the HuggingFace cache on disk. Falls back to DEFAULT_CONTEXT_WINDOW
+   * if detection fails.
    */
   async function fetchContextWindow(model: string): Promise<number> {
     try {
       if (provider.type === "ollama") {
         return await fetchOllamaContextWindow(baseUrl, model);
+      }
+      if (provider.type === "mlx") {
+        return fetchMlxContextWindow(model);
       }
       return await fetchModelsContextWindow(baseUrl, model, apiKey);
     } catch {

--- a/src/settings/providers.test.tsx
+++ b/src/settings/providers.test.tsx
@@ -396,8 +396,9 @@ describe("ProvidersScreen", () => {
       await stdin.write(keys.up);
       await stdin.write(keys.tab);
       await stdin.write(keys.enter);
-      // Spinner frame indicates loading state (text is shimmer-styled with escape codes)
-      expect(lastFrame()).toContain("⠋");
+      // Spinner frame indicates loading state (text is shimmer-styled with escape codes).
+      // Match any frame since it cycles on a timer.
+      expect(lastFrame()).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
     });
 
     it("shows connected after successful model fetch", async () => {

--- a/src/settings/providers.tsx
+++ b/src/settings/providers.tsx
@@ -25,6 +25,7 @@ const PROVIDER_TYPES: readonly ProviderType[] = [
   "ollama",
   "opencode-zen",
   "openrouter",
+  "mlx",
 ];
 
 /** Key instructions for the provider options form. */

--- a/src/test-utils/ink.tsx
+++ b/src/test-utils/ink.tsx
@@ -15,7 +15,7 @@ import { mockConfig } from "./mock-config";
  * to complete so `lastFrame()` reflects the post-escape state.
  */
 export async function flushInkFrames(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 25));
+  await new Promise((resolve) => setTimeout(resolve, 50));
 }
 
 /** Stdin wrapper that auto-flushes after each write. */


### PR DESCRIPTION
## Summary

Adds MLX (`mlx_lm.server`) as a first-class provider type so users can point
tomo at a local MLX server without masquerading it as Ollama. Also teaches
the provider to read the context window from the HuggingFace cache on disk,
since mlx_lm doesn't expose that info over HTTP.

## GitHub Issue

N/A

## What Changed

**New `mlx` provider type.** Adds `"mlx"` to `providerTypeSchema`, wires up a
default URL (`http://127.0.0.1:8080`) and `MLX_API_KEY` env var in
`provider/client.ts`, and exposes it in the settings dropdown. Because MLX
is OpenAI-compatible, model listing flows through the existing `/v1/models`
path — no new client implementation required. Previously users who selected
"ollama" and pointed the URL at MLX hit Ollama's native `/api/show` and
`/api/tags` endpoints and got confusing results.

**Context window from HuggingFace config.json.** `mlx_lm.server`'s `/v1/models`
returns only `id`/`object`/`created` — no context length — and there's no
other endpoint that exposes it. Since mlx_lm downloads HF models to the
local cache before serving, we read `config.json` directly from
`~/.cache/huggingface/hub/models--<org>--<repo>/snapshots/*/`. Field lookup
walks `max_position_embeddings` → `max_sequence_length` → `seq_length` →
`n_positions` → `sliding_window` at the top level first, then falls back to
`text_config` for multimodal models (e.g. gemma-3). `HF_HUB_CACHE` and
`HF_HOME` env vars are honoured, and absolute local model paths are
supported. Any failure falls through to the existing 8192 default.

**Test-stability fixups.** Spinner assertions in chat/model-selector/providers
tests hardcoded frame 0 (`⠋`), which raced against the 80ms spinner tick —
relaxed to match any frame in the cycle. Also bumped `flushInkFrames` from
25ms to 50ms to give ink input parsing more headroom on slower hosts.

## Notes for Reviewers

- `fetchMlxContextWindow` is synchronous (fs reads are cheap) but called
  from the async `fetchContextWindow` wrapper — the outer try/catch still
  catches any unexpected throw.
- The HF cache layout uses `models--<org>--<repo>/snapshots/<hash>/` — we
  take the first snapshot directory found. Multiple snapshots from stale
  revisions shouldn't matter in practice since `max_position_embeddings`
  is architectural, not per-revision.
- Coverage is at 100% across the new code and the rest of the repo.