### PR TITLE
fix(tools): disambiguate tool results sent to the LLM

### DIFF
--- a/src/agent/completion-loop.ts
+++ b/src/agent/completion-loop.ts
@@ -10,6 +10,7 @@ import {
   executeToolCalls,
 } from "../tools/execute-tool-calls";
 import type { ToolRegistry } from "../tools/registry";
+import { formatToolResultForLlm } from "../tools/tool-result-format";
 import type { ToolContext } from "../tools/types";
 
 /** Maximum number of nudge retries when the model returns an empty response. */
@@ -153,12 +154,14 @@ export async function runCompletionLoop(
     };
     currentMessages.push(assistantMessage);
 
-    // Convert display tool-result messages to provider format.
+    // Convert display tool-result messages to provider format. The status
+    // and format fields are collapsed into explicit markers in the content
+    // string so the LLM is not left inferring success/failure from prose.
     for (const msg of displayMessages) {
       if (msg.role === "tool-result") {
         currentMessages.push({
           role: "tool",
-          content: msg.output,
+          content: formatToolResultForLlm(msg.output, msg.status, msg.format),
           tool_call_id: msg.toolCallId,
         });
       }

--- a/src/provider/messages.ts
+++ b/src/provider/messages.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage as DisplayMessage } from "../chat/message";
+import { formatToolResultForLlm } from "../tools/tool-result-format";
 import { stripAnsi } from "../utils/strip-ansi";
 import type { ChatMessage as ProviderMessage, ToolCall } from "./client";
 
