### PR TITLE
feat(tools): add remove_file tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ src/
 ├── settings/     # /settings menu and submenus (providers, tools, MCP, etc)
 ├── session/      # session persistence and the session browser
 ├── model/        # model selector
-├── tools/        # built-in tools (read, write, edit, glob, grep, run, agent, ...)
+├── tools/        # built-in tools (read, write, edit, remove, glob, grep, run, agent, ...)
 ├── mcp/          # MCP client, transports, manager
 ├── skills/       # skill loading + registry
 ├── skill-sets/   # git-backed skill set discovery

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The model can call tools to read files, run commands, and more. Tools are enable
 | Read File    | Read file contents with line numbers               | Enabled  |
 | Write File   | Create or overwrite a file                         | Enabled  |
 | Edit File    | Apply string replacements to a file                | Enabled  |
+| Remove File  | Delete a file                                      | Enabled  |
 | Glob         | Find files by glob pattern (respects `.gitignore`) | Enabled  |
 | Grep         | Search file contents by regex                      | Enabled  |
 | Run Command  | Run a shell command                                | Enabled  |
@@ -71,14 +72,16 @@ The model can call tools to read files, run commands, and more. Tools are enable
 
 ## Permissions
 
-Write and edit operations prompt for confirmation by default. Read File is auto-allowed inside the current working directory. Manage permissions in `/settings → Permissions`, or in your config file:
+Write, edit, and remove operations prompt for confirmation by default. Read File is auto-allowed inside the current working directory. Manage permissions in `/settings → Permissions`, or in your config file:
 
 ```yaml
 permissions:
   cwdReadFile: true # auto-allow reads inside cwd (default: true)
   cwdWriteFile: true # auto-allow writes inside cwd
+  cwdRemoveFile: true # auto-allow removes inside cwd
   globalReadFile: true # auto-allow reads outside cwd
   globalWriteFile: true # auto-allow writes outside cwd
+  globalRemoveFile: true # auto-allow removes outside cwd
 ```
 
 File operations outside the current working directory require the `global*` permissions even when the matching `cwd*` permission is enabled.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -18,6 +18,7 @@ import { globTool } from "./tools/glob";
 import { grepTool } from "./tools/grep";
 import { readFileTool } from "./tools/read-file";
 import { createToolRegistry } from "./tools/registry";
+import { removeFileTool } from "./tools/remove-file";
 import { runCommandTool } from "./tools/run-command";
 import { createSkillTool } from "./tools/skill";
 import { webSearchTool } from "./tools/web-search";
