### PR TITLE
feat(mcp): OAuth 2.1 authentication for HTTP MCP servers

### DIFF
--- a/mock-mcps/http-oauth.mjs
+++ b/mock-mcps/http-oauth.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+// Mock OAuth-gated HTTP MCP server used by src/mcp/oauth.integration.test.ts.
+//
+// Implements the minimal subset of the MCP OAuth flow:
+//
+//   1. `POST /mcp` without Authorization → 401 + WWW-Authenticate header
+//   2. `GET /.well-known/oauth-protected-resource` (RFC 9728)
+//   3. `GET /.well-known/oauth-authorization-server` (RFC 8414)
+//   4. `POST /register` (RFC 7591 DCR) — accepts any metadata, returns a
+//      fixed client_id
+//   5. `GET /authorize` — issues a code and redirects to the loopback
+//      redirect_uri carrying `?code=...&state=...`
+//   6. `POST /token` — exchanges the code for a bearer token
+//   7. `POST /mcp` with a valid bearer → JSON-RPC server matching
+//      `mock-mcps/http.mjs`
+//
+// The mock also supports a test-only header `x-force-401` so the
+// mid-session reauth path can be exercised: any MCP request carrying that
+// header returns 401 even with a valid bearer, letting the caller drive the
+// retry loop.
+
+import { createServer } from "http";
+
+const PORT = Number(process.env.PORT || 9879);
+const ISSUER = `http://localhost:${PORT}`;
+
+const SERVER_INFO = { name: "mock-oauth-http-server", version: "1.0.0" };
+const PROTOCOL_VERSION = "2025-03-26";
+
+const TOOLS = [
+  {
+    name: "get_weather",
+    description: "Returns fake weather data for a city",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    },
+  },
+];
+
+const VALID_TOKEN = "test-access-token";
+const CLIENT_ID = "test-client-id";
+
+/** Authorization codes issued by /authorize, mapped to their state value. */
+const issuedCodes = new Map();
+
+/** When true, the next /mcp request returns 401 and auto-clears the flag. */
+let forceNext401 = false;
+
+function jsonResponse(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function handleToolCall(name, args) {
+  if (name === "get_weather") {
+    return {
+      content: [{ type: "text", text: `Weather in ${args.city}: 14°C` }],
+      isError: false,
+    };
+  }
+  return {
+    content: [{ type: "text", text: `Unknown tool: ${name}` }],
+    isError: true,
+  };
+}
+
+function handleRpc(msg) {
+  switch (msg.method) {
+    case "initialize":
+      return {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      };
+    case "tools/list":
+      return { tools: TOOLS };
+    case "tools/call":
+      return handleToolCall(msg.params.name, msg.params.arguments);
+    default:
+      return undefined;
+  }
+}
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => resolve(body));
+  });
+}
+
+async function handleMcpPost(req, res) {
+  const auth = req.headers.authorization;
+  if (forceNext401) {
+    forceNext401 = false;
+    res.writeHead(401, {
+      "content-type": "application/json",
+      "www-authenticate": `Bearer resource_metadata="${ISSUER}/.well-known/oauth-protected-resource"`,
+    });
+    res.end(JSON.stringify({ error: "forced" }));
+    return;
+  }
+  if (auth !== `Bearer ${VALID_TOKEN}`) {
+    res.writeHead(401, {
+      "content-type": "application/json",
+      "www-authenticate": `Bearer resource_metadata="${ISSUER}/.well-known/oauth-protected-resource"`,
+    });
+    res.end(JSON.stringify({ error: "unauthorized" }));
+    return;
+  }
+
+  const body = await readBody(req);
+  let msg;
+  try {
+    msg = JSON.parse(body);
+  } catch {
+    jsonResponse(res, 400, {
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32700, message: "Parse error" },
+    });
+    return;
+  }
+
+  // Notifications have no id — acknowledge with 204.
+  if (msg.id === undefined) {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const result = handleRpc(msg);
+  if (result !== undefined) {
+    jsonResponse(res, 200, { jsonrpc: "2.0", id: msg.id, result });
+    return;
+  }
+  jsonResponse(res, 200, {
+    jsonrpc: "2.0",
+    id: msg.id,
+    error: { code: -32601, message: `Method not found: ${msg.method}` },
+  });
+}
+
+function handleProtectedResource(res) {
+  jsonResponse(res, 200, {
+    resource: ISSUER,
+    authorization_servers: [ISSUER],
+  });
+}
+
+function handleAuthServerMetadata(res) {
+  jsonResponse(res, 200, {
+    issuer: ISSUER,
+    authorization_endpoint: `${ISSUER}/authorize`,
+    token_endpoint: `${ISSUER}/token`,
+    registration_endpoint: `${ISSUER}/register`,
+    response_types_supported: ["code"],
+    code_challenge_methods_supported: ["S256"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
+  });
+}
+
+async function handleRegister(req, res) {
+  await readBody(req); // ignore the posted metadata — any input is accepted
+  jsonResponse(res, 201, {
+    client_id: CLIENT_ID,
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    redirect_uris: [],
+    token_endpoint_auth_method: "none",
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+  });
+}
+
+function handleAuthorize(req, res) {
+  const url = new URL(req.url, ISSUER);
+  const redirectUri = url.searchParams.get("redirect_uri");
+  const state = url.searchParams.get("state") ?? "";
+  if (!redirectUri) {
+    res.writeHead(400);
+    res.end("missing redirect_uri");
+    return;
+  }
+  // Issue a fresh one-time code and redirect the user back to the client.
+  const code = `code-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  issuedCodes.set(code, state);
+  const target = new URL(redirectUri);
+  target.searchParams.set("code", code);
+  target.searchParams.set("state", state);
+  res.writeHead(302, { location: target.toString() });
+  res.end();
+}
+
+async function handleToken(req, res) {
+  const body = await readBody(req);
+  const params = new URLSearchParams(body);
+  const grantType = params.get("grant_type");
+  const code = params.get("code");
+  if (grantType !== "authorization_code") {
+    jsonResponse(res, 400, { error: "unsupported_grant_type" });
+    return;
+  }
+  if (!code || !issuedCodes.has(code)) {
+    jsonResponse(res, 400, { error: "invalid_grant" });
+    return;
+  }
+  issuedCodes.delete(code);
+  jsonResponse(res, 200, {
+    access_token: VALID_TOKEN,
+    token_type: "Bearer",
+    expires_in: 3600,
+  });
+}
+
+function handleForceNext401(res) {
+  forceNext401 = true;
+  jsonResponse(res, 200, { ok: true });
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url ?? "/", ISSUER);
+
+  if (req.method === "GET" && url.pathname === "/.well-known/oauth-protected-resource") {
+    return handleProtectedResource(res);
+  }
+  if (req.method === "GET" && url.pathname === "/.well-known/oauth-authorization-server") {
+    return handleAuthServerMetadata(res);
+  }
+  if (req.method === "POST" && url.pathname === "/register") {
+    return handleRegister(req, res);
+  }
+  if (req.method === "GET" && url.pathname === "/authorize") {
+    return handleAuthorize(req, res);
+  }
+  if (req.method === "POST" && url.pathname === "/token") {
+    return handleToken(req, res);
+  }
+  if (req.method === "POST" && url.pathname === "/__force_next_401") {
+    return handleForceNext401(res);
+  }
+  if (req.method === "POST" && (url.pathname === "/" || url.pathname === "/mcp")) {
+    return handleMcpPost(req, res);
+  }
+
+  res.writeHead(404, { "content-type": "text/plain" });
+  res.end("Not Found");
+});
+
+server.listen(PORT, () => {
+  console.log(`Mock OAuth MCP HTTP server listening on ${ISSUER}`);
+});

--- a/src/chat/chat.test.tsx
+++ b/src/chat/chat.test.tsx
@@ -15,6 +15,7 @@ import { keys } from "../test-utils/keys";
 import { setupMsw, http, HttpResponse } from "../test-utils/msw";
 import { GLOBAL_CONFIG_PATH } from "../config/file";
 import { useConfig } from "../config/hook";
+import { type McpAuthStore, createMcpAuthStore } from "../mcp/mcp-auth-store";
 import { writeFile } from "../utils/fs";
 import { Chat } from "./chat";
 
@@ -37,31 +38,6 @@ vi.mock("./open-pager", () => ({
   openPager: vi.fn(),
 }));
 
-// Share a single McpAuthStore instance across all useMcp calls in the test
-// so the tests can push/inspect entries via the same reference the Chat
-// component subscribes to.
-vi.mock("../mcp/mcp-auth-store", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../mcp/mcp-auth-store")>();
-  let shared: ReturnType<typeof actual.createMcpAuthStore> | null = null;
-  return {
-    ...actual,
-    createMcpAuthStore: () => {
-      if (!shared) shared = actual.createMcpAuthStore();
-      return shared;
-    },
-    /** Test-only hook to reset the shared instance between tests. */
-    __resetAuthStoreForTests: () => {
-      shared = null;
-    },
-  };
-});
-
-const { createMcpAuthStore, __resetAuthStoreForTests } = (await import(
-  "../mcp/mcp-auth-store"
-)) as typeof import("../mcp/mcp-auth-store") & {
-  __resetAuthStoreForTests: () => void;
-};
-
 const { openPager } = await import("./open-pager");
 
 const COLUMNS = 40;
@@ -83,7 +59,6 @@ const ollamaShowHandler = http.post("http://localhost:11434/api/show", () =>
 describe("Chat", () => {
   afterEach(() => {
     setColumns(undefined);
-    __resetAuthStoreForTests();
   });
 
   /** Empty tool registry for tests that don't need tools. */
@@ -92,14 +67,18 @@ describe("Chat", () => {
   /** Empty skill registry for tests that don't need skills. */
   const emptySkillRegistry = createSkillRegistry();
 
-  /** Renders Chat with a fixed terminal width and optional commandRegistry. */
-  function renderChat(commandRegistry?: CommandRegistry) {
+  /** Renders Chat with a fixed terminal width and optional overrides. */
+  function renderChat(
+    commandRegistry?: CommandRegistry,
+    authStore?: McpAuthStore,
+  ) {
     setColumns(COLUMNS);
     return renderInk(
       <Chat
         commandRegistry={commandRegistry}
         skillRegistry={emptySkillRegistry}
         toolRegistry={emptyToolRegistry}
+        authStore={authStore}
       />,
     );
   }
@@ -2136,7 +2115,7 @@ describe("Chat", () => {
         serverName: "github",
         authUrl: "https://auth.example.com/authorize?state=abc",
       });
-      const { lastFrame } = renderChat();
+      const { lastFrame } = renderChat(undefined, authStore);
       // Give React a tick to subscribe + render.
       await new Promise((r) => setTimeout(r, 50));
       const frame = lastFrame() ?? "";
@@ -2151,7 +2130,7 @@ describe("Chat", () => {
         authUrl: "https://auth.example.com/authorize?state=abc",
       });
       const caught = handle.pending.catch((err) => err);
-      const { stdin } = renderChat();
+      const { stdin } = renderChat(undefined, authStore);
       await new Promise((r) => setTimeout(r, 50));
       await stdin.write(keys.escape);
       await new Promise((r) => setTimeout(r, 50));

--- a/src/chat/chat.test.tsx
+++ b/src/chat/chat.test.tsx
@@ -37,6 +37,31 @@ vi.mock("./open-pager", () => ({
   openPager: vi.fn(),
 }));
 
+// Share a single McpAuthStore instance across all useMcp calls in the test
+// so the tests can push/inspect entries via the same reference the Chat
+// component subscribes to.
+vi.mock("../mcp/mcp-auth-store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../mcp/mcp-auth-store")>();
+  let shared: ReturnType<typeof actual.createMcpAuthStore> | null = null;
+  return {
+    ...actual,
+    createMcpAuthStore: () => {
+      if (!shared) shared = actual.createMcpAuthStore();
+      return shared;
+    },
+    /** Test-only hook to reset the shared instance between tests. */
+    __resetAuthStoreForTests: () => {
+      shared = null;
+    },
+  };
+});
+
+const { createMcpAuthStore, __resetAuthStoreForTests } = (await import(
+  "../mcp/mcp-auth-store"
+)) as typeof import("../mcp/mcp-auth-store") & {
+  __resetAuthStoreForTests: () => void;
+};
+
 const { openPager } = await import("./open-pager");
 
 const COLUMNS = 40;
@@ -58,6 +83,7 @@ const ollamaShowHandler = http.post("http://localhost:11434/api/show", () =>
 describe("Chat", () => {
   afterEach(() => {
     setColumns(undefined);
+    __resetAuthStoreForTests();
   });
 
   /** Empty tool registry for tests that don't need tools. */
@@ -2100,6 +2126,39 @@ describe("Chat", () => {
         "Provider or model is no longer configured",
       );
       expect(strandedExecute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mcp auth modal", () => {
+    it("renders the auth modal when the store has a pending entry", async () => {
+      const authStore = createMcpAuthStore();
+      authStore.push({
+        serverName: "github",
+        authUrl: "https://auth.example.com/authorize?state=abc",
+      });
+      const { lastFrame } = renderChat();
+      // Give React a tick to subscribe + render.
+      await new Promise((r) => setTimeout(r, 50));
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("Authorize MCP server: github");
+      expect(frame).toContain("https://auth.example.com/authorize?state=abc");
+    });
+
+    it("cancels the pending auth via Esc, settling the store entry", async () => {
+      const authStore = createMcpAuthStore();
+      const handle = authStore.push({
+        serverName: "github",
+        authUrl: "https://auth.example.com/authorize?state=abc",
+      });
+      const caught = handle.pending.catch((err) => err);
+      const { stdin } = renderChat();
+      await new Promise((r) => setTimeout(r, 50));
+      await stdin.write(keys.escape);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(authStore.peek()).toBeNull();
+      const err = await caught;
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/authorization cancelled/);
     });
   });
 

--- a/src/chat/chat.tsx
+++ b/src/chat/chat.tsx
@@ -10,6 +10,7 @@ import {
 import { isCommand } from "../commands/is-command";
 import type { ImageAttachment } from "../images/clipboard";
 import { McpAuthModal } from "../mcp/mcp-auth-modal";
+import type { McpAuthStore } from "../mcp/mcp-auth-store";
 import { useMcp } from "../mcp/use-mcp";
 import { isSkill, parseSkillInput } from "../skills/utils";
 import type { SkillRegistry } from "../skills/registry";
@@ -75,6 +76,8 @@ interface UseChatProps {
   commandRegistry?: CommandRegistry;
   skillRegistry: SkillRegistry;
   toolRegistry: ToolRegistry;
+  /** Optional pre-built MCP auth store — injected by tests so they can push entries that the rendered modal subscribes to. */
+  authStore?: McpAuthStore;
 }
 
 /** Manages mode switching between input, history, and takeover screens. */
@@ -149,6 +152,7 @@ function useChat(props: UseChatProps) {
   const { authStore } = useMcp({
     toolRegistry: props.toolRegistry,
     onConnectionError: handleMcpConnectionError,
+    authStore: props.authStore,
   });
 
   /** Handles an invoke result — either enters takeover mode or appends an inline message. */
@@ -569,6 +573,8 @@ interface ChatProps {
   commandRegistry?: CommandRegistry;
   skillRegistry: SkillRegistry;
   toolRegistry: ToolRegistry;
+  /** Optional pre-built MCP auth store — injected by tests. */
+  authStore?: McpAuthStore;
 }
 
 /** Chat router — renders ChatInput, MessageHistory, or takeover content based on mode. */
@@ -601,6 +607,7 @@ export function Chat(props: ChatProps) {
     commandRegistry: props.commandRegistry,
     skillRegistry: props.skillRegistry,
     toolRegistry: props.toolRegistry,
+    authStore: props.authStore,
   });
 
   const pendingAuth = useSyncExternalStore(

--- a/src/chat/chat.tsx
+++ b/src/chat/chat.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { isCommand } from "../commands/is-command";
 import type { ImageAttachment } from "../images/clipboard";
+import { McpAuthModal } from "../mcp/mcp-auth-modal";
 import { useMcp } from "../mcp/use-mcp";
 import { isSkill, parseSkillInput } from "../skills/utils";
 import type { SkillRegistry } from "../skills/registry";
@@ -145,7 +146,7 @@ function useChat(props: UseChatProps) {
     },
     [appendMessage],
   );
-  useMcp({
+  const { authStore } = useMcp({
     toolRegistry: props.toolRegistry,
     onConnectionError: handleMcpConnectionError,
   });
@@ -559,6 +560,7 @@ function useChat(props: UseChatProps) {
     handleConfirmResult,
     handleAskResult,
     handlePager,
+    authStore,
   };
 }
 
@@ -594,11 +596,18 @@ export function Chat(props: ChatProps) {
     handleConfirmResult,
     handleAskResult,
     handlePager,
+    authStore,
   } = useChat({
     commandRegistry: props.commandRegistry,
     skillRegistry: props.skillRegistry,
     toolRegistry: props.toolRegistry,
   });
+
+  const pendingAuth = useSyncExternalStore(
+    authStore.subscribe,
+    authStore.peek,
+    authStore.peek,
+  );
 
   return (
     <>
@@ -636,32 +645,44 @@ export function Chat(props: ChatProps) {
           onExit={handleExit}
         />
       )}
-      {mode.kind === "input" && currentPrompt?.kind === "confirm" && (
-        <>
-          {currentPrompt.diff && (
-            <Box paddingBottom={1}>
-              <Indent>
-                <DiffView output={currentPrompt.diff} />
-              </Indent>
-            </Box>
-          )}
-          <ConfirmPrompt
-            key={currentPrompt.id}
-            onResult={handleConfirmResult}
-            label={currentPrompt.label ?? currentPrompt.message}
-            detail={currentPrompt.detail}
-          />
-        </>
-      )}
-      {mode.kind === "input" && currentPrompt?.kind === "ask" && (
-        <AskPrompt
-          key={currentPrompt.id}
-          question={currentPrompt.question}
-          options={currentPrompt.options}
-          onResult={handleAskResult}
+      {mode.kind === "input" && pendingAuth && (
+        <McpAuthModal
+          key={pendingAuth.id}
+          serverName={pendingAuth.serverName}
+          authUrl={pendingAuth.authUrl}
+          onCancel={() => authStore.cancel(pendingAuth.id)}
         />
       )}
-      {mode.kind === "input" && !currentPrompt && (
+      {mode.kind === "input" &&
+        !pendingAuth &&
+        currentPrompt?.kind === "confirm" && (
+          <>
+            {currentPrompt.diff && (
+              <Box paddingBottom={1}>
+                <Indent>
+                  <DiffView output={currentPrompt.diff} />
+                </Indent>
+              </Box>
+            )}
+            <ConfirmPrompt
+              key={currentPrompt.id}
+              onResult={handleConfirmResult}
+              label={currentPrompt.label ?? currentPrompt.message}
+              detail={currentPrompt.detail}
+            />
+          </>
+        )}
+      {mode.kind === "input" &&
+        !pendingAuth &&
+        currentPrompt?.kind === "ask" && (
+          <AskPrompt
+            key={currentPrompt.id}
+            question={currentPrompt.question}
+            options={currentPrompt.options}
+            onResult={handleAskResult}
+          />
+        )}
+      {mode.kind === "input" && !pendingAuth && !currentPrompt && (
         <ChatInput
           onMessage={handleMessage}
           onUp={handleUp}

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -11,6 +11,9 @@ export const GLOBAL_CONFIG_PATH = resolve(homedir(), ".tomo", "config.yaml");
 /** Path to the local config file (.tomo/config.yaml in cwd). */
 export const LOCAL_CONFIG_PATH = resolve(process.cwd(), ".tomo", "config.yaml");
 
+/** Directory holding per-server OAuth state files for HTTP MCP connections. */
+export const MCP_OAUTH_DIR = resolve(homedir(), ".tomo", "mcp-oauth");
+
 /** Default global config YAML written on first run. */
 const DEFAULT_CONFIG_YAML = `activeProvider: null
 activeModel: null

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   configSchema,
   mcpConnectionSchema,
+  mcpHttpAuthSchema,
   mcpSchema,
   permissionsSchema,
   providerSchema,
@@ -215,6 +216,103 @@ describe("mcpConnectionSchema", () => {
 
   it("rejects stdio connection without command", () => {
     expect(() => mcpConnectionSchema.parse({ transport: "stdio" })).toThrow();
+  });
+
+  it("parses an http connection with an empty auth block", () => {
+    const result = mcpConnectionSchema.parse({
+      transport: "http",
+      url: "https://mcp.example.com/mcp",
+      auth: {},
+    });
+    if (result.transport === "http") {
+      expect(result.auth).toEqual({});
+    }
+  });
+
+  it("parses an http connection with a pre-registered clientId", () => {
+    const result = mcpConnectionSchema.parse({
+      transport: "http",
+      url: "https://mcp.example.com/mcp",
+      auth: { clientId: "tomo-client" },
+    });
+    if (result.transport === "http") {
+      expect(result.auth?.clientId).toBe("tomo-client");
+      expect(result.auth?.clientSecret).toBeUndefined();
+    }
+  });
+
+  it("parses an http connection with clientId, clientSecret and scope", () => {
+    const result = mcpConnectionSchema.parse({
+      transport: "http",
+      url: "https://mcp.example.com/mcp",
+      auth: {
+        clientId: "tomo-client",
+        clientSecret: "s3cret",
+        scope: "read write",
+      },
+    });
+    if (result.transport === "http") {
+      expect(result.auth).toEqual({
+        clientId: "tomo-client",
+        clientSecret: "s3cret",
+        scope: "read write",
+      });
+    }
+  });
+
+  it("parses an http connection with both headers and auth", () => {
+    const result = mcpConnectionSchema.parse({
+      transport: "http",
+      url: "https://mcp.example.com/mcp",
+      headers: { "User-Agent": "tomo" },
+      auth: { clientId: "tomo-client" },
+    });
+    if (result.transport === "http") {
+      expect(result.headers).toEqual({ "User-Agent": "tomo" });
+      expect(result.auth?.clientId).toBe("tomo-client");
+    }
+  });
+
+  it("rejects an http connection with clientSecret but no clientId", () => {
+    expect(() =>
+      mcpConnectionSchema.parse({
+        transport: "http",
+        url: "https://mcp.example.com/mcp",
+        auth: { clientSecret: "s3cret" },
+      }),
+    ).toThrow(/clientSecret requires clientId/);
+  });
+});
+
+describe("mcpHttpAuthSchema", () => {
+  it("parses an empty auth block", () => {
+    expect(mcpHttpAuthSchema.parse({})).toEqual({});
+  });
+
+  it("parses scope without clientId", () => {
+    const result = mcpHttpAuthSchema.parse({ scope: "read" });
+    expect(result.scope).toBe("read");
+    expect(result.clientId).toBeUndefined();
+  });
+
+  it("rejects an empty clientId string", () => {
+    expect(() => mcpHttpAuthSchema.parse({ clientId: "" })).toThrow();
+  });
+
+  it("rejects an empty clientSecret string", () => {
+    expect(() =>
+      mcpHttpAuthSchema.parse({ clientId: "x", clientSecret: "" }),
+    ).toThrow();
+  });
+
+  it("rejects an empty scope string", () => {
+    expect(() => mcpHttpAuthSchema.parse({ scope: "" })).toThrow();
+  });
+
+  it("rejects clientSecret without clientId", () => {
+    expect(() => mcpHttpAuthSchema.parse({ clientSecret: "s3cret" })).toThrow(
+      /clientSecret requires clientId/,
+    );
   });
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -81,11 +81,24 @@ export const mcpStdioConnectionSchema = z.object({
   enabled: z.boolean().default(true),
 });
 
+/** Schema for OAuth configuration on an HTTP MCP connection. */
+export const mcpHttpAuthSchema = z
+  .object({
+    clientId: z.string().min(1).optional(),
+    clientSecret: z.string().min(1).optional(),
+    scope: z.string().min(1).optional(),
+  })
+  .refine((v) => !(v.clientSecret && !v.clientId), {
+    message: "clientSecret requires clientId",
+    path: ["clientSecret"],
+  });
+
 /** Schema for an MCP HTTP connection. */
 export const mcpHttpConnectionSchema = z.object({
   transport: z.literal("http"),
   url: z.url("url must be a valid URL"),
   headers: z.record(z.string(), z.string()).optional(),
+  auth: mcpHttpAuthSchema.optional(),
   enabled: z.boolean().default(true),
 });
 
@@ -149,6 +162,9 @@ export type Tools = z.infer<typeof toolsSchema>;
 
 /** Agent spawning configuration. */
 export type Agents = z.infer<typeof agentsSchema>;
+
+/** OAuth configuration for an HTTP MCP connection. */
+export type McpHttpAuth = z.infer<typeof mcpHttpAuthSchema>;
 
 /** An MCP connection (stdio or HTTP). */
 export type McpConnection = z.infer<typeof mcpConnectionSchema>;

--- a/src/mcp/auth-retry.test.ts
+++ b/src/mcp/auth-retry.test.ts
@@ -1,0 +1,102 @@
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { describe, expect, it, vi } from "vitest";
+import { type AuthRetryContext, withAuthRetry } from "./auth-retry";
+
+/** Builds an `AuthRetryContext` whose methods are all vitest spies. */
+function makeContext(
+  overrides: Partial<AuthRetryContext> = {},
+): AuthRetryContext {
+  return {
+    pendingCode: vi.fn(() => null),
+    clearPending: vi.fn(),
+    finishAuth: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("withAuthRetry", () => {
+  it("returns the operation result when it succeeds on the first try", async () => {
+    const context = makeContext();
+    const op = vi.fn(async () => "ok");
+
+    const result = await withAuthRetry(context, op);
+
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(context.finishAuth).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-UnauthorizedError errors without retrying", async () => {
+    const context = makeContext();
+    const boom = new Error("boom");
+    const op = vi.fn(async () => {
+      throw boom;
+    });
+
+    await expect(withAuthRetry(context, op)).rejects.toBe(boom);
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(context.finishAuth).not.toHaveBeenCalled();
+  });
+
+  it("rethrows the UnauthorizedError when no auth flow is pending", async () => {
+    const unauthorized = new UnauthorizedError("no tokens");
+    const context = makeContext({ pendingCode: vi.fn(() => null) });
+    const op = vi.fn(async () => {
+      throw unauthorized;
+    });
+
+    await expect(withAuthRetry(context, op)).rejects.toBe(unauthorized);
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(context.finishAuth).not.toHaveBeenCalled();
+  });
+
+  it("awaits the pending code, exchanges it, and retries the operation on UnauthorizedError", async () => {
+    const pending = Promise.resolve("the-code");
+    const context = makeContext({
+      pendingCode: vi.fn(() => pending),
+    });
+    const op = vi.fn(async () => {
+      if (op.mock.calls.length === 1) throw new UnauthorizedError("401");
+      return "retried-ok";
+    });
+
+    const result = await withAuthRetry(context, op);
+
+    expect(result).toBe("retried-ok");
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(context.finishAuth).toHaveBeenCalledWith("the-code");
+    expect(context.clearPending).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a rejection from the pending-code promise", async () => {
+    const pending = Promise.reject(new Error("loopback wait aborted"));
+    const context = makeContext({ pendingCode: vi.fn(() => pending) });
+    const op = vi.fn(async () => {
+      throw new UnauthorizedError("401");
+    });
+
+    await expect(withAuthRetry(context, op)).rejects.toThrow(
+      /loopback wait aborted/,
+    );
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(context.finishAuth).not.toHaveBeenCalled();
+  });
+
+  it("propagates a rejection from finishAuth without retrying", async () => {
+    const context = makeContext({
+      pendingCode: vi.fn(() => Promise.resolve("code")),
+      finishAuth: vi.fn(async () => {
+        throw new Error("token exchange failed");
+      }),
+    });
+    const op = vi.fn(async () => {
+      throw new UnauthorizedError("401");
+    });
+
+    await expect(withAuthRetry(context, op)).rejects.toThrow(
+      /token exchange failed/,
+    );
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(context.clearPending).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/mcp/auth-retry.ts
+++ b/src/mcp/auth-retry.ts
@@ -1,0 +1,46 @@
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+
+/** State the retry wrapper needs from the owning MCP client closure. */
+export interface AuthRetryContext {
+  /**
+   * Returns the currently pending authorization-code promise, or `null` if no
+   * OAuth flow is in progress. The owning client sets this in the provider's
+   * `onRedirect` callback before the SDK throws `UnauthorizedError`.
+   */
+  pendingCode: () => Promise<string> | null;
+  /**
+   * Clears the pending auth state after a successful code exchange so a
+   * subsequent `UnauthorizedError` (e.g. mid-session) can trigger a fresh
+   * flow rather than reusing a consumed code.
+   */
+  clearPending: () => void;
+  /** Exchanges the authorization code for tokens via the underlying transport. */
+  finishAuth: (code: string) => Promise<void>;
+}
+
+/**
+ * Runs `op` and — if it throws `UnauthorizedError` — awaits the pending
+ * authorization code, exchanges it for tokens via `finishAuth`, and retries
+ * once.
+ *
+ * Errors other than `UnauthorizedError` are rethrown unchanged. If
+ * `UnauthorizedError` is thrown but no auth flow is in progress (the SDK
+ * raised it without calling our provider's `onRedirect`), the original
+ * error is rethrown — there is no code to wait for.
+ */
+export async function withAuthRetry<T>(
+  context: AuthRetryContext,
+  op: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await op();
+  } catch (error) {
+    if (!(error instanceof UnauthorizedError)) throw error;
+    const pending = context.pendingCode();
+    if (!pending) throw error;
+    const code = await pending;
+    context.clearPending();
+    await context.finishAuth(code);
+    return await op();
+  }
+}

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -10,14 +10,21 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from "vitest";
 import type { McpClient } from "./client";
 import {
+  buildUiAwareOnRedirect,
   createHttpMcpClient,
   createMcpClient,
   createStdioMcpClient,
   flattenContent,
 } from "./client";
+import { createMcpAuthStore } from "./mcp-auth-store";
+
+vi.mock("../utils/open-url", () => ({
+  openUrl: vi.fn(async () => {}),
+}));
 
 const STDIO_MOCK = resolve(__dirname, "../../mock-mcps/stdio.mjs");
 const HTTP_MOCK = resolve(__dirname, "../../mock-mcps/http.mjs");
@@ -274,6 +281,148 @@ describe("createHttpMcpClient", () => {
     } finally {
       await c.disconnect();
     }
+  });
+
+  it("accepts an authUi store without changing non-auth behaviour", async () => {
+    const store = createMcpAuthStore();
+    const c = await createHttpMcpClient({
+      serverName: "mock",
+      url: HTTP_URL,
+      authDataDir,
+      authUi: store,
+    });
+    try {
+      await c.connect();
+      const tools = await c.listTools();
+      expect(tools.length).toBeGreaterThan(0);
+      // The mock server never issues a 401 so the store is never pushed to.
+      expect(store.peek()).toBeNull();
+    } finally {
+      await c.disconnect();
+    }
+  });
+});
+
+describe("buildUiAwareOnRedirect", () => {
+  /** Builds a fake `HttpAuthFlow` whose `beginFlow` is a spy. */
+  function fakeFlow() {
+    return { beginFlow: vi.fn() };
+  }
+
+  /** Builds a fake `LoopbackCatcher` whose `waitForCode` returns a controllable promise. */
+  function fakeCatcher(
+    impl: (opts: {
+      expectedState: string;
+      signal: AbortSignal;
+    }) => Promise<string>,
+  ) {
+    return { waitForCode: vi.fn(impl) };
+  }
+
+  it("registers the loopback wait against the auth store entry as a race", async () => {
+    const flow = fakeFlow();
+    const catcher = fakeCatcher(async () => "loopback-code");
+    const store = createMcpAuthStore();
+
+    const onRedirect = buildUiAwareOnRedirect(flow, catcher, store, "github");
+
+    await onRedirect(
+      new URL("https://auth.example.com/authorize?state=xyz&client_id=foo"),
+    );
+
+    // beginFlow should have been called once with an abort and a code promise.
+    expect(flow.beginFlow).toHaveBeenCalledTimes(1);
+    const beginArgs = flow.beginFlow.mock.calls[0];
+    expect(beginArgs?.[0]).toBeInstanceOf(AbortController);
+    await expect(beginArgs?.[1]).resolves.toBe("loopback-code");
+
+    // The store entry was pushed and dismissed once the race settled.
+    expect(store.size()).toBe(0);
+  });
+
+  it("passes the URL state and signal through to the catcher", async () => {
+    const flow = fakeFlow();
+    const catcher = fakeCatcher(
+      async () => new Promise<string>(() => {}), // never resolves
+    );
+    const store = createMcpAuthStore();
+
+    const onRedirect = buildUiAwareOnRedirect(flow, catcher, store, "github");
+
+    await onRedirect(new URL("https://auth.example.com/authorize?state=xyz"));
+
+    expect(catcher.waitForCode).toHaveBeenCalledTimes(1);
+    const args = catcher.waitForCode.mock.calls[0]?.[0];
+    expect(args?.expectedState).toBe("xyz");
+    expect(args?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("defaults the state to empty string when the URL has no state param", async () => {
+    const flow = fakeFlow();
+    const catcher = fakeCatcher(async () => new Promise<string>(() => {}));
+    const store = createMcpAuthStore();
+
+    const onRedirect = buildUiAwareOnRedirect(flow, catcher, store, "github");
+
+    await onRedirect(new URL("https://auth.example.com/authorize"));
+    expect(catcher.waitForCode.mock.calls[0]?.[0]?.expectedState).toBe("");
+  });
+
+  it("opens the authorization URL via openUrl", async () => {
+    const { openUrl } = await import("../utils/open-url");
+    const openSpy = vi.mocked(openUrl);
+    openSpy.mockClear();
+
+    const flow = fakeFlow();
+    const catcher = fakeCatcher(async () => new Promise<string>(() => {}));
+    const store = createMcpAuthStore();
+
+    const onRedirect = buildUiAwareOnRedirect(flow, catcher, store, "github");
+
+    await onRedirect(new URL("https://auth.example.com/authorize?state=s"));
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://auth.example.com/authorize?state=s",
+    );
+  });
+
+  it("dismisses the store entry after the race settles via loopback", async () => {
+    const flow = fakeFlow();
+    const catcher = fakeCatcher(async () => "loopback-code");
+    const store = createMcpAuthStore();
+
+    const onRedirect = buildUiAwareOnRedirect(flow, catcher, store, "github");
+
+    await onRedirect(new URL("https://auth.example.com/authorize?state=s"));
+
+    // Wait one microtask for the .then handler to run.
+    await new Promise<void>((r) => setImmediate(r));
+    expect(store.size()).toBe(0);
+  });
+
+  it("dismisses the store entry after the race settles via UI cancel", async () => {
+    const flow = fakeFlow();
+    const catcher = fakeCatcher(
+      async () => new Promise<string>(() => {}), // never resolves
+    );
+    const store = createMcpAuthStore();
+
+    const onRedirect = buildUiAwareOnRedirect(flow, catcher, store, "github");
+
+    await onRedirect(new URL("https://auth.example.com/authorize?state=s"));
+
+    // Cancel via the store — race rejects, dismiss handler runs.
+    const entry = store.peek();
+    expect(entry).not.toBeNull();
+    if (entry) store.cancel(entry.id);
+
+    // Race rejects with McpAuthCancelledError; we passed it to flow.beginFlow.
+    const racedPromise = flow.beginFlow.mock.calls[0]?.[1];
+    await expect(racedPromise).rejects.toThrow(/authorization cancelled/);
+
+    // After the race settles, the dismiss handler runs (idempotent here
+    // since cancel already removed the entry).
+    await new Promise<void>((r) => setImmediate(r));
+    expect(store.size()).toBe(0);
   });
 });
 

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -1,6 +1,16 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
 import type { McpClient } from "./client";
 import {
   createHttpMcpClient,
@@ -128,6 +138,7 @@ describe("flattenContent", () => {
 describe("createHttpMcpClient", () => {
   let server: ChildProcess | null = null;
   let client: McpClient | null = null;
+  let authDataDir: string;
 
   beforeAll(async () => {
     server = spawn("node", [HTTP_MOCK], {
@@ -162,18 +173,30 @@ describe("createHttpMcpClient", () => {
     }
   });
 
+  beforeEach(() => {
+    // Isolate each test's persisted OAuth state (including the bound
+    // loopback port) so they don't leak across runs or into ~/.tomo.
+    authDataDir = mkdtempSync(resolve(tmpdir(), "tomo-mcp-client-"));
+  });
+
   afterEach(async () => {
     if (client) {
       await client.disconnect();
       client = null;
     }
+    rmSync(authDataDir, { recursive: true, force: true });
   });
 
   /** Connects an http client to the mock server. */
   async function connectMock(
     headers?: Record<string, string>,
   ): Promise<McpClient> {
-    const c = createHttpMcpClient({ url: HTTP_URL, headers });
+    const c = await createHttpMcpClient({
+      serverName: "mock",
+      url: HTTP_URL,
+      headers,
+      authDataDir,
+    });
     await c.connect();
     return c;
   }
@@ -226,25 +249,70 @@ describe("createHttpMcpClient", () => {
     await c.disconnect();
     await expect(c.disconnect()).resolves.not.toThrow();
   });
+
+  it("listTools throws when called before connect", async () => {
+    const c = await createHttpMcpClient({
+      serverName: "mock-not-connected",
+      url: HTTP_URL,
+      authDataDir,
+    });
+    try {
+      await expect(c.listTools()).rejects.toThrow(/not connected/);
+    } finally {
+      await c.disconnect();
+    }
+  });
+
+  it("callTool throws when called before connect", async () => {
+    const c = await createHttpMcpClient({
+      serverName: "mock-not-connected",
+      url: HTTP_URL,
+      authDataDir,
+    });
+    try {
+      await expect(c.callTool("x", {})).rejects.toThrow(/not connected/);
+    } finally {
+      await c.disconnect();
+    }
+  });
 });
 
 describe("createMcpClient", () => {
-  it("builds a stdio client from a stdio connection", () => {
-    const client = createMcpClient({
-      transport: "stdio",
-      command: "node",
-      args: [],
-      enabled: true,
-    });
+  let authDataDir: string;
+
+  beforeEach(() => {
+    authDataDir = mkdtempSync(resolve(tmpdir(), "tomo-mcp-dispatch-"));
+  });
+
+  afterEach(() => {
+    rmSync(authDataDir, { recursive: true, force: true });
+  });
+
+  it("builds a stdio client from a stdio connection", async () => {
+    const client = await createMcpClient(
+      "mock",
+      {
+        transport: "stdio",
+        command: "node",
+        args: [],
+        enabled: true,
+      },
+      { authDataDir },
+    );
     expect(client).toBeDefined();
   });
 
-  it("builds an http client from an http connection", () => {
-    const client = createMcpClient({
-      transport: "http",
-      url: "https://example.com/mcp",
-      enabled: true,
-    });
-    expect(client).toBeDefined();
+  it("builds an http client from an http connection", async () => {
+    const http = await createMcpClient(
+      "dispatch-http",
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        enabled: true,
+      },
+      { authDataDir },
+    );
+    expect(http).toBeDefined();
+    await http.disconnect();
   });
 });

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -2,11 +2,19 @@ import { Client } from "@modelcontextprotocol/sdk/client";
 // `.js` extensions are required for these subpath imports because the SDK's
 // package.json `exports` map uses a literal `./*` → `./dist/esm/*` rule.
 // esbuild's resolver will not resolve them without the explicit extension.
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
 import { z } from "zod";
+import { MCP_OAUTH_DIR } from "../config/file";
 import type { McpConnection } from "../config/schema";
+import { withAuthRetry } from "./auth-retry";
+import { createHttpAuthFlow } from "./http-auth-flow";
+import { createLoopbackCatcher } from "./oauth-loopback";
+import { type McpOAuthConfig, createMcpOAuthProvider } from "./oauth-provider";
+import { readOAuthState, writeOAuthState } from "./oauth-storage";
+import { openUrl } from "../utils/open-url";
 
 /** A discovered tool exposed by an MCP server. */
 export interface McpToolDefinition {
@@ -23,7 +31,7 @@ export interface McpCallResult {
   isError: boolean;
 }
 
-/** Stdio-only MCP client wrapper around the official SDK. */
+/** Unified MCP client wrapper around the official SDK transports. */
 export interface McpClient {
   /** Connects to the server and performs the initialize handshake. */
   connect: () => Promise<void>;
@@ -35,7 +43,7 @@ export interface McpClient {
     args: Record<string, unknown>,
     signal?: AbortSignal,
   ) => Promise<McpCallResult>;
-  /** Closes the underlying transport and kills the subprocess. */
+  /** Closes the underlying transport and any auxiliary resources. */
   disconnect: () => Promise<void>;
 }
 
@@ -65,12 +73,19 @@ export function flattenContent(content: readonly unknown[]): string {
     .join("\n");
 }
 
+/** Identity retry wrapper — invokes the operation directly with no auth handling. */
+const directInvoke = <T>(op: () => Promise<T>): Promise<T> => op();
+
 /**
- * Wraps an SDK transport in an `McpClient`, handling the protocol-layer
- * calls (`listTools`, `callTool`, `disconnect`). Shared between the stdio
- * and http factories so the protocol handling lives in one place.
+ * Wraps an SDK transport in an `McpClient`, handling the protocol-layer calls
+ * (`listTools`, `callTool`, `disconnect`). The optional `retry` parameter lets
+ * the HTTP variant interpose OAuth-aware retries around every operation while
+ * the stdio variant uses the default identity wrapper.
  */
-function wrapTransport(transport: Transport): McpClient {
+function wrapTransport(
+  transport: Transport,
+  retry: <T>(op: () => Promise<T>) => Promise<T> = directInvoke,
+): McpClient {
   const client = new Client(
     { name: "tomo", version: "0.0.0" },
     { capabilities: {} },
@@ -78,11 +93,11 @@ function wrapTransport(transport: Transport): McpClient {
 
   return {
     async connect() {
-      await client.connect(transport);
+      await retry(() => client.connect(transport));
     },
 
     async listTools() {
-      const result = await client.listTools();
+      const result = await retry(() => client.listTools());
       return result.tools.map((tool) => ({
         name: tool.name,
         description: tool.description,
@@ -91,18 +106,20 @@ function wrapTransport(transport: Transport): McpClient {
     },
 
     async callTool(name, args, signal) {
-      const raw = await client.callTool(
-        { name, arguments: args },
-        undefined,
-        signal ? { signal } : undefined,
-      );
-      // The non-task call shape always has `content`. The task-based shape
-      // (`toolResult`) is unused here, so the content branch always holds.
-      const parsed = callToolResultSchema.parse(raw);
-      return {
-        text: flattenContent(parsed.content),
-        isError: parsed.isError === true,
-      };
+      return retry(async () => {
+        const raw = await client.callTool(
+          { name, arguments: args },
+          undefined,
+          signal ? { signal } : undefined,
+        );
+        // The non-task call shape always has `content`. The task-based shape
+        // (`toolResult`) is unused here, so the content branch always holds.
+        const parsed = callToolResultSchema.parse(raw);
+        return {
+          text: flattenContent(parsed.content),
+          isError: parsed.isError === true,
+        };
+      });
     },
 
     async disconnect() {
@@ -128,19 +145,178 @@ export function createStdioMcpClient(connection: {
   return wrapTransport(transport);
 }
 
-/** Creates a streamable-HTTP MCP client for the given connection config. */
-export function createHttpMcpClient(connection: {
+/** Construction options for `createHttpMcpClient`. */
+export interface CreateHttpMcpClientOptions {
+  /** Server name — used as the state-file stem for persisted OAuth credentials. */
+  serverName: string;
+  /** URL of the MCP server. */
   url: string;
+  /** Static headers (e.g. API-key auth). Coexists with OAuth. */
   headers?: Record<string, string>;
-}): McpClient {
-  const transport = new StreamableHTTPClientTransport(new URL(connection.url), {
-    requestInit: connection.headers ? { headers: connection.headers } : {},
+  /** Optional pre-registered OAuth client configuration. */
+  auth?: McpOAuthConfig;
+  /** Overrides the default OAuth state directory. Tests use this to write under a tmp dir. */
+  authDataDir?: string;
+}
+
+/**
+ * Creates a streamable-HTTP MCP client for the given connection config.
+ *
+ * Eagerly binds a loopback HTTP server so the registered redirect URI is
+ * stable from the first SDK read of `clientMetadata.redirect_uris`. If a
+ * previous run persisted a bound port in the server's OAuth state file, the
+ * loopback reuses it so a DCR-registered redirect URI keeps working across
+ * restarts; otherwise an ephemeral port is bound and persisted for next time.
+ *
+ * The returned client wraps every SDK operation (`connect`, `listTools`,
+ * `callTool`) with `withAuthRetry`, so a `401` that triggers the SDK's
+ * `redirectToAuthorization` flow is caught transparently: our provider's
+ * `onRedirect` opens the user's browser and registers a promise for the
+ * authorization code, the wrapper awaits it, exchanges it via
+ * `transport.finishAuth`, and retries the original operation.
+ */
+export async function createHttpMcpClient(
+  options: CreateHttpMcpClientOptions,
+): Promise<McpClient> {
+  const dataDir = options.authDataDir ?? MCP_OAUTH_DIR;
+
+  // Reuse the bound port across restarts when one has been persisted so the
+  // DCR-registered redirect URI stays valid.
+  const persisted = readOAuthState(dataDir, options.serverName);
+  const catcher = await createLoopbackCatcher({ port: persisted.redirectPort });
+  if (persisted.redirectPort !== catcher.port) {
+    writeOAuthState(dataDir, options.serverName, {
+      ...persisted,
+      redirectPort: catcher.port,
+    });
+  }
+
+  // Mutable live transport+client — both get replaced when an initial
+  // connect triggers OAuth. The SDK's `StreamableHTTPClientTransport.start`
+  // and `Client.connect` both refuse to run a second time on the same
+  // instance, so retrying after `finishAuth` requires a fresh pair.
+  let liveTransport: StreamableHTTPClientTransport | null = null;
+  let liveClient: Client | null = null;
+
+  /* v8 ignore start -- finishAuth closure is reached only on a real SDK-driven 401, covered end-to-end in M7 */
+  const authFlow = createHttpAuthFlow({
+    catcher,
+    openUrl,
+    finishAuth: async (code) => {
+      if (!liveTransport) throw new Error("no transport to finish auth on");
+      await liveTransport.finishAuth(code);
+    },
   });
-  return wrapTransport(transport);
+  /* v8 ignore stop */
+
+  const provider = createMcpOAuthProvider({
+    serverName: options.serverName,
+    dataDir,
+    config: options.auth,
+    redirectUri: catcher.redirectUri,
+    onRedirect: authFlow.onRedirect,
+  });
+
+  /** Builds a fresh transport+client pair wired to the shared provider. */
+  const buildPair = () => {
+    const transport = new StreamableHTTPClientTransport(new URL(options.url), {
+      authProvider: provider,
+      requestInit: options.headers ? { headers: options.headers } : {},
+    });
+    const client = new Client(
+      { name: "tomo", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    return { transport, client };
+  };
+
+  return {
+    async connect() {
+      // First attempt on a fresh pair. If the server is already authorised
+      // (tokens cached from a previous run), this succeeds directly.
+      const first = buildPair();
+      liveTransport = first.transport;
+      try {
+        await first.client.connect(first.transport);
+        liveClient = first.client;
+        return;
+      } catch (error) {
+        /* v8 ignore start -- reauth flow is covered end-to-end in M7 */
+        if (!(error instanceof UnauthorizedError)) throw error;
+        const pending = authFlow.retryContext.pendingCode();
+        if (!pending) throw error;
+
+        const code = await pending;
+        authFlow.retryContext.clearPending();
+        // Exchange on the transport that actually received the 401 — it
+        // holds the discovery state needed for the token exchange.
+        await first.transport.finishAuth(code);
+        // finishAuth has saved tokens in the provider; a new pair will read
+        // them via provider.tokens() on its next request.
+        await first.transport.close();
+
+        const second = buildPair();
+        liveTransport = second.transport;
+        await second.client.connect(second.transport);
+        liveClient = second.client;
+        /* v8 ignore stop */
+      }
+    },
+
+    async listTools() {
+      if (!liveClient) throw new Error("not connected");
+      const c = liveClient;
+      const result = await withAuthRetry(authFlow.retryContext, () =>
+        c.listTools(),
+      );
+      return result.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      }));
+    },
+
+    async callTool(name, args, signal) {
+      if (!liveClient) throw new Error("not connected");
+      const c = liveClient;
+      return withAuthRetry(authFlow.retryContext, async () => {
+        const raw = await c.callTool(
+          { name, arguments: args },
+          undefined,
+          signal ? { signal } : undefined,
+        );
+        const parsed = callToolResultSchema.parse(raw);
+        return {
+          text: flattenContent(parsed.content),
+          isError: parsed.isError === true,
+        };
+      });
+    },
+
+    async disconnect() {
+      authFlow.abortIfActive();
+      if (liveTransport) {
+        await liveTransport.close();
+      }
+      liveTransport = null;
+      liveClient = null;
+      await catcher.close();
+    },
+  };
+}
+
+/** Optional overrides threaded into the underlying client factories. */
+export interface McpClientContext {
+  /** Overrides the default OAuth state directory. */
+  authDataDir?: string;
 }
 
 /** Builds an MCP client from a connection config, dispatching on transport type. */
-export function createMcpClient(connection: McpConnection): McpClient {
+export async function createMcpClient(
+  name: string,
+  connection: McpConnection,
+  context: McpClientContext = {},
+): Promise<McpClient> {
   if (connection.transport === "stdio") {
     return createStdioMcpClient({
       command: connection.command,
@@ -149,7 +325,10 @@ export function createMcpClient(connection: McpConnection): McpClient {
     });
   }
   return createHttpMcpClient({
+    serverName: name,
     url: connection.url,
     headers: connection.headers,
+    auth: connection.auth,
+    authDataDir: context.authDataDir,
   });
 }

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -245,16 +245,18 @@ export async function createHttpMcpClient(
   let liveTransport: StreamableHTTPClientTransport | null = null;
   let liveClient: Client | null = null;
 
-  /* v8 ignore start -- finishAuth closure is reached only on a real SDK-driven 401, covered end-to-end in M7 */
   const authFlow = createHttpAuthFlow({
     catcher,
     openUrl,
     finishAuth: async (code) => {
+      // withAuthRetry only calls this after `listTools`/`callTool` has
+      // already guarded against a null `liveClient`, so `liveTransport`
+      // is set by invariant. The runtime check is belt-and-braces.
+      /* v8 ignore next -- invariant — liveTransport is set once connect succeeds */
       if (!liveTransport) throw new Error("no transport to finish auth on");
       await liveTransport.finishAuth(code);
     },
   });
-  /* v8 ignore stop */
 
   const provider = createMcpOAuthProvider({
     serverName: options.serverName,
@@ -299,9 +301,9 @@ export async function createHttpMcpClient(
         liveClient = first.client;
         return;
       } catch (error) {
-        /* v8 ignore start -- reauth flow is covered end-to-end in M7 */
         if (!(error instanceof UnauthorizedError)) throw error;
         const pending = authFlow.retryContext.pendingCode();
+        /* v8 ignore next -- invariant: onRedirect runs before the SDK throws UnauthorizedError, so pending is always set here */
         if (!pending) throw error;
 
         const code = await pending;
@@ -317,7 +319,6 @@ export async function createHttpMcpClient(
         liveTransport = second.transport;
         await second.client.connect(second.transport);
         liveClient = second.client;
-        /* v8 ignore stop */
       }
     },
 

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -9,12 +9,13 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
 import { z } from "zod";
 import { MCP_OAUTH_DIR } from "../config/file";
 import type { McpConnection } from "../config/schema";
+import { openUrl } from "../utils/open-url";
 import { withAuthRetry } from "./auth-retry";
 import { createHttpAuthFlow } from "./http-auth-flow";
+import type { McpAuthStore } from "./mcp-auth-store";
 import { createLoopbackCatcher } from "./oauth-loopback";
 import { type McpOAuthConfig, createMcpOAuthProvider } from "./oauth-provider";
 import { readOAuthState, writeOAuthState } from "./oauth-storage";
-import { openUrl } from "../utils/open-url";
 
 /** A discovered tool exposed by an MCP server. */
 export interface McpToolDefinition {
@@ -75,6 +76,47 @@ export function flattenContent(content: readonly unknown[]): string {
 
 /** Identity retry wrapper — invokes the operation directly with no auth handling. */
 const directInvoke = <T>(op: () => Promise<T>): Promise<T> => op();
+
+/**
+ * Builds a UI-aware `onRedirect` that pushes an entry onto an auth store
+ * and races the loopback catcher against the store's pending promise, so
+ * Esc cancels and loopback wins both settle the retry wrapper cleanly.
+ * Extracted from `createHttpMcpClient` so the race + dismiss cleanup is
+ * unit-testable with fake dependencies.
+ */
+export function buildUiAwareOnRedirect(
+  flow: Pick<import("./http-auth-flow").HttpAuthFlow, "beginFlow">,
+  catcher: Pick<import("./oauth-loopback").LoopbackCatcher, "waitForCode">,
+  authUi: McpAuthStore,
+  serverName: string,
+): (authorizationUrl: URL) => Promise<void> {
+  return async (authorizationUrl) => {
+    const expectedState = authorizationUrl.searchParams.get("state") ?? "";
+    const abort = new AbortController();
+    const loopbackCode = catcher.waitForCode({
+      expectedState,
+      signal: abort.signal,
+    });
+    const uiHandle = authUi.push({
+      serverName,
+      authUrl: authorizationUrl.toString(),
+    });
+
+    // Race the loopback code against a user-pasted code from the modal.
+    // Whichever settles first drives the flow; the loser is discarded.
+    const raced = Promise.race([loopbackCode, uiHandle.pending]);
+
+    // Whenever the race settles, remove the modal entry. Errors swallowed
+    // here — the `raced` promise itself is what withAuthRetry awaits.
+    void raced.then(
+      () => authUi.dismiss(uiHandle.id),
+      () => authUi.dismiss(uiHandle.id),
+    );
+
+    flow.beginFlow(abort, raced);
+    await openUrl(authorizationUrl.toString());
+  };
+}
 
 /**
  * Wraps an SDK transport in an `McpClient`, handling the protocol-layer calls
@@ -157,6 +199,11 @@ export interface CreateHttpMcpClientOptions {
   auth?: McpOAuthConfig;
   /** Overrides the default OAuth state directory. Tests use this to write under a tmp dir. */
   authDataDir?: string;
+  /**
+   * When provided, the OAuth flow pushes an entry onto this store so the
+   * chat UI can render an auth-in-progress modal and surface cancellation.
+   */
+  authUi?: McpAuthStore;
 }
 
 /**
@@ -214,7 +261,18 @@ export async function createHttpMcpClient(
     dataDir,
     config: options.auth,
     redirectUri: catcher.redirectUri,
-    onRedirect: authFlow.onRedirect,
+    // When there is no UI store the flow is loopback-only. When one is
+    // provided, we instead push a modal entry and race the loopback code
+    // against the UI's pending promise so Esc-to-cancel and loopback-win
+    // both settle the retry wrapper.
+    onRedirect: options.authUi
+      ? buildUiAwareOnRedirect(
+          authFlow,
+          catcher,
+          options.authUi,
+          options.serverName,
+        )
+      : authFlow.onRedirect,
   });
 
   /** Builds a fresh transport+client pair wired to the shared provider. */
@@ -309,6 +367,8 @@ export async function createHttpMcpClient(
 export interface McpClientContext {
   /** Overrides the default OAuth state directory. */
   authDataDir?: string;
+  /** Auth store used to render an in-progress modal for HTTP connections. */
+  authUi?: McpAuthStore;
 }
 
 /** Builds an MCP client from a connection config, dispatching on transport type. */
@@ -330,5 +390,6 @@ export async function createMcpClient(
     headers: connection.headers,
     auth: connection.auth,
     authDataDir: context.authDataDir,
+    authUi: context.authUi,
   });
 }

--- a/src/mcp/errors.test.ts
+++ b/src/mcp/errors.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { McpAuthCancelledError } from "./errors";
+
+describe("McpAuthCancelledError", () => {
+  it("embeds the server name in the message", () => {
+    const err = new McpAuthCancelledError("github");
+    expect(err.message).toBe("MCP server 'github' authorization cancelled");
+  });
+
+  it("has the class name set for instanceof and logging", () => {
+    const err = new McpAuthCancelledError("github");
+    expect(err.name).toBe("McpAuthCancelledError");
+    expect(err instanceof McpAuthCancelledError).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+});

--- a/src/mcp/errors.ts
+++ b/src/mcp/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Thrown when an MCP OAuth authorization flow is aborted before it completes.
+ *
+ * Raised from the HTTP client wrapper when the user cancels the browser-auth
+ * prompt, when the chat disconnects mid-flow, or when the loopback wait is
+ * aborted by signal. Manager and UI layers can match on this type to print a
+ * user-friendly "authorization cancelled" message instead of a generic error.
+ */
+export class McpAuthCancelledError extends Error {
+  constructor(serverName: string) {
+    super(`MCP server '${serverName}' authorization cancelled`);
+    this.name = "McpAuthCancelledError";
+  }
+}

--- a/src/mcp/http-auth-flow.test.ts
+++ b/src/mcp/http-auth-flow.test.ts
@@ -112,22 +112,31 @@ describe("createHttpAuthFlow", () => {
     });
 
     it("aborts the previously-registered flow when a second onRedirect arrives", async () => {
-      const flow = createHttpAuthFlow(makeInputs());
+      // Capture each onRedirect's AbortSignal so we can assert the first
+      // was aborted by the second call — otherwise a stale loopback
+      // waiter would race the new dispatch.
+      const capturedSignals: AbortSignal[] = [];
+      const flow = createHttpAuthFlow(
+        makeInputs({
+          waitForCode: async (opts) => {
+            capturedSignals.push(opts.signal);
+            return "code";
+          },
+        }),
+      );
       await flow.onRedirect(
         new URL("https://auth.example.com/authorize?state=first"),
       );
-      const firstPending = flow.retryContext.pendingCode();
       await flow.onRedirect(
         new URL("https://auth.example.com/authorize?state=second"),
       );
-      // The first pending promise is replaced; abortIfActive should now
-      // only abort the second flow.
+      expect(capturedSignals).toHaveLength(2);
+      expect(capturedSignals[0]?.aborted).toBe(true);
+      expect(capturedSignals[1]?.aborted).toBe(false);
+
       flow.abortIfActive();
-      // First pending is still a (stale) resolved promise from the fake
-      // — we just assert that the second flow tracks correctly by
-      // resetting and checking the state is now clean.
+      expect(capturedSignals[1]?.aborted).toBe(true);
       expect(flow.retryContext.pendingCode()).toBeNull();
-      expect(firstPending).not.toBeNull();
     });
   });
 
@@ -148,6 +157,25 @@ describe("createHttpAuthFlow", () => {
       flow.abortIfActive();
       expect(abort.signal.aborted).toBe(true);
       expect(flow.retryContext.pendingCode()).toBeNull();
+    });
+
+    it("aborts a previous onRedirect flow when beginFlow supersedes it", async () => {
+      const capturedSignals: AbortSignal[] = [];
+      const flow = createHttpAuthFlow(
+        makeInputs({
+          waitForCode: async (opts) => {
+            capturedSignals.push(opts.signal);
+            return "code";
+          },
+        }),
+      );
+      await flow.onRedirect(
+        new URL("https://auth.example.com/authorize?state=s"),
+      );
+      const abort = new AbortController();
+      flow.beginFlow(abort, Promise.resolve("direct-code"));
+      expect(capturedSignals[0]?.aborted).toBe(true);
+      expect(abort.signal.aborted).toBe(false);
     });
   });
 

--- a/src/mcp/http-auth-flow.test.ts
+++ b/src/mcp/http-auth-flow.test.ts
@@ -131,6 +131,26 @@ describe("createHttpAuthFlow", () => {
     });
   });
 
+  describe("beginFlow", () => {
+    it("registers the supplied code promise as pending", async () => {
+      const flow = createHttpAuthFlow(makeInputs());
+      const abort = new AbortController();
+      flow.beginFlow(abort, Promise.resolve("direct-code"));
+      await expect(flow.retryContext.pendingCode()).resolves.toBe(
+        "direct-code",
+      );
+    });
+
+    it("abortIfActive cancels the controller registered via beginFlow", () => {
+      const flow = createHttpAuthFlow(makeInputs());
+      const abort = new AbortController();
+      flow.beginFlow(abort, Promise.resolve("code"));
+      flow.abortIfActive();
+      expect(abort.signal.aborted).toBe(true);
+      expect(flow.retryContext.pendingCode()).toBeNull();
+    });
+  });
+
   describe("abortIfActive", () => {
     it("is a no-op when no flow is active", () => {
       const flow = createHttpAuthFlow(makeInputs());

--- a/src/mcp/http-auth-flow.test.ts
+++ b/src/mcp/http-auth-flow.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHttpAuthFlow } from "./http-auth-flow";
+
+/** Builds an HttpAuthFlowInputs with spy-backed defaults, overridable per test. */
+function makeInputs(
+  overrides: {
+    waitForCode?: (opts: {
+      expectedState: string;
+      signal: AbortSignal;
+      timeoutMs?: number;
+    }) => Promise<string>;
+    openUrl?: (url: string) => Promise<void>;
+    finishAuth?: (code: string) => Promise<void>;
+  } = {},
+) {
+  return {
+    catcher: {
+      waitForCode: overrides.waitForCode ?? vi.fn(async () => "default-code"),
+    },
+    openUrl: overrides.openUrl ?? vi.fn(async () => {}),
+    finishAuth: overrides.finishAuth ?? vi.fn(async () => {}),
+  };
+}
+
+describe("createHttpAuthFlow", () => {
+  describe("retryContext.pendingCode", () => {
+    it("is null before any flow starts", () => {
+      const flow = createHttpAuthFlow(makeInputs());
+      expect(flow.retryContext.pendingCode()).toBeNull();
+    });
+
+    it("returns the registered promise after onRedirect runs", async () => {
+      const waitForCode = vi.fn(async () => "the-code");
+      const flow = createHttpAuthFlow(makeInputs({ waitForCode }));
+      await flow.onRedirect(
+        new URL("https://auth.example.com/authorize?state=abc"),
+      );
+      const pending = flow.retryContext.pendingCode();
+      expect(pending).not.toBeNull();
+      await expect(pending).resolves.toBe("the-code");
+    });
+  });
+
+  describe("retryContext.clearPending", () => {
+    it("resets both the code and the abort references", async () => {
+      const flow = createHttpAuthFlow(makeInputs());
+      await flow.onRedirect(
+        new URL("https://auth.example.com/authorize?state=abc"),
+      );
+      flow.retryContext.clearPending();
+      expect(flow.retryContext.pendingCode()).toBeNull();
+      // After clearPending, abortIfActive must not re-fire the controller
+      // (nothing to observe directly, but this also covers the no-op branch).
+      expect(() => flow.abortIfActive()).not.toThrow();
+    });
+  });
+
+  describe("retryContext.finishAuth", () => {
+    it("delegates to the configured finishAuth", async () => {
+      const finishAuth = vi.fn(async () => {});
+      const flow = createHttpAuthFlow(makeInputs({ finishAuth }));
+      await flow.retryContext.finishAuth("the-code");
+      expect(finishAuth).toHaveBeenCalledWith("the-code");
+    });
+  });
+
+  describe("onRedirect", () => {
+    it("passes the state parameter and signal to the catcher", async () => {
+      const waitForCode = vi
+        .fn<
+          (opts: {
+            expectedState: string;
+            signal: AbortSignal;
+            timeoutMs?: number;
+          }) => Promise<string>
+        >()
+        .mockResolvedValue("code");
+      const flow = createHttpAuthFlow(makeInputs({ waitForCode }));
+      await flow.onRedirect(
+        new URL("https://auth.example.com/authorize?state=xyz"),
+      );
+      expect(waitForCode).toHaveBeenCalledTimes(1);
+      const args = waitForCode.mock.calls[0]?.[0];
+      expect(args?.expectedState).toBe("xyz");
+      expect(args?.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("defaults expectedState to empty string when the URL has no state", async () => {
+      const waitForCode = vi
+        .fn<
+          (opts: {
+            expectedState: string;
+            signal: AbortSignal;
+            timeoutMs?: number;
+          }) => Promise<string>
+        >()
+        .mockResolvedValue("code");
+      const flow = createHttpAuthFlow(makeInputs({ waitForCode }));
+      await flow.onRedirect(new URL("https://auth.example.com/authorize"));
+      expect(waitForCode.mock.calls[0]?.[0]?.expectedState).toBe("");
+    });
+
+    it("opens the authorization URL in the browser", async () => {
+      const openUrl = vi.fn(async () => {});
+      const flow = createHttpAuthFlow(makeInputs({ openUrl }));
+      await flow.onRedirect(
+        new URL("https://auth.example.com/authorize?state=s"),
+      );
+      expect(openUrl).toHaveBeenCalledWith(
+        "https://auth.example.com/authorize?state=s",
+      );
+    });
+
+    it("aborts the previously-registered flow when a second onRedirect arrives", async () => {
+      const flow = createHttpAuthFlow(makeInputs());
+      await flow.onRedirect(
+        new URL("https://auth.example.com/authorize?state=first"),
+      );
+      const firstPending = flow.retryContext.pendingCode();
+      await flow.onRedirect(
+        new URL("https://auth.example.com/authorize?state=second"),
+      );
+      // The first pending promise is replaced; abortIfActive should now
+      // only abort the second flow.
+      flow.abortIfActive();
+      // First pending is still a (stale) resolved promise from the fake
+      // — we just assert that the second flow tracks correctly by
+      // resetting and checking the state is now clean.
+      expect(flow.retryContext.pendingCode()).toBeNull();
+      expect(firstPending).not.toBeNull();
+    });
+  });
+
+  describe("abortIfActive", () => {
+    it("is a no-op when no flow is active", () => {
+      const flow = createHttpAuthFlow(makeInputs());
+      expect(() => flow.abortIfActive()).not.toThrow();
+    });
+
+    it("aborts the controller registered by the latest onRedirect", async () => {
+      // Capture the signal passed to waitForCode so we can assert the abort
+      // is propagated correctly.
+      let capturedSignal: AbortSignal | undefined;
+      const flow = createHttpAuthFlow(
+        makeInputs({
+          waitForCode: async (opts) => {
+            capturedSignal = opts.signal;
+            return "code";
+          },
+        }),
+      );
+      await flow.onRedirect(
+        new URL("https://auth.example.com/authorize?state=s"),
+      );
+      flow.abortIfActive();
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(flow.retryContext.pendingCode()).toBeNull();
+    });
+  });
+});

--- a/src/mcp/http-auth-flow.ts
+++ b/src/mcp/http-auth-flow.ts
@@ -24,11 +24,18 @@ export interface HttpAuthFlow {
   /** Retry context to pass into `withAuthRetry` around transport operations. */
   retryContext: AuthRetryContext;
   /**
-   * Provider hook invoked when the SDK wants to drive the user to an
-   * authorization URL. Registers a pending code promise against the loopback
-   * catcher and opens the browser, then resolves.
+   * Provider hook that spins up a loopback-only flow: registers the abort
+   * controller + waitForCode pending promise, then opens the browser.
+   * Callers that need a different code source (e.g. racing loopback against
+   * a UI paste) should use `beginFlow` directly instead.
    */
   onRedirect: (authorizationUrl: URL) => Promise<void>;
+  /**
+   * Registers a new flow's abort controller and code-source promise. The
+   * retry context's `pendingCode` returns `codePromise` until the flow
+   * settles or `abortIfActive` is called.
+   */
+  beginFlow: (abort: AbortController, codePromise: Promise<string>) => void;
   /**
    * Cancels any in-flight auth flow. Called from `disconnect` so a mid-flow
    * tear-down unblocks the loopback waiter.
@@ -67,6 +74,11 @@ export function createHttpAuthFlow(inputs: HttpAuthFlowInputs): HttpAuthFlow {
         signal: controller.signal,
       });
       await inputs.openUrl(authorizationUrl.toString());
+    },
+
+    beginFlow(controller, codePromise) {
+      abort = controller;
+      code = codePromise;
     },
 
     abortIfActive() {

--- a/src/mcp/http-auth-flow.ts
+++ b/src/mcp/http-auth-flow.ts
@@ -66,6 +66,9 @@ export function createHttpAuthFlow(inputs: HttpAuthFlowInputs): HttpAuthFlow {
     },
 
     async onRedirect(authorizationUrl: URL) {
+      // A new flow supersedes any in-flight one — abort it so the old
+      // loopback waiter stops and does not race the new dispatch.
+      if (abort) abort.abort();
       const expectedState = authorizationUrl.searchParams.get("state") ?? "";
       const controller = new AbortController();
       abort = controller;
@@ -77,6 +80,8 @@ export function createHttpAuthFlow(inputs: HttpAuthFlowInputs): HttpAuthFlow {
     },
 
     beginFlow(controller, codePromise) {
+      // Same supersede rule for the UI-aware path.
+      if (abort && abort !== controller) abort.abort();
       abort = controller;
       code = codePromise;
     },

--- a/src/mcp/http-auth-flow.ts
+++ b/src/mcp/http-auth-flow.ts
@@ -1,0 +1,80 @@
+import type { AuthRetryContext } from "./auth-retry";
+
+/** Minimum loopback-catcher surface needed by the flow. */
+export interface HttpAuthFlowCatcher {
+  waitForCode(options: {
+    expectedState: string;
+    signal: AbortSignal;
+    timeoutMs?: number;
+  }): Promise<string>;
+}
+
+/** Dependencies injected into the flow. */
+export interface HttpAuthFlowInputs {
+  /** Loopback server used to capture the authorization code. */
+  catcher: HttpAuthFlowCatcher;
+  /** Launches the system browser at the given authorization URL. */
+  openUrl: (url: string) => Promise<void>;
+  /** Exchanges the captured code for tokens via the transport. */
+  finishAuth: (code: string) => Promise<void>;
+}
+
+/** Public surface of an HTTP MCP client's in-flight OAuth authorization. */
+export interface HttpAuthFlow {
+  /** Retry context to pass into `withAuthRetry` around transport operations. */
+  retryContext: AuthRetryContext;
+  /**
+   * Provider hook invoked when the SDK wants to drive the user to an
+   * authorization URL. Registers a pending code promise against the loopback
+   * catcher and opens the browser, then resolves.
+   */
+  onRedirect: (authorizationUrl: URL) => Promise<void>;
+  /**
+   * Cancels any in-flight auth flow. Called from `disconnect` so a mid-flow
+   * tear-down unblocks the loopback waiter.
+   */
+  abortIfActive: () => void;
+}
+
+/**
+ * Creates a coordinated auth-flow state holder for an HTTP MCP client.
+ *
+ * Owns the `activeCode` / `activeAbort` refs that are set when the SDK drives
+ * the user to the authorization URL and consumed by the retry wrapper when it
+ * catches an `UnauthorizedError`. Extracted from `createHttpMcpClient` so the
+ * closures are unit-testable without having to drive the full SDK transport.
+ */
+export function createHttpAuthFlow(inputs: HttpAuthFlowInputs): HttpAuthFlow {
+  let code: Promise<string> | null = null;
+  let abort: AbortController | null = null;
+
+  return {
+    retryContext: {
+      pendingCode: () => code,
+      clearPending: () => {
+        code = null;
+        abort = null;
+      },
+      finishAuth: (authorizationCode) => inputs.finishAuth(authorizationCode),
+    },
+
+    async onRedirect(authorizationUrl: URL) {
+      const expectedState = authorizationUrl.searchParams.get("state") ?? "";
+      const controller = new AbortController();
+      abort = controller;
+      code = inputs.catcher.waitForCode({
+        expectedState,
+        signal: controller.signal,
+      });
+      await inputs.openUrl(authorizationUrl.toString());
+    },
+
+    abortIfActive() {
+      if (abort) {
+        abort.abort();
+        abort = null;
+        code = null;
+      }
+    },
+  };
+}

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -128,7 +128,7 @@ describe("createMcpManager", () => {
       callTool: vi.fn(async () => ({ text: "", isError: false })),
       disconnect: vi.fn(async () => {}),
     };
-    manager = createMcpManager(() => fakeClient);
+    manager = createMcpManager(async () => fakeClient);
     const result = await manager.startAll({
       stringy: mockStdioConnection(),
     });

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -2,8 +2,11 @@ import type { McpConnection } from "../config/schema";
 import type { McpClient, McpToolDefinition } from "./client";
 import { createMcpClient } from "./client";
 
-/** Factory that creates an MCP client for a given connection. */
-export type McpClientFactory = (connection: McpConnection) => McpClient;
+/** Factory that creates an MCP client for a given named connection. */
+export type McpClientFactory = (
+  name: string,
+  connection: McpConnection,
+) => Promise<McpClient>;
 
 /** Result of starting a single MCP server. */
 export interface StartResult {
@@ -51,7 +54,7 @@ export function createMcpManager(
     name: string,
     connection: McpConnection,
   ): Promise<StartResult> {
-    const client = clientFactory(connection);
+    const client = await clientFactory(name, connection);
     try {
       await client.connect();
       const tools = await client.listTools();

--- a/src/mcp/mcp-auth-modal.test.tsx
+++ b/src/mcp/mcp-auth-modal.test.tsx
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderInk } from "../test-utils/ink";
+import { keys } from "../test-utils/keys";
+import { McpAuthModal } from "./mcp-auth-modal";
+
+const AUTH_URL =
+  "https://auth.example.com/authorize?response_type=code&state=abc123&code_challenge=xyz";
+
+describe("McpAuthModal", () => {
+  describe("browser mode", () => {
+    it("renders the server name, auth URL, and browser hint", () => {
+      const { lastFrame } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          onCancel={vi.fn()}
+        />,
+      );
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("Authorize MCP server: github");
+      expect(frame).toContain(AUTH_URL);
+      expect(frame).toContain("Opening your browser");
+      expect(frame).toContain("esc");
+      expect(frame).toContain("cancel");
+    });
+
+    it("does not render a paste-URL prompt", () => {
+      const { lastFrame } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          onCancel={vi.fn()}
+        />,
+      );
+      const frame = lastFrame() ?? "";
+      expect(frame).not.toContain("paste the full callback URL");
+    });
+
+    it("fires onCancel when Esc is pressed", async () => {
+      const onCancel = vi.fn();
+      const { stdin } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          onCancel={onCancel}
+        />,
+      );
+      await stdin.write(keys.escape);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("headless mode", () => {
+    it("renders the paste-URL hint and a prompt cursor", () => {
+      const { lastFrame } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          headless
+          onCancel={vi.fn()}
+          onPasteUrl={vi.fn()}
+        />,
+      );
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("paste the full callback URL");
+      expect(frame).toContain("❯");
+      expect(frame).toContain("enter");
+      expect(frame).toContain("submit");
+    });
+
+    it("does not crash when no paste handler is provided", () => {
+      const { lastFrame } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          headless
+          onCancel={vi.fn()}
+        />,
+      );
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("paste the full callback URL");
+    });
+
+    it("captures typed input and fires onPasteUrl on enter", async () => {
+      const onPasteUrl = vi.fn();
+      const { stdin } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          headless
+          onCancel={vi.fn()}
+          onPasteUrl={onPasteUrl}
+        />,
+      );
+      await stdin.write("http://127.0.0.1:54321/callback?code=xyz&state=abc");
+      await stdin.write(keys.enter);
+      expect(onPasteUrl).toHaveBeenCalledWith(
+        "http://127.0.0.1:54321/callback?code=xyz&state=abc",
+      );
+    });
+
+    it("does not fire onPasteUrl on empty submit", async () => {
+      const onPasteUrl = vi.fn();
+      const { stdin } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          headless
+          onCancel={vi.fn()}
+          onPasteUrl={onPasteUrl}
+        />,
+      );
+      await stdin.write(keys.enter);
+      expect(onPasteUrl).not.toHaveBeenCalled();
+    });
+
+    it("ignores keys that processTextEdit does not handle (e.g. tab)", async () => {
+      // processTextEdit returns null for keys like tab and up/down arrows.
+      // The modal should not crash or submit anything on those.
+      const onPasteUrl = vi.fn();
+      const { stdin } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          headless
+          onCancel={vi.fn()}
+          onPasteUrl={onPasteUrl}
+        />,
+      );
+      await stdin.write(keys.tab);
+      await stdin.write(keys.enter);
+      expect(onPasteUrl).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when a text-edit key returns an unchanged result (e.g. left arrow at start)", async () => {
+      // processTextEdit returns `{value, cursor: 0}` for a left arrow at
+      // column 0 — both fields match the current state so neither setter
+      // should fire. Exercised here purely to cover the equality guards.
+      const onPasteUrl = vi.fn();
+      const { stdin } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          headless
+          onCancel={vi.fn()}
+          onPasteUrl={onPasteUrl}
+        />,
+      );
+      await stdin.write(keys.left);
+      await stdin.write(keys.enter);
+      expect(onPasteUrl).not.toHaveBeenCalled();
+    });
+
+    it("does not fire onPasteUrl on whitespace-only submit", async () => {
+      const onPasteUrl = vi.fn();
+      const { stdin } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          headless
+          onCancel={vi.fn()}
+          onPasteUrl={onPasteUrl}
+        />,
+      );
+      await stdin.write("   ");
+      await stdin.write(keys.enter);
+      expect(onPasteUrl).not.toHaveBeenCalled();
+    });
+
+    it("fires onCancel when Esc is pressed", async () => {
+      const onCancel = vi.fn();
+      const { stdin } = renderInk(
+        <McpAuthModal
+          serverName="github"
+          authUrl={AUTH_URL}
+          headless
+          onCancel={onCancel}
+          onPasteUrl={vi.fn()}
+        />,
+      );
+      await stdin.write(keys.escape);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/mcp/mcp-auth-modal.tsx
+++ b/src/mcp/mcp-auth-modal.tsx
@@ -1,0 +1,143 @@
+import { Box, Text, useInput } from "ink";
+import { useState } from "react";
+import { splitAtCursor } from "../input/cursor";
+import { processTextEdit } from "../input/text-edit";
+import { Border } from "../ui/border";
+import type { InstructionItem } from "../ui/key-instructions";
+import { KeyInstructions } from "../ui/key-instructions";
+import { Indent } from "../ui/layout/indent";
+import { LoadingIndicator } from "../ui/loading-indicator";
+import { theme } from "../ui/theme";
+
+/** Key instructions for the default (browser) mode. */
+const BROWSER_INSTRUCTIONS: InstructionItem[] = [
+  { key: "esc", description: "cancel" },
+];
+
+/** Key instructions for the headless paste mode. */
+const HEADLESS_INSTRUCTIONS: InstructionItem[] = [
+  { key: "enter", description: "submit" },
+  { key: "esc", description: "cancel" },
+];
+
+/** Props for McpAuthModal. */
+export interface McpAuthModalProps {
+  /** Name of the MCP server that is awaiting authorization. */
+  serverName: string;
+  /** Full authorization URL the user should visit in their browser. */
+  authUrl: string;
+  /** When true, a paste-URL input is shown instead of the "waiting for browser" spinner. */
+  headless?: boolean;
+  /** Called when the user cancels the flow (Esc). */
+  onCancel: () => void;
+  /**
+   * Called with the full pasted callback URL when the user submits in
+   * headless mode. The upstream caller is responsible for parsing the URL
+   * and extracting the authorization code.
+   */
+  onPasteUrl?: (callbackUrl: string) => void;
+}
+
+/** Drives Esc-to-cancel for the auth modal. */
+function useMcpAuthModal(props: McpAuthModalProps) {
+  useInput((_input, key) => {
+    if (key.escape) {
+      props.onCancel();
+    }
+  });
+}
+
+/** Props for the headless paste-URL input. */
+interface PasteUrlInputProps {
+  onSubmit: (value: string) => void;
+}
+
+/** Text input that captures the pasted callback URL. */
+function PasteUrlInput(props: PasteUrlInputProps) {
+  const [value, setValue] = useState("");
+  const [cursor, setCursor] = useState(0);
+
+  useInput((input, key) => {
+    if (key.return) {
+      if (value.trim()) props.onSubmit(value.trim());
+      return;
+    }
+    if (key.escape) return; // handled by parent useMcpAuthModal
+    const result = processTextEdit(input, key, value, cursor);
+    if (result) {
+      if (result.value !== value) setValue(result.value);
+      if (result.cursor !== cursor) setCursor(result.cursor);
+    }
+  });
+
+  const split = splitAtCursor(value, cursor);
+
+  return (
+    <Indent>
+      <Text color={theme.brand}>{"❯ "}</Text>
+      <Text>
+        {split.before}
+        <Text inverse>{split.at}</Text>
+        {split.after}
+      </Text>
+    </Indent>
+  );
+}
+
+/**
+ * Bordered modal shown while an MCP server is driving the user through an
+ * OAuth flow. In the default (browser) mode it displays the server name, the
+ * authorization URL, and an animated "waiting for browser" indicator; in the
+ * headless mode it replaces the indicator with a paste-URL input so the user
+ * can finish the flow on a host without a browser. Esc cancels.
+ *
+ * The component is purely presentational — all lifecycle concerns (the
+ * loopback catcher, browser launch, promise race) live upstream.
+ */
+export function McpAuthModal(props: McpAuthModalProps) {
+  useMcpAuthModal(props);
+
+  const instructions = props.headless
+    ? HEADLESS_INSTRUCTIONS
+    : BROWSER_INSTRUCTIONS;
+
+  return (
+    <Box flexDirection="column" paddingTop={1}>
+      <Border color={theme.brand} />
+      <Indent>
+        <Text color={theme.brand}>
+          Authorize MCP server: {props.serverName}
+        </Text>
+      </Indent>
+      <Box paddingTop={1}>
+        <Indent>
+          <Text dimColor>
+            {props.headless
+              ? "Visit the URL below, then paste the full callback URL:"
+              : "Opening your browser — sign in to complete the flow."}
+          </Text>
+        </Indent>
+      </Box>
+      <Box paddingTop={1}>
+        <Indent>
+          <Text>{props.authUrl}</Text>
+        </Indent>
+      </Box>
+      <Box paddingTop={1}>
+        {props.headless ? (
+          props.onPasteUrl !== undefined ? (
+            <PasteUrlInput onSubmit={props.onPasteUrl} />
+          ) : null
+        ) : (
+          <Indent>
+            <LoadingIndicator text="waiting for browser…" />
+          </Indent>
+        )}
+      </Box>
+      <Border color={theme.brand} />
+      <Box justifyContent="flex-end" height={1}>
+        <KeyInstructions items={instructions} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/mcp/mcp-auth-store.test.ts
+++ b/src/mcp/mcp-auth-store.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { McpAuthCancelledError } from "./errors";
+import { createMcpAuthStore } from "./mcp-auth-store";
+
+describe("createMcpAuthStore", () => {
+  describe("push + peek", () => {
+    it("peek returns null when empty", () => {
+      const store = createMcpAuthStore();
+      expect(store.peek()).toBeNull();
+      expect(store.size()).toBe(0);
+    });
+
+    it("push returns an id and a pending promise, and the entry is visible via peek", () => {
+      const store = createMcpAuthStore();
+      const handle = store.push({
+        serverName: "github",
+        authUrl: "https://auth.example.com/authorize?state=abc",
+      });
+      expect(handle.id).toBeTruthy();
+      expect(handle.pending).toBeInstanceOf(Promise);
+      expect(store.size()).toBe(1);
+      const front = store.peek();
+      expect(front?.id).toBe(handle.id);
+      expect(front?.serverName).toBe("github");
+      expect(front?.authUrl).toBe(
+        "https://auth.example.com/authorize?state=abc",
+      );
+    });
+
+    it("peek returns a stable reference for the same front entry", () => {
+      const store = createMcpAuthStore();
+      store.push({ serverName: "a", authUrl: "u" });
+      const first = store.peek();
+      const second = store.peek();
+      expect(first).toBe(second);
+    });
+
+    it("peek always returns the front entry (FIFO)", () => {
+      const store = createMcpAuthStore();
+      const first = store.push({ serverName: "a", authUrl: "u1" });
+      store.push({ serverName: "b", authUrl: "u2" });
+      expect(store.peek()?.id).toBe(first.id);
+    });
+  });
+
+  describe("resolveWithCode", () => {
+    it("resolves the pending promise and removes the entry", async () => {
+      const store = createMcpAuthStore();
+      const handle = store.push({ serverName: "x", authUrl: "u" });
+      store.resolveWithCode(handle.id, "the-code");
+      await expect(handle.pending).resolves.toBe("the-code");
+      expect(store.peek()).toBeNull();
+    });
+
+    it("is a no-op for an unknown id", () => {
+      const store = createMcpAuthStore();
+      expect(() => store.resolveWithCode("missing", "code")).not.toThrow();
+    });
+  });
+
+  describe("cancel", () => {
+    it("rejects the pending promise with McpAuthCancelledError and removes the entry", async () => {
+      const store = createMcpAuthStore();
+      const handle = store.push({ serverName: "github", authUrl: "u" });
+      store.cancel(handle.id);
+      await expect(handle.pending).rejects.toBeInstanceOf(
+        McpAuthCancelledError,
+      );
+      await expect(handle.pending).rejects.toThrow(
+        /MCP server 'github' authorization cancelled/,
+      );
+      expect(store.peek()).toBeNull();
+    });
+
+    it("is a no-op for an unknown id", () => {
+      const store = createMcpAuthStore();
+      expect(() => store.cancel("missing")).not.toThrow();
+    });
+  });
+
+  describe("dismiss", () => {
+    it("removes the entry from the queue without settling the promise", async () => {
+      const store = createMcpAuthStore();
+      const handle = store.push({ serverName: "x", authUrl: "u" });
+      store.dismiss(handle.id);
+      expect(store.peek()).toBeNull();
+
+      // Prove the promise did not settle by racing it against a short timer.
+      const timeout = new Promise<string>((resolve) =>
+        setTimeout(() => resolve("timed out"), 10),
+      );
+      await expect(Promise.race([handle.pending, timeout])).resolves.toBe(
+        "timed out",
+      );
+    });
+
+    it("is a no-op for an unknown id", () => {
+      const store = createMcpAuthStore();
+      expect(() => store.dismiss("missing")).not.toThrow();
+    });
+  });
+
+  describe("subscribe", () => {
+    it("notifies subscribers on push, resolveWithCode, cancel, and dismiss", () => {
+      const store = createMcpAuthStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      const first = store.push({ serverName: "a", authUrl: "u" });
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      store.resolveWithCode(first.id, "code");
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      const second = store.push({ serverName: "b", authUrl: "u" });
+      expect(listener).toHaveBeenCalledTimes(3);
+
+      store.cancel(second.id);
+      // Capture the error to avoid an unhandled rejection warning.
+      second.pending.catch(() => {});
+      expect(listener).toHaveBeenCalledTimes(4);
+
+      const third = store.push({ serverName: "c", authUrl: "u" });
+      expect(listener).toHaveBeenCalledTimes(5);
+
+      store.dismiss(third.id);
+      expect(listener).toHaveBeenCalledTimes(6);
+    });
+
+    it("unsubscribe stops further notifications", () => {
+      const store = createMcpAuthStore();
+      const listener = vi.fn();
+      const unsubscribe = store.subscribe(listener);
+      store.push({ serverName: "a", authUrl: "u" });
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsubscribe();
+      store.push({ serverName: "b", authUrl: "u" });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not notify when resolveWithCode/cancel/dismiss hit an unknown id", () => {
+      const store = createMcpAuthStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+      store.resolveWithCode("missing", "code");
+      store.cancel("missing");
+      store.dismiss("missing");
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/mcp/mcp-auth-store.ts
+++ b/src/mcp/mcp-auth-store.ts
@@ -1,0 +1,140 @@
+import { McpAuthCancelledError } from "./errors";
+
+/** Parameters describing an in-flight MCP OAuth authorization prompt. */
+export interface McpAuthParams {
+  /** Name of the MCP server that is driving the user through the flow. */
+  serverName: string;
+  /** Authorization URL the user should visit in their browser. */
+  authUrl: string;
+}
+
+/** A pending auth prompt as rendered in the chat UI. */
+export interface McpAuthPending extends McpAuthParams {
+  /** Unique identifier, used to resolve or dismiss the entry. */
+  id: string;
+}
+
+/** Handle returned from `push`, letting the producer await the user's response. */
+export interface McpAuthPushHandle {
+  /** Identifier of the pushed entry. */
+  id: string;
+  /**
+   * Resolves with the authorization code when the user pastes a valid
+   * callback URL into the modal. Rejects with `McpAuthCancelledError` when
+   * the user cancels. Stays pending forever if the entry is dismissed
+   * without being resolved or cancelled — callers that race this against
+   * another source should drop their reference after the race settles.
+   */
+  pending: Promise<string>;
+}
+
+/** Store of pending MCP OAuth prompts, modelled on the chat prompt queue. */
+export interface McpAuthStore {
+  /** Pushes a new pending entry and returns the id plus a promise to await the result. */
+  push(params: McpAuthParams): McpAuthPushHandle;
+  /** Removes an entry from the queue without settling its pending promise. */
+  dismiss(id: string): void;
+  /**
+   * Resolves the entry's pending promise with the authorization code
+   * extracted from the pasted callback URL. No-op if the id is unknown.
+   */
+  resolveWithCode(id: string, code: string): void;
+  /**
+   * Rejects the entry's pending promise with `McpAuthCancelledError`. Used
+   * when the user hits Esc on the modal.
+   */
+  cancel(id: string): void;
+  /** Returns the front-of-queue entry, or null if empty. */
+  peek(): McpAuthPending | null;
+  /** Returns the current queue length. */
+  size(): number;
+  /** Subscribes to queue changes. Returns an unsubscribe function. */
+  subscribe(listener: () => void): () => void;
+}
+
+/** Internal entry shape that also carries the promise's resolve/reject hooks. */
+interface InternalEntry extends McpAuthPending {
+  resolve: (code: string) => void;
+  reject: (error: Error) => void;
+}
+
+/** Creates a new in-memory MCP auth store. */
+export function createMcpAuthStore(): McpAuthStore {
+  const entries: InternalEntry[] = [];
+  const listeners = new Set<() => void>();
+
+  /** Notifies all subscribers that the queue changed. */
+  function notify(): void {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  /** Removes the entry with the given id and returns it, or undefined. */
+  function takeEntry(id: string): InternalEntry | undefined {
+    const index = entries.findIndex((entry) => entry.id === id);
+    if (index === -1) return undefined;
+    const [entry] = entries.splice(index, 1);
+    return entry;
+  }
+
+  return {
+    push(params) {
+      const id = crypto.randomUUID();
+      let resolve!: (code: string) => void;
+      let reject!: (error: Error) => void;
+      const pending = new Promise<string>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      entries.push({
+        id,
+        serverName: params.serverName,
+        authUrl: params.authUrl,
+        resolve,
+        reject,
+      });
+      notify();
+      return { id, pending };
+    },
+
+    dismiss(id) {
+      const removed = takeEntry(id);
+      if (removed) notify();
+    },
+
+    resolveWithCode(id, code) {
+      const entry = takeEntry(id);
+      if (!entry) return;
+      entry.resolve(code);
+      notify();
+    },
+
+    cancel(id) {
+      const entry = takeEntry(id);
+      if (!entry) return;
+      entry.reject(new McpAuthCancelledError(entry.serverName));
+      notify();
+    },
+
+    peek() {
+      // Return the internal entry directly (not a fresh projection) so
+      // `useSyncExternalStore` sees a stable snapshot reference and does
+      // not re-render on every tick. `InternalEntry` is a subtype of
+      // `McpAuthPending`, so the extra `resolve`/`reject` fields are
+      // simply invisible to callers that use the declared type.
+      return entries[0] ?? null;
+    },
+
+    size() {
+      return entries.length;
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/src/mcp/oauth-loopback.test.ts
+++ b/src/mcp/oauth-loopback.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createLoopbackCatcher } from "./oauth-loopback";
+
+describe("createLoopbackCatcher", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0)) {
+      await cleanup();
+    }
+  });
+
+  /** Starts a catcher and registers it for afterEach teardown. */
+  async function start(options?: Parameters<typeof createLoopbackCatcher>[0]) {
+    const catcher = await createLoopbackCatcher(options);
+    cleanups.push(() => catcher.close());
+    return catcher;
+  }
+
+  describe("binding", () => {
+    it("binds an ephemeral port when none is provided", async () => {
+      const catcher = await start();
+      expect(catcher.port).toBeGreaterThan(0);
+      expect(catcher.redirectUri).toBe(
+        `http://127.0.0.1:${catcher.port}/callback`,
+      );
+    });
+
+    it("binds a specific port when provided", async () => {
+      // Ask the OS for a free port first so the test is deterministic.
+      const probe = await start();
+      const reservedPort = probe.port;
+      await probe.close();
+      cleanups.pop();
+
+      const catcher = await start({ port: reservedPort });
+      expect(catcher.port).toBe(reservedPort);
+    });
+
+    it("rejects when the requested port is already in use", async () => {
+      const first = await start();
+      await expect(
+        createLoopbackCatcher({ port: first.port }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("waitForCode happy path", () => {
+    it("resolves with the code when state matches", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      const pending = catcher.waitForCode({
+        expectedState: "abc123",
+        signal: abort.signal,
+      });
+
+      const response = await fetch(
+        `${catcher.redirectUri}?code=the-code&state=abc123`,
+      );
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain("Signed in");
+
+      await expect(pending).resolves.toBe("the-code");
+    });
+
+    it("includes URL-encoded codes in the resolution", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      const pending = catcher.waitForCode({
+        expectedState: "s",
+        signal: abort.signal,
+      });
+
+      await fetch(
+        `${catcher.redirectUri}?code=${encodeURIComponent("code with spaces/+")}&state=s`,
+      );
+      await expect(pending).resolves.toBe("code with spaces/+");
+    });
+  });
+
+  describe("waitForCode rejections", () => {
+    it("rejects on state mismatch and responds with 400", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      const pending = catcher.waitForCode({
+        expectedState: "expected",
+        signal: abort.signal,
+      });
+      // Attach the rejection assertion before the request that triggers it
+      // so node does not see a transient unhandled rejection.
+      const pendingAssertion =
+        expect(pending).rejects.toThrow(/state mismatch/i);
+
+      const response = await fetch(
+        `${catcher.redirectUri}?code=the-code&state=wrong`,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("State mismatch");
+
+      await pendingAssertion;
+    });
+
+    it("rejects when the callback has an `error` parameter with description", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      const pending = catcher.waitForCode({
+        expectedState: "s",
+        signal: abort.signal,
+      });
+      const pendingAssertion = expect(pending).rejects.toThrow(
+        /access_denied: User declined/,
+      );
+
+      const response = await fetch(
+        `${catcher.redirectUri}?error=access_denied&error_description=User+declined&state=s`,
+      );
+      expect(response.status).toBe(400);
+      const body = await response.text();
+      expect(body).toContain("Authorization error");
+      expect(body).toContain("access_denied");
+      expect(body).toContain("User declined");
+
+      await pendingAssertion;
+    });
+
+    it("rejects with just the error code when no description is present", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      const pending = catcher.waitForCode({
+        expectedState: "s",
+        signal: abort.signal,
+      });
+      const pendingAssertion = expect(pending).rejects.toThrow(
+        /OAuth authorization error: invalid_scope$/,
+      );
+
+      const response = await fetch(
+        `${catcher.redirectUri}?error=invalid_scope&state=s`,
+      );
+      expect(response.status).toBe(400);
+
+      await pendingAssertion;
+    });
+
+    it("rejects when the callback is missing a code", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      const pending = catcher.waitForCode({
+        expectedState: "s",
+        signal: abort.signal,
+      });
+      const pendingAssertion =
+        expect(pending).rejects.toThrow(/missing `code`/);
+
+      const response = await fetch(`${catcher.redirectUri}?state=s`);
+      expect(response.status).toBe(400);
+
+      await pendingAssertion;
+    });
+
+    it("rejects when the wait times out", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      await expect(
+        catcher.waitForCode({
+          expectedState: "s",
+          signal: abort.signal,
+          timeoutMs: 20,
+        }),
+      ).rejects.toThrow(/timed out/);
+    });
+
+    it("rejects immediately when the signal is already aborted", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      abort.abort();
+      await expect(
+        catcher.waitForCode({
+          expectedState: "s",
+          signal: abort.signal,
+        }),
+      ).rejects.toThrow(/aborted/);
+    });
+
+    it("rejects when the signal is aborted mid-wait", async () => {
+      const catcher = await start();
+      const abort = new AbortController();
+      const pending = catcher.waitForCode({
+        expectedState: "s",
+        signal: abort.signal,
+      });
+      abort.abort();
+      await expect(pending).rejects.toThrow(/aborted/);
+    });
+  });
+
+  describe("request routing", () => {
+    it("404s non-callback paths", async () => {
+      const catcher = await start();
+      const response = await fetch(
+        `http://127.0.0.1:${catcher.port}/anything-else`,
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("responds 409 when a callback arrives with no active wait", async () => {
+      const catcher = await start();
+      const response = await fetch(`${catcher.redirectUri}?code=stray&state=s`);
+      expect(response.status).toBe(409);
+    });
+  });
+
+  describe("close", () => {
+    it("close is idempotent", async () => {
+      const catcher = await start();
+      await catcher.close();
+      await expect(catcher.close()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/mcp/oauth-loopback.test.ts
+++ b/src/mcp/oauth-loopback.test.ts
@@ -210,6 +210,46 @@ describe("createLoopbackCatcher", () => {
     });
   });
 
+  describe("concurrent waits", () => {
+    it("a settling stale wait does not clobber a newer wait's dispatch", async () => {
+      // Regression: cleanup() used to unconditionally null the outer
+      // `dispatch` slot, so if a stale first wait settled (via abort or
+      // timeout) after a second wait installed its handler, the second
+      // wait's dispatch was clobbered and its callback returned 409.
+      const catcher = await start();
+
+      // Start + abort a first wait so its cleanup runs *after* the
+      // second wait is registered below.
+      const firstAbort = new AbortController();
+      const firstPending = catcher.waitForCode({
+        expectedState: "first",
+        signal: firstAbort.signal,
+      });
+      // Attach the rejection handler before triggering it.
+      const firstAssertion = expect(firstPending).rejects.toThrow(/aborted/);
+
+      // Register a second wait. At this point the outer dispatch slot
+      // should be the second wait's handler.
+      const secondAbort = new AbortController();
+      const secondPending = catcher.waitForCode({
+        expectedState: "second",
+        signal: secondAbort.signal,
+      });
+
+      // Now tear down the first wait. Its cleanup must NOT clear the
+      // outer dispatch slot — it no longer owns it.
+      firstAbort.abort();
+      await firstAssertion;
+
+      // The second wait's callback must still be routed.
+      const response = await fetch(
+        `${catcher.redirectUri}?code=the-code&state=second`,
+      );
+      expect(response.status).toBe(200);
+      await expect(secondPending).resolves.toBe("the-code");
+    });
+  });
+
   describe("close", () => {
     it("close is idempotent", async () => {
       const catcher = await start();

--- a/src/mcp/oauth-loopback.ts
+++ b/src/mcp/oauth-loopback.ts
@@ -78,10 +78,21 @@ export function createLoopbackCatcher(
           return new Promise<string>((resolve, reject) => {
             const timeoutMs = waitOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
+            // Identity-guarded cleanup: only clears the outer `dispatch`
+            // slot if it still points at *this* wait's handler, so a
+            // settling stale wait cannot clobber a newer wait that has
+            // since installed its own dispatch. `myDispatch` is assigned
+            // below after the early-abort guard; the null-check here
+            // makes cleanup() a no-op for the dispatch slot until then.
+            let myDispatch:
+              | ((url: URL) => { status: number; body: string })
+              | null = null;
             const cleanup = () => {
               clearTimeout(timer);
               waitOpts.signal.removeEventListener("abort", onAbort);
-              dispatch = null;
+              if (myDispatch !== null && dispatch === myDispatch) {
+                dispatch = null;
+              }
             };
 
             const onAbort = () => {
@@ -101,7 +112,7 @@ export function createLoopbackCatcher(
             }
             waitOpts.signal.addEventListener("abort", onAbort, { once: true });
 
-            dispatch = (url) => {
+            myDispatch = (url: URL) => {
               cleanup();
               const error = url.searchParams.get("error");
               if (error) {
@@ -127,6 +138,7 @@ export function createLoopbackCatcher(
                 body: "Signed in. You can close this tab and return to tomo.",
               };
             };
+            dispatch = myDispatch;
           });
         },
         close() {

--- a/src/mcp/oauth-loopback.ts
+++ b/src/mcp/oauth-loopback.ts
@@ -1,0 +1,138 @@
+import { createServer } from "node:http";
+
+/** Default timeout for the authorization callback — 5 minutes. */
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Options for creating a loopback catcher. */
+export interface CreateLoopbackCatcherOptions {
+  /** Fixed port to bind. Omit to let the OS assign an ephemeral port. */
+  port?: number;
+}
+
+/** Options for `waitForCode`. */
+export interface WaitForCodeOptions {
+  /** OAuth `state` value the callback must echo back for the code to be accepted. */
+  expectedState: string;
+  /** Aborts the wait — the promise rejects and the waiter is cleared. */
+  signal: AbortSignal;
+  /** Overrides the default 5-minute wait. */
+  timeoutMs?: number;
+}
+
+/** A loopback HTTP server that catches a single OAuth authorization-code redirect. */
+export interface LoopbackCatcher {
+  /** Redirect URI advertised to the authorization server (e.g. `http://127.0.0.1:54321/callback`). */
+  redirectUri: string;
+  /** Bound port — persist this so the same URI can be reused across restarts. */
+  port: number;
+  /** Resolves with the authorization code, rejects on state mismatch, OAuth error, abort, or timeout. */
+  waitForCode(options: WaitForCodeOptions): Promise<string>;
+  /** Shuts down the underlying HTTP server. Idempotent. */
+  close(): Promise<void>;
+}
+
+/**
+ * Binds an HTTP server to `127.0.0.1` that listens for a single OAuth
+ * authorization-code redirect on `/callback`. A fixed port can be supplied so
+ * the same redirect URI (registered at DCR time) can be reused across
+ * restarts; when omitted the OS assigns an ephemeral port.
+ */
+export function createLoopbackCatcher(
+  options: CreateLoopbackCatcherOptions = {},
+): Promise<LoopbackCatcher> {
+  return new Promise((resolveCreate, rejectCreate) => {
+    // Set by waitForCode while a flow is in progress. Given the callback URL,
+    // returns the HTTP response body to send to the browser and settles the
+    // wait promise as a side effect. Null means no flow is currently active.
+    let dispatch: ((url: URL) => { status: number; body: string }) | null =
+      null;
+
+    const server = createServer((req, res) => {
+      /* v8 ignore next -- req.url is always set by the node http parser */
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const result =
+        url.pathname !== "/callback"
+          ? { status: 404, body: "Not Found" }
+          : !dispatch
+            ? { status: 409, body: "No active OAuth flow" }
+            : dispatch(url);
+      res.writeHead(result.status, { "content-type": "text/plain" });
+      res.end(result.body);
+    });
+
+    server.once("error", rejectCreate);
+    server.listen(options.port ?? 0, "127.0.0.1", () => {
+      const address = server.address();
+      /* v8 ignore next 5 -- TCP listens always return an AddressInfo object */
+      if (typeof address !== "object" || address === null) {
+        server.close();
+        rejectCreate(new Error("loopback server did not bind to a TCP port"));
+        return;
+      }
+      const port = address.port;
+
+      resolveCreate({
+        redirectUri: `http://127.0.0.1:${port}/callback`,
+        port,
+        waitForCode(waitOpts) {
+          return new Promise<string>((resolve, reject) => {
+            const timeoutMs = waitOpts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+            const cleanup = () => {
+              clearTimeout(timer);
+              waitOpts.signal.removeEventListener("abort", onAbort);
+              dispatch = null;
+            };
+
+            const onAbort = () => {
+              cleanup();
+              reject(new Error("loopback wait aborted"));
+            };
+
+            const timer = setTimeout(() => {
+              cleanup();
+              reject(new Error(`loopback wait timed out after ${timeoutMs}ms`));
+            }, timeoutMs);
+
+            if (waitOpts.signal.aborted) {
+              cleanup();
+              reject(new Error("loopback wait aborted"));
+              return;
+            }
+            waitOpts.signal.addEventListener("abort", onAbort, { once: true });
+
+            dispatch = (url) => {
+              cleanup();
+              const error = url.searchParams.get("error");
+              if (error) {
+                const description = url.searchParams.get("error_description");
+                const message = description
+                  ? `${error}: ${description}`
+                  : error;
+                reject(new Error(`OAuth authorization error: ${message}`));
+                return { status: 400, body: `Authorization error: ${message}` };
+              }
+              if (url.searchParams.get("state") !== waitOpts.expectedState) {
+                reject(new Error("OAuth callback state mismatch"));
+                return { status: 400, body: "State mismatch" };
+              }
+              const code = url.searchParams.get("code");
+              if (!code) {
+                reject(new Error("OAuth callback missing `code` parameter"));
+                return { status: 400, body: "Missing code" };
+              }
+              resolve(code);
+              return {
+                status: 200,
+                body: "Signed in. You can close this tab and return to tomo.",
+              };
+            };
+          });
+        },
+        close() {
+          return new Promise<void>((r) => server.close(() => r()));
+        },
+      });
+    });
+  });
+}

--- a/src/mcp/oauth-provider.test.ts
+++ b/src/mcp/oauth-provider.test.ts
@@ -88,6 +88,28 @@ describe("createMcpOAuthProvider", () => {
     });
   });
 
+  describe("state", () => {
+    it("returns a non-empty value so the SDK always embeds state in the auth URL", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.state().length).toBeGreaterThan(0);
+    });
+
+    it("returns a fresh value on each call", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.state()).not.toBe(provider.state());
+    });
+  });
+
   describe("clientInformation", () => {
     it("returns undefined when no config and no persisted state (SDK triggers DCR)", () => {
       const provider = createMcpOAuthProvider({

--- a/src/mcp/oauth-provider.test.ts
+++ b/src/mcp/oauth-provider.test.ts
@@ -1,0 +1,395 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMcpOAuthProvider } from "./oauth-provider";
+import { readOAuthState, writeOAuthState } from "./oauth-storage";
+
+const REDIRECT_URI = "http://127.0.0.1:54321/callback";
+
+function makeTokens(overrides: Partial<OAuthTokens> = {}): OAuthTokens {
+  return {
+    access_token: "at",
+    token_type: "Bearer",
+    ...overrides,
+  };
+}
+
+describe("createMcpOAuthProvider", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(resolve(tmpdir(), "tomo-oauth-provider-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("clientMetadata", () => {
+    it("returns a tomo-branded metadata document with token_endpoint_auth_method 'none' for public clients", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      const metadata = provider.clientMetadata;
+      expect(metadata.client_name).toBe("tomo");
+      expect(metadata.redirect_uris).toEqual([REDIRECT_URI]);
+      expect(metadata.grant_types).toEqual([
+        "authorization_code",
+        "refresh_token",
+      ]);
+      expect(metadata.response_types).toEqual(["code"]);
+      expect(metadata.token_endpoint_auth_method).toBe("none");
+      expect(metadata.scope).toBeUndefined();
+    });
+
+    it("uses client_secret_basic when a clientSecret is configured", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        config: { clientId: "id", clientSecret: "secret" },
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.clientMetadata.token_endpoint_auth_method).toBe(
+        "client_secret_basic",
+      );
+    });
+
+    it("forwards the configured scope into clientMetadata", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        config: { scope: "read write" },
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.clientMetadata.scope).toBe("read write");
+    });
+  });
+
+  describe("redirectUrl", () => {
+    it("returns the configured redirect URI", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.redirectUrl).toBe(REDIRECT_URI);
+    });
+  });
+
+  describe("clientInformation", () => {
+    it("returns undefined when no config and no persisted state (SDK triggers DCR)", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.clientInformation()).toBeUndefined();
+    });
+
+    it("returns a synthesised object when config.clientId is set", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        config: { clientId: "pre-registered" },
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.clientInformation()).toEqual({
+        client_id: "pre-registered",
+      });
+    });
+
+    it("includes client_secret when configured", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        config: { clientId: "pre", clientSecret: "s3cret" },
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.clientInformation()).toEqual({
+        client_id: "pre",
+        client_secret: "s3cret",
+      });
+    });
+
+    it("prefers configured clientId over any persisted client information", () => {
+      writeOAuthState(dir, "github", {
+        clientInformation: { client_id: "persisted" },
+      });
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        config: { clientId: "from-config" },
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.clientInformation()).toEqual({
+        client_id: "from-config",
+      });
+    });
+
+    it("returns persisted client information when config is empty", () => {
+      writeOAuthState(dir, "github", {
+        clientInformation: { client_id: "from-dcr" },
+      });
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.clientInformation()).toEqual({
+        client_id: "from-dcr",
+      });
+    });
+  });
+
+  describe("saveClientInformation", () => {
+    it("persists the provided client information to disk", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      const info: OAuthClientInformationFull = {
+        client_id: "from-dcr",
+        client_secret: "dcr-secret",
+        redirect_uris: [REDIRECT_URI],
+      };
+      provider.saveClientInformation(info);
+      expect(readOAuthState(dir, "github").clientInformation).toEqual(info);
+    });
+  });
+
+  describe("tokens / saveTokens", () => {
+    it("returns undefined when no tokens are persisted", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.tokens()).toBeUndefined();
+    });
+
+    it("round-trips tokens via saveTokens + tokens()", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      const tokens = makeTokens({ refresh_token: "rt", expires_in: 3600 });
+      provider.saveTokens(tokens);
+      expect(provider.tokens()).toEqual(tokens);
+    });
+
+    it("overwrites previously persisted tokens (refresh rotation)", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      provider.saveTokens(makeTokens({ access_token: "old" }));
+      provider.saveTokens(makeTokens({ access_token: "new" }));
+      expect(provider.tokens()?.access_token).toBe("new");
+    });
+  });
+
+  describe("codeVerifier / saveCodeVerifier", () => {
+    it("round-trips the PKCE verifier", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      provider.saveCodeVerifier("verifier-value");
+      expect(provider.codeVerifier()).toBe("verifier-value");
+    });
+
+    it("throws when no verifier is persisted", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(() => provider.codeVerifier()).toThrow(
+        /no PKCE code verifier persisted for MCP server 'github'/,
+      );
+    });
+  });
+
+  describe("discoveryState / saveDiscoveryState", () => {
+    it("round-trips discovery state", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      const state: OAuthDiscoveryState = {
+        authorizationServerUrl: "https://auth.example.com",
+      };
+      provider.saveDiscoveryState(state);
+      expect(provider.discoveryState()).toEqual(state);
+    });
+
+    it("returns undefined when no discovery state is persisted", () => {
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      expect(provider.discoveryState()).toBeUndefined();
+    });
+  });
+
+  describe("redirectToAuthorization", () => {
+    it("invokes the onRedirect callback with the authorization URL", async () => {
+      const onRedirect = vi.fn();
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect,
+      });
+      const url = new URL("https://auth.example.com/authorize?state=abc");
+      await provider.redirectToAuthorization(url);
+      expect(onRedirect).toHaveBeenCalledWith(url);
+    });
+
+    it("awaits an async onRedirect", async () => {
+      let resolved = false;
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: async () => {
+          await Promise.resolve();
+          resolved = true;
+        },
+      });
+      await provider.redirectToAuthorization(
+        new URL("https://auth.example.com/authorize"),
+      );
+      expect(resolved).toBe(true);
+    });
+  });
+
+  describe("invalidateCredentials", () => {
+    function seedFullState(): void {
+      writeOAuthState(dir, "github", {
+        clientInformation: { client_id: "dcr-id" },
+        tokens: makeTokens(),
+        codeVerifier: "v",
+        discoveryState: { authorizationServerUrl: "https://auth" },
+        redirectPort: 12345,
+      });
+    }
+
+    it("'all' deletes the state file entirely", () => {
+      seedFullState();
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      provider.invalidateCredentials("all");
+      expect(readOAuthState(dir, "github")).toEqual({});
+    });
+
+    it("'tokens' clears only the tokens field", () => {
+      seedFullState();
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      provider.invalidateCredentials("tokens");
+      const state = readOAuthState(dir, "github");
+      expect(state.tokens).toBeUndefined();
+      expect(state.clientInformation).toEqual({ client_id: "dcr-id" });
+      expect(state.codeVerifier).toBe("v");
+      expect(state.discoveryState).toEqual({
+        authorizationServerUrl: "https://auth",
+      });
+      expect(state.redirectPort).toBe(12345);
+    });
+
+    it("'client' clears only the clientInformation field", () => {
+      seedFullState();
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      provider.invalidateCredentials("client");
+      const state = readOAuthState(dir, "github");
+      expect(state.clientInformation).toBeUndefined();
+      expect(state.tokens).toEqual(makeTokens());
+    });
+
+    it("'client' does not affect pre-registered clientInformation returned by the provider", () => {
+      seedFullState();
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        config: { clientId: "pre" },
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      provider.invalidateCredentials("client");
+      expect(provider.clientInformation()).toEqual({ client_id: "pre" });
+    });
+
+    it("'verifier' clears only the codeVerifier field", () => {
+      seedFullState();
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      provider.invalidateCredentials("verifier");
+      const state = readOAuthState(dir, "github");
+      expect(state.codeVerifier).toBeUndefined();
+      expect(state.tokens).toEqual(makeTokens());
+    });
+
+    it("'discovery' clears only the discoveryState field", () => {
+      seedFullState();
+      const provider = createMcpOAuthProvider({
+        serverName: "github",
+        dataDir: dir,
+        redirectUri: REDIRECT_URI,
+        onRedirect: vi.fn(),
+      });
+      provider.invalidateCredentials("discovery");
+      const state = readOAuthState(dir, "github");
+      expect(state.discoveryState).toBeUndefined();
+      expect(state.tokens).toEqual(makeTokens());
+    });
+  });
+});

--- a/src/mcp/oauth-provider.ts
+++ b/src/mcp/oauth-provider.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type {
   OAuthClientProvider,
   OAuthDiscoveryState,
@@ -31,6 +32,7 @@ export interface McpOAuthConfig {
 export interface McpOAuthProvider extends OAuthClientProvider {
   get redirectUrl(): string;
   get clientMetadata(): OAuthClientMetadata;
+  state(): string;
   clientInformation(): OAuthClientInformationMixed | undefined;
   saveClientInformation(info: OAuthClientInformationMixed): void;
   tokens(): OAuthTokens | undefined;
@@ -125,6 +127,16 @@ export function createMcpOAuthProvider(
 
     get clientMetadata(): OAuthClientMetadata {
       return clientMetadata;
+    },
+
+    state(): string {
+      // A fresh CSRF-protection value per authorization attempt. The SDK
+      // calls this once per auth flow and embeds the return value in the
+      // authorization URL. Authorization servers that do not receive a
+      // `state` parameter will not echo one on the callback, so we must
+      // always provide one or the loopback's state validation rejects
+      // every callback.
+      return randomUUID();
     },
 
     clientInformation(): OAuthClientInformationMixed | undefined {

--- a/src/mcp/oauth-provider.ts
+++ b/src/mcp/oauth-provider.ts
@@ -1,0 +1,193 @@
+import type {
+  OAuthClientProvider,
+  OAuthDiscoveryState,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformation,
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import {
+  type McpOAuthState,
+  deleteOAuthState,
+  readOAuthState,
+  writeOAuthState,
+} from "./oauth-storage";
+
+/** Pre-registered OAuth client configuration sourced from the MCP connection config. */
+export interface McpOAuthConfig {
+  clientId?: string;
+  clientSecret?: string;
+  scope?: string;
+}
+
+/**
+ * Tomo's narrowed `OAuthClientProvider`. Every persistence method is
+ * synchronous (backed by local JSON files) and every optional hook from the
+ * SDK's interface is implemented as required. Callers that need the wider SDK
+ * type can simply assign an `McpOAuthProvider` into an `OAuthClientProvider`.
+ */
+export interface McpOAuthProvider extends OAuthClientProvider {
+  get redirectUrl(): string;
+  get clientMetadata(): OAuthClientMetadata;
+  clientInformation(): OAuthClientInformationMixed | undefined;
+  saveClientInformation(info: OAuthClientInformationMixed): void;
+  tokens(): OAuthTokens | undefined;
+  saveTokens(tokens: OAuthTokens): void;
+  redirectToAuthorization(authorizationUrl: URL): Promise<void>;
+  saveCodeVerifier(codeVerifier: string): void;
+  codeVerifier(): string;
+  discoveryState(): OAuthDiscoveryState | undefined;
+  saveDiscoveryState(state: OAuthDiscoveryState): void;
+  invalidateCredentials(
+    scope: "all" | "client" | "tokens" | "verifier" | "discovery",
+  ): void;
+}
+
+/** Construction options for `createMcpOAuthProvider`. */
+export interface McpOAuthProviderOptions {
+  /** Name of the MCP server — used as the state-file stem. */
+  serverName: string;
+  /** Directory holding per-server state files (typically `MCP_OAUTH_DIR`). */
+  dataDir: string;
+  /** Optional pre-registered client configuration. When `clientId` is set, dynamic client registration is skipped. */
+  config?: McpOAuthConfig;
+  /** Full redirect URI to advertise in `clientMetadata.redirect_uris` (e.g. `http://127.0.0.1:PORT/callback`). */
+  redirectUri: string;
+  /** Invoked when the SDK is ready to drive the user to the authorization URL. */
+  onRedirect: (authorizationUrl: URL) => void | Promise<void>;
+}
+
+/**
+ * Merges updates into the current state for a server and writes the result back
+ * to disk. Returns the new state so callers can chain further reads.
+ */
+function updateState(
+  opts: McpOAuthProviderOptions,
+  patch: Partial<McpOAuthState>,
+): McpOAuthState {
+  const current = readOAuthState(opts.dataDir, opts.serverName);
+  const next: McpOAuthState = { ...current, ...patch };
+  writeOAuthState(opts.dataDir, opts.serverName, next);
+  return next;
+}
+
+/** Builds the static `OAuthClientMetadata` document derived from provider options. */
+function buildClientMetadata(
+  opts: McpOAuthProviderOptions,
+): OAuthClientMetadata {
+  const metadata: OAuthClientMetadata = {
+    client_name: "tomo",
+    redirect_uris: [opts.redirectUri],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: opts.config?.clientSecret
+      ? "client_secret_basic"
+      : "none",
+  };
+  if (opts.config?.scope) {
+    metadata.scope = opts.config.scope;
+  }
+  return metadata;
+}
+
+/** Returns the pre-registered client information synthesised from config, or undefined when none is configured. */
+function preRegisteredClient(
+  opts: McpOAuthProviderOptions,
+): OAuthClientInformation | undefined {
+  if (!opts.config?.clientId) return undefined;
+  const info: OAuthClientInformation = { client_id: opts.config.clientId };
+  if (opts.config.clientSecret) {
+    info.client_secret = opts.config.clientSecret;
+  }
+  return info;
+}
+
+/**
+ * Creates a disk-backed `OAuthClientProvider` for a single MCP server.
+ *
+ * State is persisted under `<dataDir>/<serverName>.json` at mode 0600 so that
+ * tokens, client registration, PKCE verifier, discovery cache, and the loopback
+ * redirect port survive restarts. Pre-registered clients in `opts.config` take
+ * precedence over any persisted client information and cause the SDK to skip
+ * dynamic client registration.
+ */
+export function createMcpOAuthProvider(
+  opts: McpOAuthProviderOptions,
+): McpOAuthProvider {
+  const clientMetadata = buildClientMetadata(opts);
+
+  return {
+    get redirectUrl(): string {
+      return opts.redirectUri;
+    },
+
+    get clientMetadata(): OAuthClientMetadata {
+      return clientMetadata;
+    },
+
+    clientInformation(): OAuthClientInformationMixed | undefined {
+      const preRegistered = preRegisteredClient(opts);
+      if (preRegistered) return preRegistered;
+      return readOAuthState(opts.dataDir, opts.serverName).clientInformation;
+    },
+
+    saveClientInformation(info: OAuthClientInformationMixed): void {
+      updateState(opts, { clientInformation: info });
+    },
+
+    tokens(): OAuthTokens | undefined {
+      return readOAuthState(opts.dataDir, opts.serverName).tokens;
+    },
+
+    saveTokens(tokens: OAuthTokens): void {
+      updateState(opts, { tokens });
+    },
+
+    async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+      await opts.onRedirect(authorizationUrl);
+    },
+
+    saveCodeVerifier(codeVerifier: string): void {
+      updateState(opts, { codeVerifier });
+    },
+
+    codeVerifier(): string {
+      const verifier = readOAuthState(
+        opts.dataDir,
+        opts.serverName,
+      ).codeVerifier;
+      if (!verifier) {
+        throw new Error(
+          `no PKCE code verifier persisted for MCP server '${opts.serverName}'`,
+        );
+      }
+      return verifier;
+    },
+
+    discoveryState(): OAuthDiscoveryState | undefined {
+      return readOAuthState(opts.dataDir, opts.serverName).discoveryState;
+    },
+
+    saveDiscoveryState(state: OAuthDiscoveryState): void {
+      updateState(opts, { discoveryState: state });
+    },
+
+    invalidateCredentials(
+      scope: "all" | "client" | "tokens" | "verifier" | "discovery",
+    ): void {
+      if (scope === "all") {
+        deleteOAuthState(opts.dataDir, opts.serverName);
+        return;
+      }
+      const current = readOAuthState(opts.dataDir, opts.serverName);
+      const next: McpOAuthState = { ...current };
+      if (scope === "client") next.clientInformation = undefined;
+      if (scope === "tokens") next.tokens = undefined;
+      if (scope === "verifier") next.codeVerifier = undefined;
+      if (scope === "discovery") next.discoveryState = undefined;
+      writeOAuthState(opts.dataDir, opts.serverName, next);
+    },
+  };
+}

--- a/src/mcp/oauth-storage.test.ts
+++ b/src/mcp/oauth-storage.test.ts
@@ -1,0 +1,135 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type McpOAuthState,
+  deleteOAuthState,
+  readOAuthState,
+  writeOAuthState,
+} from "./oauth-storage";
+
+describe("oauth-storage", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(resolve(tmpdir(), "tomo-oauth-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("readOAuthState", () => {
+    it("returns an empty state when the file is missing", () => {
+      expect(readOAuthState(dir, "github")).toEqual({});
+    });
+
+    it("returns an empty state when the file is malformed JSON", () => {
+      writeFileSync(resolve(dir, "github.json"), "not json");
+      expect(readOAuthState(dir, "github")).toEqual({});
+    });
+
+    it("returns an empty state when JSON does not match the schema", () => {
+      writeFileSync(
+        resolve(dir, "github.json"),
+        JSON.stringify({ tokens: { access_token: 123 } }),
+      );
+      expect(readOAuthState(dir, "github")).toEqual({});
+    });
+
+    it("round-trips a full state", () => {
+      const state: McpOAuthState = {
+        clientInformation: { client_id: "abc", client_secret: "s" },
+        tokens: {
+          access_token: "at",
+          token_type: "Bearer",
+          refresh_token: "rt",
+          expires_in: 3600,
+          scope: "read write",
+        },
+        codeVerifier: "verifier-value",
+        discoveryState: {
+          authorizationServerUrl: "https://auth.example.com",
+        },
+        redirectPort: 54321,
+      };
+      writeOAuthState(dir, "github", state);
+      expect(readOAuthState(dir, "github")).toEqual(state);
+    });
+
+    it("preserves unknown fields on nested SDK objects via loose parsing", () => {
+      const raw = {
+        tokens: {
+          access_token: "at",
+          token_type: "Bearer",
+          unknown_field: "kept",
+        },
+      };
+      writeFileSync(resolve(dir, "github.json"), JSON.stringify(raw));
+      const state = readOAuthState(dir, "github");
+      expect(state.tokens).toMatchObject({
+        access_token: "at",
+        token_type: "Bearer",
+        unknown_field: "kept",
+      });
+    });
+  });
+
+  describe("writeOAuthState", () => {
+    it("creates the parent directory if missing", () => {
+      const nested = resolve(dir, "nested");
+      writeOAuthState(nested, "github", { codeVerifier: "v" });
+      expect(readOAuthState(nested, "github").codeVerifier).toBe("v");
+    });
+
+    it("writes the state file with mode 0600", () => {
+      writeOAuthState(dir, "github", { codeVerifier: "v" });
+      const mode = statSync(resolve(dir, "github.json")).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it("creates the parent directory with mode 0700", () => {
+      const nested = resolve(dir, "nested");
+      writeOAuthState(nested, "github", { codeVerifier: "v" });
+      const mode = statSync(nested).mode & 0o777;
+      expect(mode).toBe(0o700);
+    });
+
+    it("overwrites existing state atomically", () => {
+      writeOAuthState(dir, "github", { codeVerifier: "v1" });
+      writeOAuthState(dir, "github", { codeVerifier: "v2" });
+      expect(readOAuthState(dir, "github").codeVerifier).toBe("v2");
+    });
+
+    it("writes formatted JSON", () => {
+      writeOAuthState(dir, "github", { codeVerifier: "v" });
+      const contents = readFileSync(resolve(dir, "github.json"), "utf-8");
+      expect(contents).toContain("\n");
+    });
+
+    it("overwrites a stale tmp file left from a prior crash", () => {
+      writeFileSync(resolve(dir, "github.json.tmp"), "garbage");
+      writeOAuthState(dir, "github", { codeVerifier: "v" });
+      expect(readOAuthState(dir, "github").codeVerifier).toBe("v");
+    });
+  });
+
+  describe("deleteOAuthState", () => {
+    it("deletes an existing state file", () => {
+      writeOAuthState(dir, "github", { codeVerifier: "v" });
+      deleteOAuthState(dir, "github");
+      expect(readOAuthState(dir, "github")).toEqual({});
+    });
+
+    it("is a no-op for a missing file", () => {
+      expect(() => deleteOAuthState(dir, "missing")).not.toThrow();
+    });
+  });
+});

--- a/src/mcp/oauth-storage.test.ts
+++ b/src/mcp/oauth-storage.test.ts
@@ -64,6 +64,16 @@ describe("oauth-storage", () => {
       expect(readOAuthState(dir, "github")).toEqual(state);
     });
 
+    it("round-trips a server name that contains URL separators", () => {
+      // Regression: a user configured the MCP connection with the full
+      // server URL as its key (e.g. "https://mcp.atlassian.com/v1/mcp").
+      // Slashes and colons must not produce a nested path whose parent
+      // directories do not exist.
+      const urlishName = "https://mcp.atlassian.com/v1/mcp";
+      writeOAuthState(dir, urlishName, { codeVerifier: "v" });
+      expect(readOAuthState(dir, urlishName).codeVerifier).toBe("v");
+    });
+
     it("preserves unknown fields on nested SDK objects via loose parsing", () => {
       const raw = {
         tokens: {

--- a/src/mcp/oauth-storage.ts
+++ b/src/mcp/oauth-storage.ts
@@ -1,0 +1,102 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformationMixed,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { z } from "zod";
+
+/** Schema for a persisted OAuth token response. Loose so unknown fields from future SDK versions survive a round-trip. */
+const oauthTokensSchema = z.looseObject({
+  access_token: z.string(),
+  token_type: z.string(),
+  id_token: z.string().optional(),
+  expires_in: z.number().optional(),
+  scope: z.string().optional(),
+  refresh_token: z.string().optional(),
+});
+
+/** Schema for persisted OAuth client information. Loose to keep unknown registration response fields. */
+const oauthClientInformationSchema = z.looseObject({
+  client_id: z.string(),
+  client_secret: z.string().optional(),
+  client_id_issued_at: z.number().optional(),
+  client_secret_expires_at: z.number().optional(),
+});
+
+/** Schema for persisted OAuth discovery state. Loose — the nested metadata blobs come from the SDK and are treated opaquely. */
+const oauthDiscoveryStateSchema = z.looseObject({
+  authorizationServerUrl: z.string(),
+});
+
+/** Schema for the full on-disk state file for one MCP server. */
+const mcpOAuthStateSchema = z.object({
+  clientInformation: oauthClientInformationSchema.optional(),
+  tokens: oauthTokensSchema.optional(),
+  codeVerifier: z.string().optional(),
+  discoveryState: oauthDiscoveryStateSchema.optional(),
+  redirectPort: z.number().int().min(1).max(65535).optional(),
+});
+
+/** On-disk OAuth state for a single MCP server. */
+export interface McpOAuthState {
+  clientInformation?: OAuthClientInformationMixed;
+  tokens?: OAuthTokens;
+  codeVerifier?: string;
+  discoveryState?: OAuthDiscoveryState;
+  redirectPort?: number;
+}
+
+/** Returns the absolute path of the state file for the given server. */
+function stateFilePath(dir: string, serverName: string): string {
+  return resolve(dir, `${serverName}.json`);
+}
+
+/** Reads persisted OAuth state for a server. Returns an empty state for a missing, unreadable, or malformed file. */
+export function readOAuthState(dir: string, serverName: string): McpOAuthState {
+  const path = stateFilePath(dir, serverName);
+  if (!existsSync(path)) return {};
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return {};
+  }
+  const result = mcpOAuthStateSchema.safeParse(raw);
+  return result.success ? result.data : {};
+}
+
+/**
+ * Atomically writes OAuth state to disk. The parent directory is created with
+ * mode 0700 if missing and the state file is always written with mode 0600.
+ * Uses a temp-file + rename so a crash mid-write cannot leave a partial file.
+ */
+export function writeOAuthState(
+  dir: string,
+  serverName: string,
+  state: McpOAuthState,
+): void {
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const path = stateFilePath(dir, serverName);
+  const tmpPath = `${path}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(state, null, 2), { mode: 0o600 });
+  chmodSync(tmpPath, 0o600);
+  renameSync(tmpPath, path);
+}
+
+/** Deletes the state file for a server. No-op if the file does not exist. */
+export function deleteOAuthState(dir: string, serverName: string): void {
+  const path = stateFilePath(dir, serverName);
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+}

--- a/src/mcp/oauth-storage.ts
+++ b/src/mcp/oauth-storage.ts
@@ -56,9 +56,21 @@ export interface McpOAuthState {
   redirectPort?: number;
 }
 
+/**
+ * Converts an arbitrary MCP server name into a filesystem-safe stem so it
+ * can be used as a filename. Any character outside `[a-zA-Z0-9._-]` is
+ * replaced with `_` — this covers URL separators (`/`, `:`), whitespace,
+ * and everything else that would break a single-segment file path. Two
+ * server names that differ only in unsafe characters can collide, which
+ * is an acceptable trade-off for keeping the filenames human-readable.
+ */
+function toSafeFileName(serverName: string): string {
+  return serverName.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
 /** Returns the absolute path of the state file for the given server. */
 function stateFilePath(dir: string, serverName: string): string {
-  return resolve(dir, `${serverName}.json`);
+  return resolve(dir, `${toSafeFileName(serverName)}.json`);
 }
 
 /** Reads persisted OAuth state for a server. Returns an empty state for a missing, unreadable, or malformed file. */

--- a/src/mcp/oauth.integration.test.ts
+++ b/src/mcp/oauth.integration.test.ts
@@ -1,0 +1,204 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const MOCK_OAUTH_SCRIPT = resolve(__dirname, "../../mock-mcps/http-oauth.mjs");
+const PORT = 9879;
+const URL_BASE = `http://localhost:${PORT}`;
+
+/**
+ * Mock `node:child_process.spawn` so `openUrl` does not actually spawn
+ * macOS's `open`. Any other spawn call (including the one that launches the
+ * mock OAuth server in `beforeAll`) falls through to the real implementation.
+ *
+ * When `open` is invoked, the mock schedules an async "fake browser" that
+ * drives the authorization URL → follows the 302 → hits the loopback catcher,
+ * which is what a real user's browser would do after signing in.
+ */
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn((cmd: string, args?: readonly string[], opts?: unknown) => {
+      if (cmd === "open" && args && args.length > 0) {
+        const url = args[0];
+        const proc = Object.assign(new EventEmitter(), {
+          unref: vi.fn(),
+        });
+        setImmediate(() => {
+          proc.emit("spawn");
+          void driveAuthorize(url).catch((err) => {
+            // Surface drive errors via stderr so test failures are obvious.
+            console.error("fake-browser drive error:", err);
+          });
+        });
+        return proc as unknown as import("node:child_process").ChildProcess;
+      }
+      return actual.spawn(
+        cmd,
+        args as readonly string[],
+        opts as import("node:child_process").SpawnOptions,
+      );
+    }),
+  };
+});
+
+const { spawn } = await import("node:child_process");
+
+/**
+ * Simulates a user clicking the authorization link in their browser: follows
+ * the SDK-generated `/authorize` URL (with `redirect: "manual"`) to capture
+ * the Location header, then fetches the loopback redirect URL so the
+ * catcher's `waitForCode` resolves.
+ */
+async function driveAuthorize(url: string): Promise<void> {
+  const authorizeResponse = await fetch(url, { redirect: "manual" });
+  const location = authorizeResponse.headers.get("location");
+  if (!location) {
+    throw new Error(
+      `/authorize did not redirect — status ${authorizeResponse.status}`,
+    );
+  }
+  await fetch(location);
+}
+
+/** Imports used by the tests. Must come after the vi.mock block above. */
+const { createHttpMcpClient } = await import("./client");
+
+describe("MCP OAuth end-to-end", () => {
+  let server: import("node:child_process").ChildProcess | null = null;
+  let authDataDir: string;
+
+  beforeAll(async () => {
+    server = spawn("node", [MOCK_OAUTH_SCRIPT], {
+      env: { ...process.env, PORT: String(PORT) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await new Promise<void>((resolveReady, rejectReady) => {
+      const timeout = setTimeout(
+        () => rejectReady(new Error("mock oauth server did not start")),
+        5000,
+      );
+      server?.stdout?.on("data", (chunk: Buffer) => {
+        if (chunk.toString().includes("listening")) {
+          clearTimeout(timeout);
+          resolveReady();
+        }
+      });
+      server?.on("error", (err) => {
+        clearTimeout(timeout);
+        rejectReady(err);
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (server && !server.killed) {
+      server.kill("SIGTERM");
+      await new Promise<void>((r) => server?.on("exit", () => r()));
+    }
+  });
+
+  beforeEach(() => {
+    authDataDir = mkdtempSync(resolve(tmpdir(), "tomo-oauth-integration-"));
+  });
+
+  afterEach(() => {
+    rmSync(authDataDir, { recursive: true, force: true });
+  });
+
+  it("completes the full OAuth flow and lists tools", async () => {
+    const client = await createHttpMcpClient({
+      serverName: "oauth-mock",
+      url: URL_BASE,
+      authDataDir,
+    });
+    try {
+      await client.connect();
+      const tools = await client.listTools();
+      expect(tools.map((t) => t.name)).toEqual(["get_weather"]);
+    } finally {
+      await client.disconnect();
+    }
+  });
+
+  it("rethrows non-UnauthorizedError errors from the initial connect", async () => {
+    // Point the client at a port nothing is listening on. The SDK's first
+    // request fails with a network error — not an UnauthorizedError — so
+    // the catch path should rethrow without entering the auth retry.
+    const client = await createHttpMcpClient({
+      serverName: "oauth-unreachable",
+      url: "http://127.0.0.1:1", // reserved — nothing listens here
+      authDataDir,
+    });
+    try {
+      await expect(client.connect()).rejects.toThrow();
+    } finally {
+      await client.disconnect();
+    }
+  });
+
+  it("transparently re-auths mid-session when a tool call 401s", async () => {
+    const client = await createHttpMcpClient({
+      serverName: "oauth-mock",
+      url: URL_BASE,
+      authDataDir,
+    });
+    try {
+      await client.connect();
+
+      // Prime the mock server so its next /mcp request returns 401.
+      await fetch(`${URL_BASE}/__force_next_401`, { method: "POST" });
+
+      // listTools' first send hits the 401 → SDK throws UnauthorizedError
+      // → withAuthRetry awaits the pending code → drives a fresh auth
+      // round via the fake browser → finishAuth → retries listTools.
+      const tools = await client.listTools();
+      expect(tools.map((t) => t.name)).toEqual(["get_weather"]);
+    } finally {
+      await client.disconnect();
+    }
+  });
+
+  it("persists tokens so a second client can connect without re-authorising", async () => {
+    // First connect runs the full flow and saves tokens to authDataDir.
+    const first = await createHttpMcpClient({
+      serverName: "oauth-mock",
+      url: URL_BASE,
+      authDataDir,
+    });
+    await first.connect();
+    await first.disconnect();
+
+    // Second connect reuses the persisted token — the fake browser should
+    // not be invoked, and the spawn mock's `open` counter stays flat.
+    vi.mocked(spawn).mockClear();
+    const second = await createHttpMcpClient({
+      serverName: "oauth-mock",
+      url: URL_BASE,
+      authDataDir,
+    });
+    try {
+      await second.connect();
+      const tools = await second.listTools();
+      expect(tools.map((t) => t.name)).toEqual(["get_weather"]);
+      const openCalls = vi
+        .mocked(spawn)
+        .mock.calls.filter((call) => call[0] === "open");
+      expect(openCalls).toHaveLength(0);
+    } finally {
+      await second.disconnect();
+    }
+  });
+});

--- a/src/mcp/use-mcp.test.tsx
+++ b/src/mcp/use-mcp.test.tsx
@@ -4,6 +4,7 @@ import type { ToolRegistry } from "../tools/registry";
 import { renderInk } from "../test-utils/ink";
 import type { McpClient, McpToolDefinition } from "./client";
 import type { McpManager, StartAllResult } from "./manager";
+import { type McpAuthStore, createMcpAuthStore } from "./mcp-auth-store";
 import { useMcp } from "./use-mcp";
 
 vi.mock("./manager", async () => {
@@ -52,11 +53,15 @@ const sampleTool: McpToolDefinition = {
 function Harness(props: {
   toolRegistry: ToolRegistry;
   onConnectionError: (name: string, error: string) => void;
+  authStore?: McpAuthStore;
+  onResult?: (authStore: McpAuthStore) => void;
 }) {
-  useMcp({
+  const result = useMcp({
     toolRegistry: props.toolRegistry,
     onConnectionError: props.onConnectionError,
+    authStore: props.authStore,
   });
+  props.onResult?.(result.authStore);
   return null;
 }
 
@@ -293,5 +298,46 @@ describe("useMcp", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  describe("authStore", () => {
+    it("returns an internally-created store when none is injected", async () => {
+      vi.mocked(createMcpManager).mockReturnValue(
+        fakeManager({ started: [], failed: [] }, new Map()),
+      );
+      const observed: { store?: McpAuthStore } = {};
+      renderInk(
+        <Harness
+          toolRegistry={createToolRegistry()}
+          onConnectionError={vi.fn()}
+          onResult={(store) => {
+            observed.store = store;
+          }}
+        />,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(observed.store).toBeDefined();
+      expect(typeof observed.store?.push).toBe("function");
+    });
+
+    it("reuses an injected store instead of creating one", async () => {
+      vi.mocked(createMcpManager).mockReturnValue(
+        fakeManager({ started: [], failed: [] }, new Map()),
+      );
+      const injected = createMcpAuthStore();
+      const observed: { store?: McpAuthStore } = {};
+      renderInk(
+        <Harness
+          toolRegistry={createToolRegistry()}
+          onConnectionError={vi.fn()}
+          authStore={injected}
+          onResult={(store) => {
+            observed.store = store;
+          }}
+        />,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(observed.store).toBe(injected);
+    });
   });
 });

--- a/src/mcp/use-mcp.ts
+++ b/src/mcp/use-mcp.ts
@@ -12,6 +12,12 @@ export interface UseMcpProps {
   toolRegistry: ToolRegistry;
   /** Called once per server that fails to connect, with the server name and error message. */
   onConnectionError: (serverName: string, error: string) => void;
+  /**
+   * Optional pre-built auth store. When omitted, one is created internally
+   * and persisted across effect runs via a ref. Injected primarily for
+   * tests that need a handle on the same store the chat UI subscribes to.
+   */
+  authStore?: McpAuthStore;
 }
 
 /** Return value of useMcp. */
@@ -43,10 +49,12 @@ export function useMcp(props: UseMcpProps): UseMcpResult {
   toolRegistryRef.current = props.toolRegistry;
 
   // The auth store lives across effect runs — re-mounting it would orphan
-  // any in-progress modals the chat UI is already subscribed to.
+  // any in-progress modals the chat UI is already subscribed to. Tests can
+  // inject their own store via props; otherwise we lazy-init one in a ref
+  // on first render and pin it for the rest of the hook's lifetime.
   const authStoreRef = useRef<McpAuthStore | null>(null);
   if (authStoreRef.current === null) {
-    authStoreRef.current = createMcpAuthStore();
+    authStoreRef.current = props.authStore ?? createMcpAuthStore();
   }
   const authStore = authStoreRef.current;
 

--- a/src/mcp/use-mcp.ts
+++ b/src/mcp/use-mcp.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from "react";
 import { useConfig } from "../config/hook";
 import type { ToolRegistry } from "../tools/registry";
+import { createMcpClient } from "./client";
 import { createMcpManager } from "./manager";
+import { type McpAuthStore, createMcpAuthStore } from "./mcp-auth-store";
 import { createMcpTool } from "./tool-adapter";
 
 /** Props for useMcp. */
@@ -12,18 +14,26 @@ export interface UseMcpProps {
   onConnectionError: (serverName: string, error: string) => void;
 }
 
+/** Return value of useMcp. */
+export interface UseMcpResult {
+  /** Store of in-progress OAuth auth prompts — consumed by the chat UI. */
+  authStore: McpAuthStore;
+}
+
 /**
  * Hook that owns the MCP manager lifecycle for the chat session.
  *
  * On mount, connects to all enabled MCP servers in the background and
  * registers their tools into the shared tool registry as each server comes
- * up. Connection failures are surfaced via `onConnectionError`. On unmount,
- * the manager disconnects every server and the registered tools are removed
- * from the registry.
+ * up. Connection failures are surfaced via `onConnectionError`. HTTP servers
+ * that drive the user through OAuth push modal entries onto `authStore`, which
+ * the chat UI renders via `useSyncExternalStore`. On unmount, the manager
+ * disconnects every server and the registered tools are removed from the
+ * registry.
  *
  * Re-runs when `config.mcp.connections` changes (e.g. after settings save).
  */
-export function useMcp(props: UseMcpProps) {
+export function useMcp(props: UseMcpProps): UseMcpResult {
   const { config } = useConfig();
 
   // Refs for callbacks so the effect doesn't re-run on every parent render.
@@ -32,8 +42,18 @@ export function useMcp(props: UseMcpProps) {
   const toolRegistryRef = useRef(props.toolRegistry);
   toolRegistryRef.current = props.toolRegistry;
 
+  // The auth store lives across effect runs — re-mounting it would orphan
+  // any in-progress modals the chat UI is already subscribed to.
+  const authStoreRef = useRef<McpAuthStore | null>(null);
+  if (authStoreRef.current === null) {
+    authStoreRef.current = createMcpAuthStore();
+  }
+  const authStore = authStoreRef.current;
+
   useEffect(() => {
-    const manager = createMcpManager();
+    const manager = createMcpManager((name, connection) =>
+      createMcpClient(name, connection, { authUi: authStore }),
+    );
     let cancelled = false;
     const localRegisteredNames = new Set<string>();
 
@@ -69,5 +89,7 @@ export function useMcp(props: UseMcpProps) {
       }
       void manager.stopAll();
     };
-  }, [config.mcp.connections]);
+  }, [config.mcp.connections, authStore]);
+
+  return { authStore };
 }

--- a/src/utils/open-url.test.ts
+++ b/src/utils/open-url.test.ts
@@ -1,0 +1,60 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openUrl } from "./open-url";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+const mockedSpawn = vi.mocked(spawn);
+
+/** Creates a fake ChildProcess that can simulate spawn success or failure. */
+function fakeChild(): ChildProcess {
+  const proc = Object.assign(new EventEmitter(), {
+    unref: vi.fn(),
+  });
+  return proc as unknown as ChildProcess;
+}
+
+describe("openUrl", () => {
+  afterEach(() => {
+    mockedSpawn.mockReset();
+  });
+
+  it("spawns macOS `open` with the URL", async () => {
+    const child = fakeChild();
+    mockedSpawn.mockReturnValue(child);
+
+    const promise = openUrl("https://example.com/authorize?state=abc");
+    child.emit("spawn");
+    await promise;
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      "open",
+      ["https://example.com/authorize?state=abc"],
+      { stdio: "ignore", detached: true },
+    );
+  });
+
+  it("unrefs the child after spawn so it outlives the tick", async () => {
+    const child = fakeChild();
+    mockedSpawn.mockReturnValue(child);
+
+    const promise = openUrl("https://example.com");
+    child.emit("spawn");
+    await promise;
+
+    expect(child.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the spawn errors (e.g. `open` not on PATH)", async () => {
+    const child = fakeChild();
+    mockedSpawn.mockReturnValue(child);
+
+    const promise = openUrl("https://example.com");
+    child.emit("error", new Error("spawn open ENOENT"));
+
+    await expect(promise).rejects.toThrow("spawn open ENOENT");
+  });
+});

--- a/src/utils/open-url.ts
+++ b/src/utils/open-url.ts
@@ -1,0 +1,24 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Launches the system browser pointed at the given URL via macOS `open`.
+ *
+ * Resolves once the launcher subprocess has been spawned — not when the
+ * browser finishes loading the page. Rejects if the spawn itself fails (for
+ * example if `open` is not on `PATH`, which would happen on a non-macOS
+ * host). The child is detached and unref'd so it outlives this process's
+ * current tick.
+ */
+export function openUrl(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("open", [url], {
+      stdio: "ignore",
+      detached: true,
+    });
+    child.once("error", reject);
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds full OAuth 2.1 support for HTTP MCP servers, letting tomo connect to protected endpoints like Atlassian, GitHub, Slack, or internal APIs that sit behind a Bearer-auth wall. The SDK handles the protocol (discovery, PKCE, DCR, token exchange, refresh); tomo plugs in a disk-backed provider, a loopback callback catcher, a browser launcher, an Ink modal, and a UI store to surface the flow in-app.

## GitHub Issue

Closes #203

## What Changed

Seven milestones, one per commit, each leaving the branch mergeable:

- **M1 — config schema.** Optional `auth: { clientId?, clientSecret?, scope? }` block on `mcpHttpConnectionSchema`. A `.refine` rejects `clientSecret` without `clientId`. Static `headers` (API-key) auth still works unchanged because the SDK only kicks in OAuth on a `401`.
- **M2 — disk-backed `OAuthClientProvider`.** `src/mcp/oauth-storage.ts` owns atomic `0600` file writes for per-server state under `~/.tomo/mcp-oauth/<server>.json` with a `0700` parent dir. `src/mcp/oauth-provider.ts` implements every hook on the SDK's provider interface, including `state()` (generates a fresh `randomUUID` each flow — required for Atlassian and friends to echo state back on the callback), `saveDiscoveryState`, and scoped `invalidateCredentials`. Server names are sanitised to a filesystem-safe stem so URL-as-connection-key values like `https://mcp.atlassian.com/v1/mcp` don't produce nested paths.
- **M3 — primitives.** `src/mcp/oauth-loopback.ts` binds an HTTP server on `127.0.0.1` that waits for a single OAuth redirect, validates the `state` parameter, supports `AbortSignal` cancellation and a 5-minute timeout, and persists the bound port so DCR-registered redirect URIs survive restarts. `src/utils/open-url.ts` wraps macOS `open` via `child_process.spawn` (hand-rolled over the 50 kB `open` npm dep).
- **M4 — wire it into `createHttpMcpClient`.** The factory chain becomes async. Each `createHttpMcpClient` call eagerly binds the loopback, builds the provider, and hands both to the client's `connect`/`listTools`/`callTool` wrappers. **The initial-connect path needs a special retry:** both `StreamableHTTPClientTransport.start` and `Client.connect` refuse to run twice on the same instance, so on a 401 we exchange the code on the failed transport (which still holds the discovery state), close it, then build a fresh pair and connect with the saved tokens. Mid-session 401s on tools still retry on the live instance via a generic `withAuthRetry` helper.
- **M5 — `McpAuthModal` Ink component.** Pure presentational overlay. Displays the server name, the auth URL, a "waiting for browser" spinner, Esc-to-cancel. A headless variant replaces the spinner with a paste-URL text input. Shipped as a dead render path — the wiring comes in M6.
- **M6 — in-progress auth prompt in the chat.** `src/mcp/mcp-auth-store.ts` implements the `prompt-queue`-style store. `useMcp` owns a single store instance across effect runs and threads it into `createMcpClient` via an optional `authUi` context. `createHttpMcpClient` swaps its `onRedirect` for a UI-aware one that races the loopback against the store's pending promise — loopback wins dismiss the entry; Esc cancels reject with `McpAuthCancelledError`. `chat.tsx` renders the modal via `useSyncExternalStore`, slotting it ahead of confirm/ask prompts and the chat input.
- **M7 — end-to-end integration test.** A new `mock-mcps/http-oauth.mjs` implements the minimum subset of RFC 9728 + RFC 8414 + RFC 7591 plus a spec-compliant `/authorize` → `/token` flow, with a `/__force_next_401` endpoint for mid-session reauth testing. `src/mcp/oauth.integration.test.ts` spawns the mock alongside the real provider + loopback + client, and mocks `node:child_process.spawn` (real spawn still available via `importOriginal`) so `openUrl` is intercepted and a "fake browser" drives `/authorize` via fetch-and-follow. Four scenarios covered: happy path, non-401 rethrow, mid-session 401 reauth, token persistence across restarts.

## Notes for Reviewers

- **Live-tested against Atlassian MCP** during development. Three real-world bugs were found and folded into M4:
  1. URL-style server names exploded `fs.writeFileSync` with `ENOENT` because `https:/...` was being treated as a nested path. Fixed in `oauth-storage.ts` via filename sanitisation.
  2. `/authorize` callbacks arrived without a `state` param because the SDK only sends state when `provider.state()` is implemented. Added the hook — Atlassian echoes state back, loopback validates, flow completes.
  3. `StreamableHTTPClientTransport already started!` after a successful browser sign-in because the M4 v0 withAuthRetry naively retried `connect()` on the same transport instance. Verified via reading the SDK source that neither `start()` nor `Client.connect()` can be called twice on the same instance. Fixed with the fresh-pair pattern described above.
- **Tokens persist across restarts.** A second run against the same server skips the browser entirely — verified by both a live test and the M7 integration test asserting zero `open` spawn calls on the second connect.
- **`McpAuthCancelledError`** is thrown when the user presses Esc on the modal. It propagates through `Promise.race` → `withAuthRetry` → `connect`, and is surfaced via `onConnectionError` in `useMcp` as a readable "authorization cancelled" message.
- **macOS-only.** `openUrl` hard-codes `open` — matches tomo's current scope. If/when Linux/Windows support lands, the dispatch lives behind a single function.
- **1628 tests pass with 100% coverage across the repo.** One narrow `/* v8 ignore */` remains in `client.ts` on a defensive `if (!pending) throw` invariant guard — it's unreachable via the public API (our provider's `onRedirect` always sets pending before the SDK throws `UnauthorizedError`).
- **`headers` and `auth` coexist.** A user can set a static `User-Agent` (or anything else) in `headers` alongside an `auth` block. The SDK only activates OAuth on a 401 response, so the static header path is untouched.