@@ -69,7 +70,7 @@ export function buildProviderMessages(
     if (msg.role === "tool-result") {
       result.push({
         role: "tool",
-        content: msg.output,
+        content: formatToolResultForLlm(msg.output, msg.status, msg.format),
         tool_call_id: msg.toolCallId,
       });
     }

--- a/src/tools/tool-result-format.test.ts
+++ b/src/tools/tool-result-format.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { formatToolResultForLlm } from "./tool-result-format";
+
+describe("formatToolResultForLlm", () => {
+  it("returns plain success output verbatim", () => {
+    expect(formatToolResultForLlm("hello world", "ok", "plain")).toBe(
+      "hello world",
+    );
+  });
+
+  it("returns empty plain success output verbatim", () => {
+    expect(formatToolResultForLlm("", "ok", "plain")).toBe("");
+  });
+
+  it("returns a plain result that contains the word 'error' verbatim (no spurious remapping)", () => {
+    expect(
+      formatToolResultForLlm("No error reported by the linter.", "ok", "plain"),
+    ).toBe("No error reported by the linter.");
+  });
+
+  it("prepends a natural-language preamble to diff-formatted successes", () => {
+    const diff = "@@ -1 +1 @@\n-old\n+new";
+    expect(formatToolResultForLlm(diff, "ok", "diff")).toBe(
+      `Edit applied successfully. Unified diff:\n${diff}`,
+    );
+  });
+
+  it("prefixes errors with 'ERROR:' regardless of format", () => {
+    expect(formatToolResultForLlm("file not found", "error", "plain")).toBe(
+      "ERROR: file not found",
+    );
+    expect(
+      formatToolResultForLlm("edit 1: oldString not found", "error", "diff"),
+    ).toBe("ERROR: edit 1: oldString not found");
+  });
+
+  it("prefixes denials with 'DENIED:' regardless of format", () => {
+    expect(
+      formatToolResultForLlm("The user denied this edit.", "denied", "plain"),
+    ).toBe("DENIED: The user denied this edit.");
+    expect(formatToolResultForLlm("rejected", "denied", "diff")).toBe(
+      "DENIED: rejected",
+    );
+  });
+
+  it("error prefix wins over diff preamble when status is error and format is diff", () => {
+    expect(formatToolResultForLlm("@@ -1 +1 @@", "error", "diff")).toBe(
+      "ERROR: @@ -1 +1 @@",
+    );
+  });
+});

--- a/src/tools/tool-result-format.ts
+++ b/src/tools/tool-result-format.ts
@@ -1,0 +1,28 @@
+import type { ToolResultFormat, ToolResultStatus } from "./types";
+
+/**
+ * Formats a tool result's output for the LLM, adding explicit status markers
+ * only where the raw text would be ambiguous.
+ *
+ * Errors and denials are prefixed so the LLM cannot mistake them for normal
+ * informational output, and absence of those prefixes implicitly signals
+ * success. Successful diff results get a natural-language preamble because a
+ * bare unified-diff does not obviously read as "the edit worked" to weaker
+ * models, and we have observed them reissuing identical edits after a
+ * successful one.
+ *
+ * Plain-text successes are returned verbatim: wrapping them in a "SUCCESS:"
+ * prefix would create contradictions like "SUCCESS: No results found" that
+ * confuse the LLM more than they help.
+ */
+export function formatToolResultForLlm(
+  output: string,
+  status: ToolResultStatus,
+  format: ToolResultFormat,
+): string {
+  if (status === "error") return `ERROR: ${output}`;
+  if (status === "denied") return `DENIED: ${output}`;
+  if (format === "diff")
+    return `Edit applied successfully. Unified diff:\n${output}`;
+  return output;
+}


### PR DESCRIPTION
## Summary

Tool results previously reached the LLM as a raw `output` string with no status or format signal. Successful `edit_file` calls sent just a unified diff, and weaker models sometimes failed to parse it as a success confirmation and then reissued the exact same edit — the second call then failed because `oldString` was already replaced. This PR adds a disambiguating transformation applied at the provider boundary.

## GitHub Issue

N/A

## What Changed

New helper `formatToolResultForLlm(output, status, format)` in `src/tools/tool-result-format.ts` that adds explicit markers only where the raw text is ambiguous:

- `error` → `ERROR: <output>` so the LLM cannot mistake an error message for informational output.
- `denied` → `DENIED: <output>` so the LLM knows the user said no and does not retry.
- `ok` + `diff` → `Edit applied successfully. Unified diff:\n<output>` so the success of a file edit is unambiguously acknowledged in prose, not inferred from diff syntax.
- `ok` + `plain` → passed through verbatim.

Plain successes are deliberately not prefixed. Wrapping them in `SUCCESS:` would create contradictions like `SUCCESS: No results found` (from grep) or `SUCCESS: Exit code: 0\n<empty>` (from run_command) that confuse the model more than they help. The convention is: absence of `ERROR:`/`DENIED:` implicitly signals success.

The helper is wired into both conversion sites:
- \`src/agent/completion-loop.ts\` — live completion loop
- \`src/provider/messages.ts\` — rebuilding provider messages from persisted chat history

`src/tools/types.ts` is deliberately left untouched. Prefixing inside the \`ok\`/\`err\`/\`denied\` factories would pollute \`ToolResult.output\`, which is rendered directly by \`ToolResultMessageView\` (\`chat-list.tsx:140\`) — it would break \`DiffView\`'s diff parser and render redundant literal \"ERROR: \" text in the already-red-styled error rows. Keeping the transformation at the provider boundary leaves the UI path clean.

## Notes for Reviewers

- This is not a silver bullet — weak models may still occasionally double-fire tool calls. The next lever if it proves insufficient is duplicate-call detection in \`execute-tool-calls.ts\`.
- Considered and rejected: adding an \`is_error\` field to the provider tool message. OpenAI's chat-completions tool-message shape does not support it (only Anthropic's Messages API does, via \`tool_result\` blocks, which is a different provider adapter entirely).
- 7 new unit tests colocated in \`tool-result-format.test.ts\` cover every branch, including the edge case where a plain \`ok\` result contains the word \"error\" (e.g. \"No error reported by the linter\") and must not be remapped.