@@ -71,6 +72,7 @@ function buildToolRegistry(skillRegistry: SkillRegistry) {
   registry.register(readFileTool);
   registry.register(writeFileTool);
   registry.register(editFileTool);
+  registry.register(removeFileTool);
   registry.register(globTool);
   registry.register(grepTool);
   registry.register(runCommandTool);

--- a/src/chat/chat.test.tsx
+++ b/src/chat/chat.test.tsx
@@ -1259,6 +1259,7 @@ describe("Chat", () => {
               glob: { enabled: true },
               grep: { enabled: true },
               readFile: { enabled: true },
+              removeFile: { enabled: true },
               runCommand: { enabled: true },
               skill: { enabled: true },
               webSearch: { enabled: true, apiKey: "tavily-test-key" },

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -78,21 +78,27 @@ describe("permissionsSchema", () => {
     const result = permissionsSchema.parse({});
     expect(result.cwdReadFile).toBe(true);
     expect(result.cwdWriteFile).toBeUndefined();
+    expect(result.cwdRemoveFile).toBeUndefined();
     expect(result.globalReadFile).toBeUndefined();
     expect(result.globalWriteFile).toBeUndefined();
+    expect(result.globalRemoveFile).toBeUndefined();
   });
 
   it("parses explicit values", () => {
     const result = permissionsSchema.parse({
       cwdReadFile: false,
       cwdWriteFile: true,
+      cwdRemoveFile: true,
       globalReadFile: true,
       globalWriteFile: false,
+      globalRemoveFile: true,
     });
     expect(result.cwdReadFile).toBe(false);
     expect(result.cwdWriteFile).toBe(true);
+    expect(result.cwdRemoveFile).toBe(true);
     expect(result.globalReadFile).toBe(true);
     expect(result.globalWriteFile).toBe(false);
+    expect(result.globalRemoveFile).toBe(true);
   });
 });
 
@@ -105,6 +111,7 @@ describe("toolsSchema", () => {
       glob: { enabled: true },
       grep: { enabled: true },
       readFile: { enabled: true },
+      removeFile: { enabled: true },
       runCommand: { enabled: true },
       skill: { enabled: true },
       webSearch: { enabled: false },
@@ -122,6 +129,7 @@ describe("toolsSchema", () => {
       glob: { enabled: true },
       grep: { enabled: true },
       readFile: { enabled: true },
+      removeFile: { enabled: true },
       runCommand: { enabled: true },
       skill: { enabled: true },
       webSearch: { enabled: true, apiKey: "tvly-123" },
@@ -135,8 +143,19 @@ describe("toolsSchema", () => {
     expect(result.tools.webSearch.apiKey).toBeUndefined();
   });
 
-  it("rejects missing tools", () => {
-    expect(() => toolsSchema.parse({})).toThrow();
+  it("fills missing tool entries with their defaults", () => {
+    const result = toolsSchema.parse({});
+    expect(result.agent.enabled).toBe(true);
+    expect(result.ask.enabled).toBe(true);
+    expect(result.editFile.enabled).toBe(true);
+    expect(result.glob.enabled).toBe(true);
+    expect(result.grep.enabled).toBe(true);
+    expect(result.readFile.enabled).toBe(true);
+    expect(result.removeFile.enabled).toBe(true);
+    expect(result.runCommand.enabled).toBe(true);
+    expect(result.skill.enabled).toBe(true);
+    expect(result.webSearch.enabled).toBe(false);
+    expect(result.writeFile.enabled).toBe(true);
   });
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -20,8 +20,10 @@ export const providerSchema = z.object({
 export const permissionsSchema = z.object({
   cwdReadFile: z.boolean().default(true),
   cwdWriteFile: z.boolean().optional(),
+  cwdRemoveFile: z.boolean().optional(),
   globalReadFile: z.boolean().optional(),
   globalWriteFile: z.boolean().optional(),
+  globalRemoveFile: z.boolean().optional(),
 });
 
 /** Schema for a single tool's config. */
@@ -36,16 +38,17 @@ export const webSearchToolConfigSchema = toolConfigSchema.extend({
 
 /** Schema for first-party tool configuration. */
 export const toolsSchema = z.object({
-  agent: toolConfigSchema,
-  ask: toolConfigSchema,
-  editFile: toolConfigSchema,
-  glob: toolConfigSchema,
-  grep: toolConfigSchema,
-  readFile: toolConfigSchema,
-  runCommand: toolConfigSchema,
-  skill: toolConfigSchema,
-  webSearch: webSearchToolConfigSchema,
-  writeFile: toolConfigSchema,
+  agent: toolConfigSchema.default({ enabled: true }),
+  ask: toolConfigSchema.default({ enabled: true }),
+  editFile: toolConfigSchema.default({ enabled: true }),
+  glob: toolConfigSchema.default({ enabled: true }),
+  grep: toolConfigSchema.default({ enabled: true }),
+  readFile: toolConfigSchema.default({ enabled: true }),
+  removeFile: toolConfigSchema.default({ enabled: true }),
+  runCommand: toolConfigSchema.default({ enabled: true }),
+  skill: toolConfigSchema.default({ enabled: true }),
+  webSearch: webSearchToolConfigSchema.default({ enabled: false }),
+  writeFile: toolConfigSchema.default({ enabled: true }),
 });
 
 /** Schema for agent spawning configuration. */
@@ -120,18 +123,7 @@ export const configSchema = z.object({
   }),
   mcp: mcpSchema.default({ connections: {} }),
   skillSets: skillSetsSchema.default({ sources: [] }),
-  tools: toolsSchema.default({
-    agent: { enabled: true },
-    ask: { enabled: true },
-    editFile: { enabled: true },
-    glob: { enabled: true },
-    grep: { enabled: true },
-    readFile: { enabled: true },
-    runCommand: { enabled: true },
-    skill: { enabled: true },
-    webSearch: { enabled: false },
-    writeFile: { enabled: true },
-  }),
+  tools: toolsSchema.prefault({}),
 });
 
 /** A single provider connection. */

--- a/src/config/updaters.test.ts
+++ b/src/config/updaters.test.ts
@@ -252,6 +252,7 @@ describe("updateTools", () => {
       glob: { enabled: true },
       grep: { enabled: true },
       readFile: { enabled: true },
+      removeFile: { enabled: true },
       runCommand: { enabled: true },
       skill: { enabled: true },
       webSearch: { enabled: true, apiKey: "tvly-123" },

--- a/src/settings/permissions.test.tsx
+++ b/src/settings/permissions.test.tsx
@@ -44,8 +44,10 @@ describe("PermissionsScreen", () => {
       const frame = lastFrame() ?? "";
       expect(frame).toContain("Read files (current directory)");
       expect(frame).toContain("Write files (current directory)");
+      expect(frame).toContain("Remove files (current directory)");
       expect(frame).toContain("Read files (global)");
       expect(frame).toContain("Write files (global)");
+      expect(frame).toContain("Remove files (global)");
     });
 
     it("shows key instructions", () => {
@@ -79,8 +81,10 @@ describe("PermissionsScreen", () => {
       expect(frame).toContain("[✓] Read files (current directory)");
       // Optional permissions default to off
       expect(frame).toContain("[ ] Write files (current directory)");
+      expect(frame).toContain("[ ] Remove files (current directory)");
       expect(frame).toContain("[ ] Read files (global)");
       expect(frame).toContain("[ ] Write files (global)");
+      expect(frame).toContain("[ ] Remove files (global)");
     });
   });
 

--- a/src/settings/permissions.tsx
+++ b/src/settings/permissions.tsx
@@ -18,8 +18,10 @@ type PermissionKey = keyof Permissions;
 const PERMISSION_ITEMS: readonly { key: PermissionKey; label: string }[] = [
   { key: "cwdReadFile", label: "Read files (current directory)" },
   { key: "cwdWriteFile", label: "Write files (current directory)" },
+  { key: "cwdRemoveFile", label: "Remove files (current directory)" },
   { key: "globalReadFile", label: "Read files (global)" },
   { key: "globalWriteFile", label: "Write files (global)" },
+  { key: "globalRemoveFile", label: "Remove files (global)" },
 ];
 
 /** Key instructions for the permissions screen. */

--- a/src/settings/tools.test.tsx
+++ b/src/settings/tools.test.tsx
@@ -45,6 +45,7 @@ describe("ToolsScreen", () => {
       expect(frame).toContain("Glob");
       expect(frame).toContain("Grep");
       expect(frame).toContain("Read File");
+      expect(frame).toContain("Remove File");
       expect(frame).toContain("Run Command");
       expect(frame).toContain("Skill");
       expect(frame).toContain("Web Search");
@@ -105,6 +106,7 @@ describe("ToolsScreen", () => {
             glob: { enabled: true },
             grep: { enabled: true },
             readFile: { enabled: true },
+            removeFile: { enabled: true },
             runCommand: { enabled: true },
             skill: { enabled: true },
             webSearch: { enabled: true, apiKey: "tvly-123" },
@@ -112,8 +114,8 @@ describe("ToolsScreen", () => {
           },
         },
       });
-      // Navigate to Web Search (9th item) and toggle
-      for (let i = 0; i < 8; i++) {
+      // Navigate to Web Search (10th item) and toggle
+      for (let i = 0; i < 9; i++) {
         await stdin.write(keys.down);
       }
       await stdin.write(keys.space);
@@ -136,7 +138,7 @@ describe("ToolsScreen", () => {
     async function openWebSearchOptions(stdin: {
       write: (s: string) => Promise<void>;
     }) {
-      for (let i = 0; i < 8; i++) {
+      for (let i = 0; i < 9; i++) {
         await stdin.write(keys.down);
       }
       await stdin.write(keys.tab);

--- a/src/settings/tools.tsx
+++ b/src/settings/tools.tsx
@@ -28,6 +28,7 @@ const TOOL_ITEMS: readonly {
   { key: "glob", label: "Glob", hasOptions: false },
   { key: "grep", label: "Grep", hasOptions: false },
   { key: "readFile", label: "Read File", hasOptions: false },
+  { key: "removeFile", label: "Remove File", hasOptions: false },
   { key: "runCommand", label: "Run Command", hasOptions: false },
   { key: "skill", label: "Skill", hasOptions: false },
   { key: "webSearch", label: "Web Search", hasOptions: true },

--- a/src/test-utils/mock-fs.test.ts
+++ b/src/test-utils/mock-fs.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { ensureDir, fileExists, readFile, writeFile } from "../utils/fs";
+import {
+  ensureDir,
+  fileExists,
+  readFile,
+  removeFile,
+  writeFile,
+} from "../utils/fs";
 import { mockFs } from "./mock-fs";
 
 describe("mockFs", () => {
@@ -46,5 +52,17 @@ describe("mockFs", () => {
   it("ensureDir is a no-op", () => {
     state = mockFs({});
     expect(() => ensureDir("/test/dir")).not.toThrow();
+  });
+
+  it("removeFile deletes a file from the virtual fs", () => {
+    state = mockFs({ "/test/file.txt": "bye" });
+    removeFile("/test/file.txt");
+    expect(state.getFile("/test/file.txt")).toBeUndefined();
+    expect(fileExists("/test/file.txt")).toBe(false);
+  });
+
+  it("removeFile throws ENOENT for missing paths", () => {
+    state = mockFs({});
+    expect(() => removeFile("/missing.txt")).toThrow("ENOENT");
   });
 });

--- a/src/test-utils/mock-fs.ts
+++ b/src/test-utils/mock-fs.ts
@@ -78,6 +78,19 @@ export function mockFs(initialFiles: Record<string, string> = {}): MockFsState {
     .spyOn(fsUtils, "ensureDir")
     .mockImplementation(() => {});
 
+  const removeFileSpy = vi
+    .spyOn(fsUtils, "removeFile")
+    .mockImplementation((path) => {
+      if (!files.has(path)) {
+        const err = new Error(
+          `ENOENT: no such file or directory, unlink '${path}'`,
+        );
+        (err as NodeJS.ErrnoException).code = "ENOENT";
+        throw err;
+      }
+      files.delete(path);
+    });
+
   return {
     getFile(path: string) {
       return files.get(path);
@@ -93,6 +106,7 @@ export function mockFs(initialFiles: Record<string, string> = {}): MockFsState {
       listDirSpy.mockRestore();
       isDirectorySpy.mockRestore();
       ensureDirSpy.mockRestore();
+      removeFileSpy.mockRestore();
     },
   };
 }

--- a/src/test-utils/stub-context.ts
+++ b/src/test-utils/stub-context.ts
@@ -9,8 +9,10 @@ export function mockToolContext(
     permissions: {
       cwdReadFile: true,
       cwdWriteFile: true,
+      cwdRemoveFile: true,
       globalReadFile: false,
       globalWriteFile: false,
+      globalRemoveFile: false,
     },
     allowedCommands: [],
     confirm: vi.fn(async () => false),

--- a/src/tools/agent.test.ts
+++ b/src/tools/agent.test.ts
@@ -30,6 +30,7 @@ vi.mock("../config/file", () => ({
       glob: { enabled: true },
       grep: { enabled: true },
       readFile: { enabled: true },
+      removeFile: { enabled: true },
       runCommand: { enabled: true },
       skill: { enabled: true },
       webSearch: { enabled: false },

--- a/src/tools/permissions.test.ts
+++ b/src/tools/permissions.test.ts
@@ -32,8 +32,10 @@ describe("checkFilePermission", () => {
     return {
       cwdReadFile: false,
       cwdWriteFile: false,
+      cwdRemoveFile: false,
       globalReadFile: false,
       globalWriteFile: false,
+      globalRemoveFile: false,
       ...overrides,
     };
   }
@@ -116,6 +118,42 @@ describe("checkFilePermission", () => {
     });
   });
 
+  describe("cwd remove", () => {
+    it("returns allowed when cwdRemoveFile is true", () => {
+      expect(
+        checkFilePermission(cwdFile, "remove", perms({ cwdRemoveFile: true })),
+      ).toBe("allowed");
+    });
+
+    it("returns needs-confirmation when cwdRemoveFile is false", () => {
+      expect(
+        checkFilePermission(cwdFile, "remove", perms({ cwdRemoveFile: false })),
+      ).toBe("needs-confirmation");
+    });
+  });
+
+  describe("global remove", () => {
+    it("returns allowed when globalRemoveFile is true", () => {
+      expect(
+        checkFilePermission(
+          globalFile,
+          "remove",
+          perms({ globalRemoveFile: true }),
+        ),
+      ).toBe("allowed");
+    });
+
+    it("returns needs-confirmation when globalRemoveFile is false", () => {
+      expect(
+        checkFilePermission(
+          globalFile,
+          "remove",
+          perms({ globalRemoveFile: false }),
+        ),
+      ).toBe("needs-confirmation");
+    });
+  });
+
   describe("undefined permissions", () => {
     it("treats undefined cwdWriteFile as needs-confirmation", () => {
       const p = { cwdReadFile: true } as Permissions;
@@ -127,6 +165,20 @@ describe("checkFilePermission", () => {
     it("treats undefined globalReadFile as needs-confirmation", () => {
       const p = { cwdReadFile: true } as Permissions;
       expect(checkFilePermission(globalFile, "read", p)).toBe(
+        "needs-confirmation",
+      );
+    });
+
+    it("treats undefined cwdRemoveFile as needs-confirmation", () => {
+      const p = { cwdReadFile: true } as Permissions;
+      expect(checkFilePermission(cwdFile, "remove", p)).toBe(
+        "needs-confirmation",
+      );
+    });
+
+    it("treats undefined globalRemoveFile as needs-confirmation", () => {
+      const p = { cwdReadFile: true } as Permissions;
+      expect(checkFilePermission(globalFile, "remove", p)).toBe(
         "needs-confirmation",
       );
     });

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -5,7 +5,17 @@ import type { Permissions } from "../config/schema";
 export type PermissionResult = "allowed" | "needs-confirmation";
 
 /** File operation type for permission lookups. */
-export type FileOperation = "read" | "write";
+export type FileOperation = "read" | "write" | "remove";
+
+/** Maps a file operation to its cwd and global permission keys. */
+const PERMISSION_KEYS: Record<
+  FileOperation,
+  { cwd: keyof Permissions; global: keyof Permissions }
+> = {
+  read: { cwd: "cwdReadFile", global: "globalReadFile" },
+  write: { cwd: "cwdWriteFile", global: "globalWriteFile" },
+  remove: { cwd: "cwdRemoveFile", global: "globalRemoveFile" },
+};
 
 /** Returns true if the resolved file path is within the current working directory. */
 export function isPathWithinCwd(filePath: string): boolean {
@@ -24,12 +34,8 @@ export function checkFilePermission(
   permissions: Permissions,
 ): PermissionResult {
   const inCwd = isPathWithinCwd(filePath);
-
-  if (inCwd) {
-    const key = operation === "read" ? "cwdReadFile" : "cwdWriteFile";
-    return permissions[key] ? "allowed" : "needs-confirmation";
-  }
-
-  const key = operation === "read" ? "globalReadFile" : "globalWriteFile";
+  const key = inCwd
+    ? PERMISSION_KEYS[operation].cwd
+    : PERMISSION_KEYS[operation].global;
   return permissions[key] ? "allowed" : "needs-confirmation";
 }

--- a/src/tools/remove-file.test.ts
+++ b/src/tools/remove-file.test.ts
@@ -1,0 +1,221 @@
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mockFs } from "../test-utils/mock-fs";
+import { mockToolContext } from "../test-utils/stub-context";
+import { removeFileTool } from "./remove-file";
+
+describe("removeFileTool", () => {
+  it("has correct name and parameters", () => {
+    expect(removeFileTool.name).toBe("remove_file");
+    expect(removeFileTool.parameters).toHaveProperty("properties");
+    expect(removeFileTool.parameters).toHaveProperty("required");
+  });
+
+  describe("formatCall", () => {
+    it("returns the path argument", () => {
+      expect(removeFileTool.formatCall({ path: "./bar.ts" })).toBe("./bar.ts");
+    });
+
+    it("returns empty string when path is missing", () => {
+      expect(removeFileTool.formatCall({})).toBe("");
+    });
+  });
+
+  describe("execute", () => {
+    let fs: ReturnType<typeof mockFs>;
+
+    afterEach(() => {
+      fs.restore();
+    });
+
+    it("removes a file in cwd and returns ok", async () => {
+      const filePath = resolve("doomed.txt");
+      fs = mockFs({ [filePath]: "bye" });
+
+      const result = await removeFileTool.execute(
+        { path: "doomed.txt" },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("ok");
+      expect(result.output).toContain("Removed");
+      expect(result.output).toContain(filePath);
+      expect(fs.getFile(filePath)).toBeUndefined();
+    });
+
+    it("removes a file outside cwd when globalRemoveFile is true", async () => {
+      const filePath = "/tmp/outside.txt";
+      fs = mockFs({ [filePath]: "bye" });
+      const ctx = mockToolContext({
+        permissions: {
+          cwdReadFile: true,
+          cwdWriteFile: true,
+          cwdRemoveFile: true,
+          globalReadFile: false,
+          globalWriteFile: false,
+          globalRemoveFile: true,
+        },
+      });
+
+      const result = await removeFileTool.execute({ path: filePath }, ctx);
+
+      expect(result.status).toBe("ok");
+      expect(fs.getFile(filePath)).toBeUndefined();
+    });
+
+    it("returns error for missing path", async () => {
+      fs = mockFs();
+
+      const result = await removeFileTool.execute(
+        { path: "nope.txt" },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("error");
+      expect(result.output).toContain("does not exist");
+    });
+
+    it("returns error for directory path", async () => {
+      const dirPath = resolve("src");
+      fs = mockFs({ [`${dirPath}/foo.ts`]: "content" });
+
+      const result = await removeFileTool.execute(
+        { path: "src" },
+        mockToolContext(),
+      );
+
+      expect(result.status).toBe("error");
+      expect(result.output).toContain("is a directory");
+      expect(result.output).toContain("remove_dir");
+    });
+
+    describe("permissions", () => {
+      it("removes without confirmation when cwdRemoveFile is granted", async () => {
+        const filePath = resolve("allowed.txt");
+        fs = mockFs({ [filePath]: "bye" });
+        const confirm = vi.fn();
+        const ctx = mockToolContext({
+          permissions: {
+            cwdReadFile: true,
+            cwdWriteFile: false,
+            cwdRemoveFile: true,
+            globalReadFile: false,
+            globalWriteFile: false,
+            globalRemoveFile: false,
+          },
+          confirm,
+        });
+
+        const result = await removeFileTool.execute(
+          { path: "allowed.txt" },
+          ctx,
+        );
+
+        expect(result.status).toBe("ok");
+        expect(confirm).not.toHaveBeenCalled();
+        expect(fs.getFile(filePath)).toBeUndefined();
+      });
+
+      it("prompts for confirmation when cwdRemoveFile is not granted", async () => {
+        const filePath = resolve("restricted.txt");
+        fs = mockFs({ [filePath]: "bye" });
+        const confirm = vi.fn(async () => true);
+        const ctx = mockToolContext({
+          permissions: {
+            cwdReadFile: true,
+            cwdWriteFile: false,
+            cwdRemoveFile: false,
+            globalReadFile: false,
+            globalWriteFile: false,
+            globalRemoveFile: false,
+          },
+          confirm,
+        });
+
+        const result = await removeFileTool.execute(
+          { path: "restricted.txt" },
+          ctx,
+        );
+
+        expect(confirm).toHaveBeenCalledOnce();
+        expect(confirm).toHaveBeenCalledWith("Remove file?", {
+          label: "Remove file?",
+          detail: expect.stringContaining("restricted.txt"),
+        });
+        expect(result.status).toBe("ok");
+        expect(fs.getFile(filePath)).toBeUndefined();
+      });
+
+      it("returns denied and does not remove when user rejects confirmation", async () => {
+        const filePath = resolve("restricted.txt");
+        fs = mockFs({ [filePath]: "bye" });
+        const confirm = vi.fn(async () => false);
+        const ctx = mockToolContext({
+          permissions: {
+            cwdReadFile: true,
+            cwdWriteFile: false,
+            cwdRemoveFile: false,
+            globalReadFile: false,
+            globalWriteFile: false,
+            globalRemoveFile: false,
+          },
+          confirm,
+        });
+
+        const result = await removeFileTool.execute(
+          { path: "restricted.txt" },
+          ctx,
+        );
+
+        expect(confirm).toHaveBeenCalledOnce();
+        expect(result.status).toBe("denied");
+        expect(fs.getFile(filePath)).toBe("bye");
+      });
+
+      it("prompts for global file even when cwdRemoveFile is allowed", async () => {
+        const filePath = "/tmp/outside.txt";
+        fs = mockFs({ [filePath]: "bye" });
+        const confirm = vi.fn(async () => true);
+        const ctx = mockToolContext({
+          permissions: {
+            cwdReadFile: true,
+            cwdWriteFile: false,
+            cwdRemoveFile: true,
+            globalReadFile: false,
+            globalWriteFile: false,
+            globalRemoveFile: false,
+          },
+          confirm,
+        });
+
+        const result = await removeFileTool.execute({ path: filePath }, ctx);
+
+        expect(confirm).toHaveBeenCalledOnce();
+        expect(result.status).toBe("ok");
+        expect(fs.getFile(filePath)).toBeUndefined();
+      });
+
+      it("returns denied and leaves global file intact when user rejects", async () => {
+        const filePath = "/tmp/outside.txt";
+        fs = mockFs({ [filePath]: "bye" });
+        const confirm = vi.fn(async () => false);
+        const ctx = mockToolContext({
+          permissions: {
+            cwdReadFile: true,
+            cwdWriteFile: false,
+            cwdRemoveFile: true,
+            globalReadFile: false,
+            globalWriteFile: false,
+            globalRemoveFile: false,
+          },
+          confirm,
+        });
+
+        const result = await removeFileTool.execute({ path: filePath }, ctx);
+
+        expect(result.status).toBe("denied");
+        expect(fs.getFile(filePath)).toBe("bye");
+      });
+    });
+  });
+});

--- a/src/tools/remove-file.ts
+++ b/src/tools/remove-file.ts
@@ -1,0 +1,68 @@
+import { resolve } from "node:path";
+import { z } from "zod";
+import { fileExists, isDirectory, removeFile } from "../utils/fs";
+import { checkFilePermission } from "./permissions";
+import type { Tool, ToolContext, ToolResult } from "./types";
+import { denied, err, ok } from "./types";
+
+/** Zod schema for remove_file arguments. */
+const argsSchema = z.object({
+  path: z.string().min(1, "no file path provided"),
+});
+
+/** The remove_file tool definition. */
+export const removeFileTool: Tool = {
+  name: "remove_file",
+  displayName: "Remove File",
+  description: `Remove a file at the given path.
+
+- Only removes files. Use the remove_dir tool to remove directories.
+- Fails if the path does not exist.
+- Fails if the path is a directory.`,
+  parameters: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "The file path to remove (absolute or relative to cwd)",
+      },
+    },
+    required: ["path"],
+  },
+  argsSchema,
+  formatCall(args: Record<string, unknown>): string {
+    return String(args.path ?? "");
+  },
+  async execute(args: unknown, context: ToolContext): Promise<ToolResult> {
+    const parsed = argsSchema.parse(args);
+    const filePath = resolve(parsed.path);
+
+    if (isDirectory(filePath)) {
+      return err(`${filePath} is a directory, use remove_dir instead`);
+    }
+
+    if (!fileExists(filePath)) {
+      return err(`${filePath} does not exist`);
+    }
+
+    const permission = checkFilePermission(
+      filePath,
+      "remove",
+      context.permissions,
+    );
+
+    if (permission === "needs-confirmation") {
+      const approved = await context.confirm("Remove file?", {
+        label: "Remove file?",
+        detail: filePath,
+      });
+      if (!approved) {
+        return denied("The user denied this remove.");
+      }
+    }
+
+    removeFile(filePath);
+
+    return ok(`Removed ${filePath}`);
+  },
+};

--- a/src/utils/fs.test.ts
+++ b/src/utils/fs.test.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   readdirSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
@@ -15,6 +16,7 @@ import {
   isDirectory,
   listDir,
   readFile,
+  removeFile,
   writeFile,
 } from "./fs";
 
@@ -26,6 +28,7 @@ vi.mock("node:fs", () => ({
   statSync: vi.fn(),
   writeFileSync: vi.fn(),
   mkdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
 }));
 
 describe("fileExists", () => {
@@ -95,5 +98,12 @@ describe("ensureDir", () => {
   it("delegates to mkdirSync with recursive option", () => {
     ensureDir("/my/dir");
     expect(mkdirSync).toHaveBeenCalledWith("/my/dir", { recursive: true });
+  });
+});
+
+describe("removeFile", () => {
+  it("delegates to unlinkSync with the path", () => {
+    removeFile("/my/file");
+    expect(unlinkSync).toHaveBeenCalledWith("/my/file");
   });
 });

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   readdirSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 
@@ -43,4 +44,9 @@ export function isDirectory(path: string): boolean {
 /** Creates a directory and any missing parents. */
 export function ensureDir(path: string): void {
   mkdirSync(path, { recursive: true });
+}
+
+/** Removes a file at the given path. Throws if the path does not exist or is a directory. */
+export function removeFile(path: string): void {
+  unlinkSync(path);
 }


### PR DESCRIPTION
## Summary

Adds a new `remove_file` tool so the model can delete files directly without escaping into `run_command rm`. Mirrors the write_file shape with its own permission keys and confirmation flow.

## GitHub Issue

Closes #252

## What Changed

**New tool.** `remove_file` takes a `path` arg, errors clearly on missing paths or directory paths (directing the model to the future `remove_dir` tool), and uses the existing `checkFilePermission` helper for permission resolution. `FileOperation` is now `"read" | "write" | "remove"`, and the branching inside `checkFilePermission` was replaced with a small key-lookup table so the three operation types are handled uniformly.

**Permissions.** Two new permission keys — `cwdRemoveFile` and `globalRemoveFile` — follow the existing optional-boolean pattern. Both default to undefined/false so confirmation is prompted unless explicitly granted. Surfaced in the `/settings → Permissions` menu alongside the existing read/write toggles.

**Schema refactor.** `toolsSchema` now gives every tool a field-level `.default(...)` matching its enabled state. This means adding a new tool in the future is non-breaking for existing configs that already have a `tools:` block. Required `.prefault({})` instead of `.default({})` on the `configSchema.tools` side because zod v4's `.default()` expects the output type, not the input type.

**Settings UI.** New "Remove File" entry in the tools toggle list and two "Remove files (current directory / global)" entries in the permissions toggle list.

**Docs.** README tools table, permissions YAML example, and CONTRIBUTING's `src/` tree comment updated.

## Notes for Reviewers

- Check order in `execute` matters: `isDirectory` is checked before `fileExists` because the mock-fs treats a directory path as non-existent for file lookups but detects nested files for `isDirectory`. If this ordering flipped, the "errors on directory path" test would report "does not exist" instead.
- `stub-context.ts` (the test helper) now defaults `cwdRemoveFile: true` for convenience so happy-path tests don't need an explicit permission override. Permission-matrix tests still pin explicit values.
- Pairs with #251 (`remove_dir`), which is a separate follow-up.